### PR TITLE
Windows: Handle focus corner cases in example and tests

### DIFF
--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -148,11 +148,11 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
             let window_state = unsafe { &*get_window_state(window) };
             window_state.manager.handle_wm_getobject(wparam, lparam)
         }
-        WM_SETFOCUS => {
+        WM_SETFOCUS | WM_EXITMENULOOP | WM_EXITSIZEMOVE => {
             update_focus(window, true);
             LRESULT(0)
         }
-        WM_KILLFOCUS => {
+        WM_KILLFOCUS | WM_ENTERMENULOOP | WM_ENTERSIZEMOVE => {
             update_focus(window, false);
             LRESULT(0)
         }

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -120,11 +120,11 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
             let window_state = unsafe { &*get_window_state(window) };
             window_state.manager.handle_wm_getobject(wparam, lparam)
         }
-        WM_SETFOCUS => {
+        WM_SETFOCUS | WM_EXITMENULOOP | WM_EXITSIZEMOVE => {
             update_focus(window, true);
             LRESULT(0)
         }
-        WM_KILLFOCUS => {
+        WM_KILLFOCUS | WM_ENTERMENULOOP | WM_ENTERSIZEMOVE => {
             update_focus(window, false);
             LRESULT(0)
         }


### PR DESCRIPTION
To see these cases in action, run the example, open the system menu (Alt+Space), choose Move or Size, then exit the move/size mode with Escape. Or open the System menu, escape out of that menu, then escape out of menu mode. In both cases, focus should not return to the button until you leave the special mode.