### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
       - main
   pull_request:
 
-name: Continuous integration
+name: CI
 
 jobs:
   rustfmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    name: cargo fmt
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt
+          override: true
+
+      - name: cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+    name: cargo clippy+test
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          profile: minimal
+          override: true
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AccessKit: UI accessibility infrastructure across platforms and programming languages
 
-![CI status](https://github.com/AccessKit/accesskit/actions/workflows/ci.yml/badge.svg)
+[![Build Status](https://github.com/DataTriny/accesskit/actions/workflows/ci.yml/badge.svg)](https://github.com/DataTriny/accesskit/actions)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AccessKit: UI accessibility infrastructure across platforms and programming languages
 
-[![Build Status](https://github.com/DataTriny/accesskit/actions/workflows/ci.yml/badge.svg)](https://github.com/DataTriny/accesskit/actions)
+[![Build Status](https://github.com/AccessKit/accesskit/actions/workflows/ci.yml/badge.svg)](https://github.com/AccessKit/accesskit/actions)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AccessKit: UI accessibility infrastructure across platforms and programming languages
 
+![CI status](https://github.com/AccessKit/accesskit/actions/workflows/ci.yml/badge.svg)
+
 ## Motivation
 
 There are numerous UI toolkits, and new ones continue to proliferate. So far, only the largest UI toolkit projects, with corporate backing, implement accessibility for users who require assistive technologies, such as blind people using screen readers. If the long tail of UI toolkits are ever going to be made fully accessible, then we must pool as much of the required effort as possible across these toolkits. Many of these toolkits are cross-platform, but each platform has its own accessibility API. These toolkits are also written in many different programming languages, so the shared infrastructure must be usable across languages.


### PR DESCRIPTION
Inspired by druid repository's GitHub actions setup.

Adds a GitHub actions pipeline that will run on every commits to `main` and all pull requests.

It contain two jobs:

- a `cargo fmt` on the whole workspace,
- a `cargo clippy` and `cargo test` that will also run on the entire workspace but on Ubuntu, MacOS and Windows 10 environments.

I also added a badge displaying the status of this pipeline in the README to bring credibility in the project.

Hopefully I got it right because I couldn't find a simple way to "dry run" it.