### PR TITLE
Use boxed `str` and slices to reduce size of `accesskit_schema::Node`

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -37,57 +37,57 @@ mod tests {
 
     pub fn test_tree() -> Arc<crate::tree::Tree> {
         let root = Node {
-            children: vec![
+            children: Box::new([
                 PARAGRAPH_0_ID,
                 PARAGRAPH_1_IGNORED_ID,
                 PARAGRAPH_2_ID,
                 PARAGRAPH_3_IGNORED_ID,
-            ],
+            ]),
             ..Node::new(ROOT_ID, Role::RootWebArea)
         };
         let paragraph_0 = Node {
-            children: vec![STATIC_TEXT_0_0_IGNORED_ID],
+            children: Box::new([STATIC_TEXT_0_0_IGNORED_ID]),
             ..Node::new(PARAGRAPH_0_ID, Role::Paragraph)
         };
         let static_text_0_0_ignored = Node {
             ignored: true,
-            name: Some("static_text_0_0_ignored".to_string()),
+            name: Some("static_text_0_0_ignored".into()),
             ..Node::new(STATIC_TEXT_0_0_IGNORED_ID, Role::StaticText)
         };
         let paragraph_1_ignored = Node {
-            children: vec![STATIC_TEXT_1_0_ID],
+            children: Box::new([STATIC_TEXT_1_0_ID]),
             ignored: true,
             ..Node::new(PARAGRAPH_1_IGNORED_ID, Role::Paragraph)
         };
         let static_text_1_0 = Node {
-            name: Some("static_text_1_0".to_string()),
+            name: Some("static_text_1_0".into()),
             ..Node::new(STATIC_TEXT_1_0_ID, Role::StaticText)
         };
         let paragraph_2 = Node {
-            children: vec![STATIC_TEXT_2_0_ID],
+            children: Box::new([STATIC_TEXT_2_0_ID]),
             ..Node::new(PARAGRAPH_2_ID, Role::Paragraph)
         };
         let static_text_2_0 = Node {
-            name: Some("static_text_2_0".to_string()),
+            name: Some("static_text_2_0".into()),
             ..Node::new(STATIC_TEXT_2_0_ID, Role::StaticText)
         };
         let paragraph_3_ignored = Node {
-            children: vec![LINK_3_0_IGNORED_ID, BUTTON_3_1_ID],
+            children: Box::new([LINK_3_0_IGNORED_ID, BUTTON_3_1_ID]),
             ignored: true,
             ..Node::new(PARAGRAPH_3_IGNORED_ID, Role::Paragraph)
         };
         let link_3_0_ignored = Node {
-            children: vec![STATIC_TEXT_3_0_0_ID],
+            children: Box::new([STATIC_TEXT_3_0_0_ID]),
             ignored: true,
             linked: true,
             ..Node::new(LINK_3_0_IGNORED_ID, Role::Link)
         };
         let static_text_3_0_0 = Node {
-            name: Some("static_text_3_0_0".to_string()),
+            name: Some("static_text_3_0_0".into()),
             ..Node::new(STATIC_TEXT_3_0_0_ID, Role::StaticText)
         };
         let button_3_1 = Node {
-            name: Some("button_3_1".to_string()),
+            name: Some("button_3_1".into()),
             ..Node::new(BUTTON_3_1_ID, Role::Button)
         };
         let initial_update = TreeUpdate {
@@ -105,10 +105,7 @@ mod tests {
                 static_text_3_0_0,
                 button_3_1,
             ],
-            tree: Some(Tree::new(
-                TreeId("test_tree".to_string()),
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(TreeId("test_tree".into()), StringEncoding::Utf8)),
             root: Some(ROOT_ID),
         };
         crate::tree::Tree::new(initial_update)

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -74,7 +74,7 @@ impl State {
                 if node_id == root {
                     node_state.parent_and_index = None
                 }
-                for child_id in &node_state.data.children {
+                for child_id in node_state.data.children.iter() {
                     if !seen_child_ids.contains(child_id) {
                         orphans.insert(*child_id);
                     }
@@ -116,7 +116,7 @@ impl State {
             ) {
                 to_remove.insert(id);
                 let node = nodes.get(&id).unwrap();
-                for child_id in &node.data.children {
+                for child_id in node.data.children.iter() {
                     traverse_orphan(nodes, to_remove, *child_id);
                 }
             }
@@ -145,7 +145,7 @@ impl State {
             let node = state.nodes.get(&id).unwrap();
             nodes.push(node.data.clone());
 
-            for child_id in &node.data.children {
+            for child_id in node.data.children.iter() {
                 traverse(state, nodes, *child_id);
             }
         }
@@ -239,11 +239,11 @@ mod tests {
         let update = TreeUpdate {
             clear: None,
             nodes: vec![Node::new(NODE_ID_1, Role::Window)],
-            tree: Some(Tree::new(TreeId(TREE_ID.to_string()), StringEncoding::Utf8)),
+            tree: Some(Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8)),
             root: Some(NODE_ID_1),
         };
         let tree = super::Tree::new(update);
-        assert_eq!(&TreeId(TREE_ID.to_string()), tree.read().id());
+        assert_eq!(&TreeId(TREE_ID.into()), tree.read().id());
         assert_eq!(NODE_ID_1, tree.read().root().id());
         assert_eq!(Role::Window, tree.read().root().role());
         assert!(tree.read().root().parent().is_none());
@@ -255,13 +255,13 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: vec![NODE_ID_2, NODE_ID_3],
+                    children: Box::new([NODE_ID_2, NODE_ID_3]),
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node::new(NODE_ID_2, Role::Button),
                 Node::new(NODE_ID_3, Role::Button),
             ],
-            tree: Some(Tree::new(TreeId(TREE_ID.to_string()), StringEncoding::Utf8)),
+            tree: Some(Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8)),
             root: Some(NODE_ID_1),
         };
         let tree = super::Tree::new(update);
@@ -283,7 +283,7 @@ mod tests {
         let first_update = TreeUpdate {
             clear: None,
             nodes: vec![root_node.clone()],
-            tree: Some(Tree::new(TreeId(TREE_ID.to_string()), StringEncoding::Utf8)),
+            tree: Some(Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8)),
             root: Some(NODE_ID_1),
         };
         let tree = super::Tree::new(first_update);
@@ -292,7 +292,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: vec![NODE_ID_2],
+                    children: Box::new([NODE_ID_2]),
                     ..root_node
                 },
                 Node::new(NODE_ID_2, Role::RootWebArea),
@@ -317,12 +317,12 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: vec![NODE_ID_2],
+                    children: Box::new([NODE_ID_2]),
                     ..root_node.clone()
                 },
                 Node::new(NODE_ID_2, Role::RootWebArea),
             ],
-            tree: Some(Tree::new(TreeId(TREE_ID.to_string()), StringEncoding::Utf8)),
+            tree: Some(Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8)),
             root: Some(NODE_ID_1),
         };
         let tree = super::Tree::new(first_update);
@@ -340,12 +340,12 @@ mod tests {
 
     #[test]
     fn move_focus_between_siblings() {
-        let tree_data = Tree::new(TreeId(TREE_ID.to_string()), StringEncoding::Utf8);
+        let tree_data = Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8);
         let first_update = TreeUpdate {
             clear: None,
             nodes: vec![
                 Node {
-                    children: vec![NODE_ID_2, NODE_ID_3],
+                    children: Box::new([NODE_ID_2, NODE_ID_3]),
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node::new(NODE_ID_2, Role::Button),

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -391,7 +391,7 @@ pub enum TextDirection {
 pub enum InvalidState {
     False,
     True,
-    Other(String),
+    Other(Box<str>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -510,7 +510,7 @@ pub struct NodeId(pub std::num::NonZeroU64);
 /// The globally unique ID of a tree. The format of this ID
 /// is up to the implementer. A UUID v4 is a safe choice.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct TreeId(pub String);
+pub struct TreeId(pub Box<str>);
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -580,7 +580,7 @@ pub struct TextMarker {
 #[serde(rename_all = "camelCase")]
 pub struct CustomAction {
     pub id: i32,
-    pub description: String,
+    pub description: Box<str>,
 }
 
 // Helper for skipping false values in serialization.
@@ -604,7 +604,7 @@ pub struct Node {
     pub bounds: Option<RelativeBounds>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub children: Vec<NodeId>,
+    pub children: Box<[NodeId]>,
 
     /// Unordered set of actions supported by this node.
     #[serde(default)]
@@ -612,19 +612,19 @@ pub struct Node {
     pub actions: BTreeSet<Action>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: Option<Box<str>>,
     /// What information was used to compute the object's name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name_from: Option<NameFrom>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub description: Option<Box<str>>,
     /// What information was used to compute the object's description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description_from: Option<DescriptionFrom>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
+    pub value: Option<Box<str>>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
@@ -786,7 +786,7 @@ pub struct Node {
     /// column.
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub indirect_children: Vec<NodeId>,
+    pub indirect_children: Box<[NodeId]>,
 
     // Relationships between this node and other nodes.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -805,26 +805,26 @@ pub struct Node {
     pub popup_for: Option<NodeId>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub controls: Vec<NodeId>,
+    pub controls: Box<[NodeId]>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub details: Vec<NodeId>,
+    pub details: Box<[NodeId]>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub described_by: Vec<NodeId>,
+    pub described_by: Box<[NodeId]>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub flow_to: Vec<NodeId>,
+    pub flow_to: Box<[NodeId]>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub labelled_by: Vec<NodeId>,
+    pub labelled_by: Box<[NodeId]>,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub radio_groups: Vec<NodeId>,
+    pub radio_groups: Box<[NodeId]>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub markers: Vec<TextMarker>,
+    pub markers: Box<[TextMarker]>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_direction: Option<TextDirection>,
@@ -836,88 +836,88 @@ pub struct Node {
     /// is the right coordinate of the second character, and so on.
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub character_offsets: Vec<f32>,
+    pub character_offsets: Box<[f32]>,
 
     /// For inline text. The indices of each word, in code units for
     /// the encoding specified in [`Tree::source_string_encoding`].
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub words: Vec<Range<usize>>,
+    pub words: Box<[Range<usize>]>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "is_empty")]
-    pub custom_actions: Vec<CustomAction>,
+    pub custom_actions: Box<[CustomAction]>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_key: Option<String>,
+    pub access_key: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invalid_state: Option<InvalidState>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_complete: Option<String>,
+    pub auto_complete: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub checked_state: Option<CheckedState>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checked_state_description: Option<String>,
+    pub checked_state_description: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub child_tree: Option<TreeId>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub class_name: Option<String>,
+    pub class_name: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub container_live_relevant: Option<String>,
+    pub container_live_relevant: Option<Box<str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub container_live_status: Option<String>,
+    pub container_live_status: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub css_display: Option<String>,
+    pub css_display: Option<Box<str>>,
 
     /// Only present when different from parent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub font_family: Option<String>,
+    pub font_family: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub html_tag: Option<String>,
+    pub html_tag: Option<Box<str>>,
 
     /// Inner HTML of an element. Only used for a top-level math element,
     /// to support third-party math accessibility products that parse MathML.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub inner_html: Option<String>,
+    pub inner_html: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub input_type: Option<String>,
+    pub input_type: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub key_shortcuts: Option<String>,
+    pub key_shortcuts: Option<Box<str>>,
 
     /// Only present when different from parent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub language: Option<String>,
+    pub language: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_relevant: Option<String>,
+    pub live_relevant: Option<Box<str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub live_status: Option<String>,
+    pub live_status: Option<Box<str>>,
 
     /// Only if not already exposed in [`Node::name`] ([`NameFrom::Placeholder`]).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub placeholder: Option<String>,
+    pub placeholder: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aria_role: Option<String>,
+    pub aria_role: Option<Box<str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub role_description: Option<String>,
+    pub role_description: Option<Box<str>>,
 
     /// Only if not already exposed in [`Node::name`] ([`NameFrom::Title`]).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tooltip: Option<String>,
+    pub tooltip: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<Box<str>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_action_verb: Option<DefaultActionVerb>,
@@ -1079,7 +1079,7 @@ impl Node {
             id,
             role,
             bounds: None,
-            children: vec![],
+            children: Default::default(),
             actions: BTreeSet::new(),
             name: None,
             name_from: None,
@@ -1120,7 +1120,7 @@ impl Node {
             is_page_breaking_object: false,
             has_aria_attribute: false,
             touch_pass_through: false,
-            indirect_children: vec![],
+            indirect_children: Default::default(),
             active_descendant: None,
             error_message: None,
             in_page_link_target: None,
@@ -1128,17 +1128,17 @@ impl Node {
             next_on_line: None,
             previous_on_line: None,
             popup_for: None,
-            controls: vec![],
-            details: vec![],
-            described_by: vec![],
-            flow_to: vec![],
-            labelled_by: vec![],
-            radio_groups: vec![],
-            markers: vec![],
+            controls: Default::default(),
+            details: Default::default(),
+            described_by: Default::default(),
+            flow_to: Default::default(),
+            labelled_by: Default::default(),
+            radio_groups: Default::default(),
+            markers: Default::default(),
             text_direction: None,
-            character_offsets: vec![],
-            words: vec![],
-            custom_actions: vec![],
+            character_offsets: Default::default(),
+            words: Default::default(),
+            custom_actions: Default::default(),
             access_key: None,
             invalid_state: None,
             auto_complete: None,


### PR DESCRIPTION
This reduces the size of `Node` by 296 bytes (on x64), from 1568 bytes down to 1272 bytes, with no loss of functionality, since the contents of `Node` aren't meant to be mutated in-place.