### PR TITLE
Fix a corner case that caused unignored node traversal to get into a …

### DIFF
--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -210,6 +210,7 @@ fn next_unignored_sibling(node: Option<Node>) -> Option<Node> {
                 if !parent.is_ignored() {
                     return None;
                 }
+                consider_children = false;
             } else {
                 return None;
             }
@@ -247,6 +248,7 @@ fn previous_unignored_sibling(node: Option<Node>) -> Option<Node> {
                 if !parent.is_ignored() {
                     return None;
                 }
+                consider_children = false;
             } else {
                 return None;
             }
@@ -568,8 +570,8 @@ mod tests {
             [
                 STATIC_TEXT_1_0_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_3_0_0_ID,
-                BUTTON_3_1_ID
+                STATIC_TEXT_3_1_0_ID,
+                BUTTON_3_2_ID
             ],
             tree.read()
                 .node_by_id(PARAGRAPH_0_ID)
@@ -598,8 +600,8 @@ mod tests {
             .is_none());
         assert_eq!(
             [
-                BUTTON_3_1_ID,
-                STATIC_TEXT_3_0_0_ID,
+                BUTTON_3_2_ID,
+                STATIC_TEXT_3_1_0_ID,
                 PARAGRAPH_2_ID,
                 STATIC_TEXT_1_0_ID
             ],
@@ -683,8 +685,8 @@ mod tests {
                 PARAGRAPH_0_ID,
                 STATIC_TEXT_1_0_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_3_0_0_ID,
-                BUTTON_3_1_ID
+                STATIC_TEXT_3_1_0_ID,
+                BUTTON_3_2_ID
             ],
             tree.read()
                 .root()
@@ -713,8 +715,8 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             [
-                BUTTON_3_1_ID,
-                STATIC_TEXT_3_0_0_ID,
+                BUTTON_3_2_ID,
+                STATIC_TEXT_3_1_0_ID,
                 PARAGRAPH_2_ID,
                 STATIC_TEXT_1_0_ID,
                 PARAGRAPH_0_ID

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -31,9 +31,13 @@ mod tests {
     pub const PARAGRAPH_2_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(6) });
     pub const STATIC_TEXT_2_0_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(7) });
     pub const PARAGRAPH_3_IGNORED_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(8) });
-    pub const LINK_3_0_IGNORED_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(9) });
-    pub const STATIC_TEXT_3_0_0_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(10) });
-    pub const BUTTON_3_1_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(11) });
+    pub const EMPTY_CONTAINER_3_0_IGNORED_ID: NodeId =
+        NodeId(unsafe { NonZeroU64::new_unchecked(9) });
+    pub const LINK_3_1_IGNORED_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(10) });
+    pub const STATIC_TEXT_3_1_0_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(11) });
+    pub const BUTTON_3_2_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(12) });
+    pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId =
+        NodeId(unsafe { NonZeroU64::new_unchecked(13) });
 
     pub fn test_tree() -> Arc<crate::tree::Tree> {
         let root = Node {
@@ -72,23 +76,36 @@ mod tests {
             ..Node::new(STATIC_TEXT_2_0_ID, Role::StaticText)
         };
         let paragraph_3_ignored = Node {
-            children: Box::new([LINK_3_0_IGNORED_ID, BUTTON_3_1_ID]),
+            children: Box::new([
+                EMPTY_CONTAINER_3_0_IGNORED_ID,
+                LINK_3_1_IGNORED_ID,
+                BUTTON_3_2_ID,
+                EMPTY_CONTAINER_3_3_IGNORED_ID,
+            ]),
             ignored: true,
             ..Node::new(PARAGRAPH_3_IGNORED_ID, Role::Paragraph)
         };
-        let link_3_0_ignored = Node {
-            children: Box::new([STATIC_TEXT_3_0_0_ID]),
+        let empty_container_3_0_ignored = Node {
+            ignored: true,
+            ..Node::new(EMPTY_CONTAINER_3_0_IGNORED_ID, Role::GenericContainer)
+        };
+        let link_3_1_ignored = Node {
+            children: Box::new([STATIC_TEXT_3_1_0_ID]),
             ignored: true,
             linked: true,
-            ..Node::new(LINK_3_0_IGNORED_ID, Role::Link)
+            ..Node::new(LINK_3_1_IGNORED_ID, Role::Link)
         };
-        let static_text_3_0_0 = Node {
-            name: Some("static_text_3_0_0".into()),
-            ..Node::new(STATIC_TEXT_3_0_0_ID, Role::StaticText)
+        let static_text_3_1_0 = Node {
+            name: Some("static_text_3_1_0".into()),
+            ..Node::new(STATIC_TEXT_3_1_0_ID, Role::StaticText)
         };
-        let button_3_1 = Node {
-            name: Some("button_3_1".into()),
-            ..Node::new(BUTTON_3_1_ID, Role::Button)
+        let button_3_2 = Node {
+            name: Some("button_3_2".into()),
+            ..Node::new(BUTTON_3_2_ID, Role::Button)
+        };
+        let empty_container_3_3_ignored = Node {
+            ignored: true,
+            ..Node::new(EMPTY_CONTAINER_3_3_IGNORED_ID, Role::GenericContainer)
         };
         let initial_update = TreeUpdate {
             clear: None,
@@ -101,9 +118,11 @@ mod tests {
                 paragraph_2,
                 static_text_2_0,
                 paragraph_3_ignored,
-                link_3_0_ignored,
-                static_text_3_0_0,
-                button_3_1,
+                empty_container_3_0_ignored,
+                link_3_1_ignored,
+                static_text_3_1_0,
+                button_3_2,
+                empty_container_3_3_ignored,
             ],
             tree: Some(Tree::new(TreeId("test_tree".into()), StringEncoding::Utf8)),
             root: Some(ROOT_ID),

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -344,11 +344,11 @@ mod tests {
     fn deepest_last_child() {
         let tree = test_tree();
         assert_eq!(
-            BUTTON_3_1_ID,
+            EMPTY_CONTAINER_3_3_IGNORED_ID,
             tree.read().root().deepest_last_child().unwrap().id()
         );
         assert_eq!(
-            BUTTON_3_1_ID,
+            EMPTY_CONTAINER_3_3_IGNORED_ID,
             tree.read()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -358,7 +358,7 @@ mod tests {
         );
         assert!(tree
             .read()
-            .node_by_id(BUTTON_3_1_ID)
+            .node_by_id(BUTTON_3_2_ID)
             .unwrap()
             .deepest_last_child()
             .is_none());
@@ -368,7 +368,7 @@ mod tests {
     fn deepest_last_unignored_child() {
         let tree = test_tree();
         assert_eq!(
-            BUTTON_3_1_ID,
+            BUTTON_3_2_ID,
             tree.read()
                 .root()
                 .deepest_last_unignored_child()
@@ -376,7 +376,7 @@ mod tests {
                 .id()
         );
         assert_eq!(
-            BUTTON_3_1_ID,
+            BUTTON_3_2_ID,
             tree.read()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -386,7 +386,7 @@ mod tests {
         );
         assert!(tree
             .read()
-            .node_by_id(BUTTON_3_1_ID)
+            .node_by_id(BUTTON_3_2_ID)
             .unwrap()
             .deepest_last_unignored_child()
             .is_none());


### PR DESCRIPTION
…loopI came across this in my conversion of an actual Chromium tree to the AccessKit schema. Apparently the necessary condition is an ignored node with one or more unignored children, but also an empty unignored child at the end (for forward traversal) or start (for backward traversal). I believe my modified test tree accurately captures this case.