### PR TITLE
Use the `nohash-hasher` crate to speed up node lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "accesskit_consumer"
 version = "0.1.0"
 dependencies = [
  "accesskit_schema",
+ "nohash-hasher",
  "parking_lot",
 ]
 
@@ -39,6 +40,7 @@ dependencies = [
 name = "accesskit_schema"
 version = "0.1.0"
 dependencies = [
+ "nohash-hasher",
  "schemars",
  "serde",
 ]
@@ -255,6 +257,12 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "objc"

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 
 [dependencies]
 accesskit_schema = { path = "../schema" }
+nohash-hasher = "0.2.0"
 parking_lot = "0.11.2"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Matt Campbell <mattcampbell@pobox.com>"]
 edition = "2018"
 
 [dependencies]
+nohash-hasher = "0.2.0"
 schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -507,6 +507,8 @@ pub enum StringEncoding {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub struct NodeId(pub std::num::NonZeroU64);
 
+impl nohash_hasher::IsEnabled for NodeId {}
+
 /// The globally unique ID of a tree. The format of this ID
 /// is up to the implementer. A UUID v4 is a safe choice.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
In my microbenchmark, this reduces the time to upgrade a `WeakNode` by about 25%.

While working on this, I fixed a bug in `Tree::update` where I was accidentally building a set of `&NodeId`s (references) rather than `NodeId`s.