### PR TITLE
Store the root node in tree data and the focus in the tree update

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -146,8 +146,12 @@ mod tests {
                 button_3_2,
                 empty_container_3_3_ignored,
             ],
-            tree: Some(Tree::new(TreeId("test_tree".into()), StringEncoding::Utf8)),
-            root: Some(ROOT_ID),
+            tree: Some(Tree::new(
+                TreeId("test_tree".into()),
+                ROOT_ID,
+                StringEncoding::Utf8,
+            )),
+            focus: None,
         };
         crate::tree::Tree::new(initial_update)
     }

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -27,7 +27,7 @@ impl<'a> Node<'a> {
     }
 
     pub fn is_focused(&self) -> bool {
-        self.tree_reader.state.data.focus == Some(self.id())
+        self.tree_reader.state.focus == Some(self.id())
     }
 
     pub fn is_ignored(&self) -> bool {
@@ -41,7 +41,7 @@ impl<'a> Node<'a> {
     pub fn is_root(&self) -> bool {
         // Don't check for absence of a parent node, in case a non-root node
         // somehow gets detached from the tree.
-        self.id() == self.tree_reader.state.root
+        self.id() == self.tree_reader.state.data.root
     }
 
     pub fn parent(self) -> Option<Node<'a>> {

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1226,6 +1226,7 @@ impl Node {
 #[serde(rename_all = "camelCase")]
 pub struct Tree {
     pub id: TreeId,
+    pub root: NodeId,
 
     /// The string encoding used by the tree source. This is required
     /// to disambiguate string indices, e.g. in [`Node::words`].
@@ -1239,12 +1240,6 @@ pub struct Tree {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<TreeId>,
 
-    /// The node with keyboard focus within this tree, if any.
-    /// If the focus is in a descendant tree, set this to the node
-    /// to which that tree is anchored.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub focus: Option<NodeId>,
-
     /// The node that's used as the root scroller, if any. On some platforms
     /// like Android we need to ignore accessibility scroll offsets for
     /// that node and get them from the viewport instead.
@@ -1253,12 +1248,12 @@ pub struct Tree {
 }
 
 impl Tree {
-    pub fn new(id: TreeId, source_string_encoding: StringEncoding) -> Tree {
+    pub fn new(id: TreeId, root: NodeId, source_string_encoding: StringEncoding) -> Tree {
         Tree {
             id,
+            root,
             source_string_encoding,
             parent: None,
-            focus: None,
             root_scroller: None,
         }
     }
@@ -1298,15 +1293,17 @@ pub struct TreeUpdate {
     ///   before or after a `TreeUpdate`.
     pub nodes: Vec<Node>,
 
-    /// Updated information about the tree as a whole. This may be omitted
+    /// Rarely updated information about the tree as a whole. This may be omitted
     /// if it has not changed since the previous update, but providing the same
     /// information again is also allowed. This is required when initializing
     /// a tree.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tree: Option<Tree>,
 
-    /// The ID of the tree's root node. This is required when the tree
-    /// is being initialized or if the root is changing.
+    /// The node with keyboard focus within this tree, if any.
+    /// If the focus is in a descendant tree, set this to the node
+    /// to which that tree is anchored. The most recent focus, if any,
+    /// must be provided with every tree update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub root: Option<NodeId>,
+    pub focus: Option<NodeId>,
 }


### PR DESCRIPTION
This makes sense, as the focus is updated much more often. It also allows code that doesn't have access to the global tree data to update the focus.