### PR TITLE
Use `parking_lot` crate for RW locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "accesskit_consumer"
 version = "0.1.0"
 dependencies = [
  "accesskit_schema",
+ "parking_lot",
 ]
 
 [[package]]
@@ -176,6 +177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "instant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +266,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -304,6 +357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +403,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "syn"

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 accesskit_schema = { path = "../schema" }
+parking_lot = "0.11.2"

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,8 +4,9 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit_schema::{NodeId, TreeId, TreeUpdate};
+use parking_lot::{RwLock, RwLockReadGuard};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::sync::Arc;
 
 use crate::{Node, NodeData, TreeData};
 
@@ -204,13 +205,13 @@ impl Tree {
     }
 
     pub fn update(&self, update: TreeUpdate) {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.write();
         state.update(update)
     }
 
     // Intended for debugging.
     pub fn serialize(&self) -> TreeUpdate {
-        let state = self.state.read().unwrap();
+        let state = self.state.read();
         state.serialize()
     }
 
@@ -219,7 +220,7 @@ impl Tree {
     pub fn read<'a>(self: &'a Arc<Tree>) -> Reader<'a> {
         Reader {
             tree: self,
-            state: self.state.read().unwrap(),
+            state: self.state.read(),
         }
     }
 }


### PR DESCRIPTION
This speeds up acquisition of an uncontended RW lock for reading (the common case). On Linux/x64, using a release build with LTO, the time to upgrade a `WeakNode` in my benchmark is reduced by about 30%. The improvement is less dramatic on Windows, but still an improvement.