### PR TITLE
Windows: More work on basic UIA properties and navigation

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -209,6 +209,10 @@ impl<'a> Node<'a> {
         self.data().invisible
     }
 
+    pub fn is_disabled(&self) -> bool {
+        self.data().disabled
+    }
+
     pub fn name(&self) -> Option<&str> {
         if let Some(name) = &self.data().name {
             Some(name)

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use std::{
-    convert::{From, TryInto},
+    convert::{From, Into, TryInto},
     mem::ManuallyDrop,
 };
 use windows::Win32::{
@@ -68,6 +68,12 @@ impl From<bool> for VariantFactory {
                 boolVal: if value { VARIANT_TRUE } else { VARIANT_FALSE },
             },
         )
+    }
+}
+
+impl<T: Into<VariantFactory>> From<Option<T>> for VariantFactory {
+    fn from(value: Option<T>) -> Self {
+        value.map_or_else(Self::empty, T::into)
     }
 }
 

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -3,10 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use std::{
-    convert::{From, Into, TryInto},
-    mem::ManuallyDrop,
-};
+use std::{convert::TryInto, mem::ManuallyDrop};
 use windows::Win32::{
     Foundation::*,
     System::{Com::*, Ole::Automation::*},


### PR DESCRIPTION
While testing with JAWS, I discovered that I need to implement the `IsControlElement`, `IsContentElement`, and `IsEnabled` properties, because JAWS doesn't respect the normal UIA-provided default values for these properties. I also refactored the abstraction for UIA properties so the getters don't all have to return an `Option`. And I modified navigation to traverse all elements, since we'll let UIA filter elements via `IsControlElement` and `IsContentElement`.