### PR TITLE
Add basic tracking of the changes in a tree update

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -6,7 +6,7 @@
 pub use accesskit_schema::{Node as NodeData, Tree as TreeData};
 
 pub(crate) mod tree;
-pub use tree::{Reader as TreeReader, Tree};
+pub use tree::{Change as TreeChange, Reader as TreeReader, Tree};
 
 pub(crate) mod node;
 pub use node::{Node, WeakNode};

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -504,7 +504,11 @@ mod tests {
         };
         let mut got_focus_change = false;
         tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::FocusMoved { old_id, new_node: Some(new_node) } = &change {
+            if let super::Change::FocusMoved {
+                old_id,
+                new_node: Some(new_node),
+            } = &change
+            {
                 if *old_id == Some(NODE_ID_2) && new_node.id() == NODE_ID_3 {
                     got_focus_change = true;
                     return;

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,23 +4,31 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit_schema::{NodeId, TreeId, TreeUpdate};
-use parking_lot::{RwLock, RwLockReadGuard};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::{Node, NodeData, TreeData};
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);
 
 pub(crate) struct NodeState {
     pub(crate) parent_and_index: Option<ParentAndIndex>,
-    pub(crate) data: NodeData,
+    pub(crate) data: Box<NodeData>,
 }
 
 pub(crate) struct State {
-    pub(crate) nodes: HashMap<NodeId, Box<NodeState>>,
+    pub(crate) nodes: HashMap<NodeId, NodeState>,
     pub(crate) root: NodeId,
     pub(crate) data: TreeData,
+}
+
+enum InternalChange {
+    NewNode(NodeId),
+    UpdatedNode(Box<NodeData>),
+    FocusChange((Option<NodeId>, Option<NodeId>)),
+    RemovedNode(Box<NodeData>),
 }
 
 impl State {
@@ -34,7 +42,7 @@ impl State {
         }
     }
 
-    fn update(&mut self, update: TreeUpdate) {
+    fn update(&mut self, update: TreeUpdate, mut changes: Option<&mut Vec<InternalChange>>) {
         // TODO: handle TreeUpdate::clear
         assert!(update.clear.is_none());
 
@@ -48,6 +56,23 @@ impl State {
             self.root = root;
         }
 
+        fn add_node(
+            nodes: &mut HashMap<NodeId, NodeState>,
+            changes: &mut Option<&mut Vec<InternalChange>>,
+            parent_and_index: Option<ParentAndIndex>,
+            data: NodeData,
+        ) {
+            let id = data.id;
+            let state = NodeState {
+                parent_and_index,
+                data: Box::new(data),
+            };
+            nodes.insert(id, state);
+            if let Some(changes) = changes {
+                changes.push(InternalChange::NewNode(id));
+            }
+        }
+
         for node_data in update.nodes {
             let node_id = node_data.id;
             orphans.remove(&node_id);
@@ -58,13 +83,16 @@ impl State {
                 orphans.remove(child_id);
                 let parent_and_index = ParentAndIndex(node_id, child_index);
                 if let Some(child_state) = self.nodes.get_mut(child_id) {
-                    child_state.parent_and_index = Some(parent_and_index);
+                    if child_state.parent_and_index != Some(parent_and_index) {
+                        child_state.parent_and_index = Some(parent_and_index);
+                    }
                 } else if let Some(child_data) = pending_nodes.remove(child_id) {
-                    let node_state = NodeState {
-                        parent_and_index: Some(parent_and_index),
-                        data: child_data,
-                    };
-                    self.nodes.insert(*child_id, Box::new(node_state));
+                    add_node(
+                        &mut self.nodes,
+                        &mut changes,
+                        Some(parent_and_index),
+                        child_data,
+                    );
                 } else {
                     pending_children.insert(*child_id, parent_and_index);
                 }
@@ -80,19 +108,21 @@ impl State {
                         orphans.insert(*child_id);
                     }
                 }
-                node_state.data = node_data;
+                if *node_state.data != node_data {
+                    let old_data = std::mem::replace(&mut node_state.data, Box::new(node_data));
+                    if let Some(changes) = &mut changes {
+                        changes.push(InternalChange::UpdatedNode(old_data));
+                    }
+                }
             } else if let Some(parent_and_index) = pending_children.remove(&node_id) {
-                let node_state = NodeState {
-                    parent_and_index: Some(parent_and_index),
-                    data: node_data,
-                };
-                self.nodes.insert(node_id, Box::new(node_state));
+                add_node(
+                    &mut self.nodes,
+                    &mut changes,
+                    Some(parent_and_index),
+                    node_data,
+                );
             } else if node_id == root {
-                let node_state = NodeState {
-                    parent_and_index: None,
-                    data: node_data,
-                };
-                self.nodes.insert(node_id, Box::new(node_state));
+                add_node(&mut self.nodes, &mut changes, None, node_data);
             } else {
                 pending_nodes.insert(node_id, node_data);
             }
@@ -107,11 +137,21 @@ impl State {
 
         assert_eq!(pending_children.len(), 0);
 
+        if let Some(tree) = update.tree {
+            assert_eq!(tree.id, self.data.id);
+            if tree.focus != self.data.focus {
+                if let Some(changes) = &mut changes {
+                    changes.push(InternalChange::FocusChange((self.data.focus, tree.focus)));
+                }
+            }
+            self.data = tree;
+        }
+
         if !orphans.is_empty() {
             let mut to_remove = HashSet::new();
 
             fn traverse_orphan(
-                nodes: &HashMap<NodeId, Box<NodeState>>,
+                nodes: &HashMap<NodeId, NodeState>,
                 to_remove: &mut HashSet<NodeId>,
                 id: NodeId,
             ) {
@@ -127,13 +167,12 @@ impl State {
             }
 
             for id in to_remove {
-                self.nodes.remove(&id);
+                if let Some(old_state) = self.nodes.remove(&id) {
+                    if let Some(changes) = &mut changes {
+                        changes.push(InternalChange::RemovedNode(old_state.data));
+                    }
+                }
             }
-        }
-
-        if let Some(tree) = update.tree {
-            assert_eq!(tree.id, self.data.id);
-            self.data = tree;
         }
 
         self.validate_global();
@@ -144,7 +183,7 @@ impl State {
 
         fn traverse(state: &State, nodes: &mut Vec<NodeData>, id: NodeId) {
             let node = state.nodes.get(&id).unwrap();
-            nodes.push(node.data.clone());
+            nodes.push((*node.data).clone());
 
             for child_id in node.data.children.iter() {
                 traverse(state, nodes, *child_id);
@@ -185,6 +224,13 @@ impl Reader<'_> {
     }
 }
 
+pub enum Change<'a> {
+    NewNode(Node<'a>),
+    UpdatedNode((Box<NodeData>, Node<'a>)),
+    FocusChange((Option<NodeId>, Option<Node<'a>>)),
+    RemovedNode(Box<NodeData>),
+}
+
 pub struct Tree {
     state: RwLock<State>,
 }
@@ -198,7 +244,7 @@ impl Tree {
             root: initial_state.root.take().unwrap(),
             data: initial_state.tree.take().unwrap(),
         };
-        state.update(initial_state);
+        state.update(initial_state, None);
         Arc::new(Self {
             state: RwLock::new(state),
         })
@@ -206,7 +252,38 @@ impl Tree {
 
     pub fn update(&self, update: TreeUpdate) {
         let mut state = self.state.write();
-        state.update(update)
+        state.update(update, None);
+    }
+
+    pub fn update_and_process_changes<F>(self: &Arc<Tree>, update: TreeUpdate, mut f: F)
+    where
+        for<'a> F: FnMut(Change<'a>),
+    {
+        let mut changes = Vec::<InternalChange>::new();
+        let mut state = self.state.write();
+        state.update(update, Some(&mut changes));
+        let state = RwLockWriteGuard::downgrade(state);
+        let reader = Reader { tree: self, state };
+        for change in changes {
+            match change {
+                InternalChange::NewNode(id) => {
+                    let node = reader.node_by_id(id).unwrap();
+                    f(Change::NewNode(node));
+                }
+                InternalChange::UpdatedNode(old_data) => {
+                    let id = old_data.id;
+                    let new_node = reader.node_by_id(id).unwrap();
+                    f(Change::UpdatedNode((old_data, new_node)));
+                }
+                InternalChange::FocusChange((old_id, new_id)) => {
+                    let new_node = new_id.map(|id| reader.node_by_id(id)).flatten();
+                    f(Change::FocusChange((old_id, new_node)));
+                }
+                InternalChange::RemovedNode(old_data) => {
+                    f(Change::RemovedNode(old_data));
+                }
+            };
+        }
     }
 
     // Intended for debugging.
@@ -301,7 +378,28 @@ mod tests {
             tree: None,
             root: None,
         };
-        tree.update(second_update);
+        let mut got_updated_root_node = false;
+        let mut got_new_child_node = false;
+        tree.update_and_process_changes(second_update, |change| {
+            if let super::Change::UpdatedNode((old_data, new_node)) = &change {
+                if new_node.id() == NODE_ID_1
+                    && old_data.children == Box::new([])
+                    && new_node.data().children == Box::new([NODE_ID_2])
+                {
+                    got_updated_root_node = true;
+                    return;
+                }
+            }
+            if let super::Change::NewNode(node) = &change {
+                if node.id() == NODE_ID_2 {
+                    got_new_child_node = true;
+                    return;
+                }
+            }
+            assert!(false);
+        });
+        assert!(got_updated_root_node);
+        assert!(got_new_child_node);
         let reader = tree.read();
         assert_eq!(1, reader.root().children().count());
         assert_eq!(NODE_ID_2, reader.root().children().next().unwrap().id());
@@ -334,7 +432,28 @@ mod tests {
             tree: None,
             root: None,
         };
-        tree.update(second_update);
+        let mut got_updated_root_node = false;
+        let mut got_removed_child_node = false;
+        tree.update_and_process_changes(second_update, |change| {
+            if let super::Change::UpdatedNode((old_data, new_node)) = &change {
+                if new_node.id() == NODE_ID_1
+                    && old_data.children == Box::new([NODE_ID_2])
+                    && new_node.data().children == Box::new([])
+                {
+                    got_updated_root_node = true;
+                    return;
+                }
+            }
+            if let super::Change::RemovedNode(old_data) = &change {
+                if old_data.id == NODE_ID_2 {
+                    got_removed_child_node = true;
+                    return;
+                }
+            }
+            assert!(false);
+        });
+        assert!(got_updated_root_node);
+        assert!(got_removed_child_node);
         assert_eq!(0, tree.read().root().children().count());
         assert!(tree.read().node_by_id(NODE_ID_2).is_none());
     }
@@ -369,8 +488,99 @@ mod tests {
             }),
             root: None,
         };
-        tree.update(second_update);
+        let mut got_focus_change = false;
+        tree.update_and_process_changes(second_update, |change| {
+            if let super::Change::FocusChange((old_id, new_node)) = &change {
+                if let Some(new_node) = new_node {
+                    if *old_id == Some(NODE_ID_2) && new_node.id() == NODE_ID_3 {
+                        got_focus_change = true;
+                        return;
+                    }
+                }
+            }
+            assert!(false);
+        });
+        assert!(got_focus_change);
         assert!(tree.read().node_by_id(NODE_ID_3).unwrap().is_focused());
         assert!(!tree.read().node_by_id(NODE_ID_2).unwrap().is_focused());
+    }
+
+    #[test]
+    fn update_node() {
+        let tree_data = Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8);
+        let child_node = Node::new(NODE_ID_2, Role::Button);
+        let first_update = TreeUpdate {
+            clear: None,
+            nodes: vec![
+                Node {
+                    children: Box::new([NODE_ID_2]),
+                    ..Node::new(NODE_ID_1, Role::Window)
+                },
+                Node {
+                    name: Some("foo".into()),
+                    ..child_node.clone()
+                },
+            ],
+            tree: Some(tree_data),
+            root: Some(NODE_ID_1),
+        };
+        let tree = super::Tree::new(first_update);
+        assert_eq!(
+            Some("foo"),
+            tree.read().node_by_id(NODE_ID_2).unwrap().name()
+        );
+        let second_update = TreeUpdate {
+            clear: None,
+            nodes: vec![Node {
+                name: Some("bar".into()),
+                ..child_node.clone()
+            }],
+            tree: None,
+            root: None,
+        };
+        let mut got_updated_child_node = false;
+        tree.update_and_process_changes(second_update, |change| {
+            if let super::Change::UpdatedNode((old_data, new_node)) = &change {
+                if new_node.id() == NODE_ID_2
+                    && old_data.name == Some("foo".into())
+                    && new_node.name() == Some("bar")
+                {
+                    got_updated_child_node = true;
+                    return;
+                }
+            }
+            assert!(false);
+        });
+        assert!(got_updated_child_node);
+        assert_eq!(
+            Some("bar"),
+            tree.read().node_by_id(NODE_ID_2).unwrap().name()
+        );
+    }
+
+    // Verify that if an update consists entirely of node data and tree data
+    // that's the same as before, no changes are reported. This would be useful
+    // for a provider that constructs a fresh tree every time, such as
+    // an immediate-mode GUI.
+    #[test]
+    fn no_change_update() {
+        let update = TreeUpdate {
+            clear: None,
+            nodes: vec![
+                Node {
+                    children: Box::new([NODE_ID_2, NODE_ID_3]),
+                    ..Node::new(NODE_ID_1, Role::Window)
+                },
+                Node::new(NODE_ID_2, Role::Button),
+                Node::new(NODE_ID_3, Role::Button),
+            ],
+            tree: Some(Tree::new(TreeId(TREE_ID.into()), StringEncoding::Utf8)),
+            root: Some(NODE_ID_1),
+        };
+        let tree = super::Tree::new(update.clone());
+        tree.update_and_process_changes(update.clone(), |_| {
+            // We don't expect any changes to be reported.
+            assert!(false);
+        });
     }
 }

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -504,12 +504,10 @@ mod tests {
         };
         let mut got_focus_change = false;
         tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::FocusMoved { old_id, new_node } = &change {
-                if let Some(new_node) = new_node {
-                    if *old_id == Some(NODE_ID_2) && new_node.id() == NODE_ID_3 {
-                        got_focus_change = true;
-                        return;
-                    }
+            if let super::Change::FocusMoved { old_id, new_node: Some(new_node) } = &change {
+                if *old_id == Some(NODE_ID_2) && new_node.id() == NODE_ID_3 {
+                    got_focus_change = true;
+                    return;
                 }
             }
             panic!("expected only focus change");
@@ -547,7 +545,7 @@ mod tests {
             clear: None,
             nodes: vec![Node {
                 name: Some("bar".into()),
-                ..child_node.clone()
+                ..child_node
             }],
             tree: None,
             root: None,
@@ -592,7 +590,7 @@ mod tests {
             root: Some(NODE_ID_1),
         };
         let tree = super::Tree::new(update.clone());
-        tree.update_and_process_changes(update.clone(), |_| {
+        tree.update_and_process_changes(update, |_| {
             panic!("expected no changes");
         });
     }

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -410,7 +410,7 @@ mod tests {
                     return;
                 }
             }
-            assert!(false);
+            panic!("expected only new child node and updated root node");
         });
         assert!(got_updated_root_node);
         assert!(got_new_child_node);
@@ -464,7 +464,7 @@ mod tests {
                     return;
                 }
             }
-            assert!(false);
+            panic!("expected only removed child node and updated root node");
         });
         assert!(got_updated_root_node);
         assert!(got_removed_child_node);
@@ -512,7 +512,7 @@ mod tests {
                     }
                 }
             }
-            assert!(false);
+            panic!("expected only focus change");
         });
         assert!(got_focus_change);
         assert!(tree.read().node_by_id(NODE_ID_3).unwrap().is_focused());
@@ -563,7 +563,7 @@ mod tests {
                     return;
                 }
             }
-            assert!(false);
+            panic!("expected only updated child node");
         });
         assert!(got_updated_child_node);
         assert_eq!(
@@ -593,8 +593,7 @@ mod tests {
         };
         let tree = super::Tree::new(update.clone());
         tree.update_and_process_changes(update.clone(), |_| {
-            // We don't expect any changes to be reported.
-            assert!(false);
+            panic!("expected no changes");
         });
     }
 }


### PR DESCRIPTION
The code for processing a `TreeUpdate` can now keep track of the nodes that are added, updated, or removed, as well as a change in focus. This feature will be the basis for platform-specific events.