### PR TITLE
Use EnumSet where appropriate in the schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
 name = "accesskit_schema"
 version = "0.1.0"
 dependencies = [
+ "enumset",
  "schemars",
  "serde",
 ]
@@ -194,10 +195,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
+name = "enumset"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
+dependencies = [
+ "enumset_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -213,6 +277,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "im"
@@ -401,11 +471,12 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "271ac0c667b8229adf70f0f957697c96fafd7486ab7481e15dc5e45e3e6a4368"
 dependencies = [
  "dyn-clone",
+ "enumset",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -413,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "6ebda811090b257411540779860bc09bf321bc587f58d2c5864309d1566214e7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,6 +557,12 @@ name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Matt Campbell <mattcampbell@pobox.com>"]
 edition = "2018"
 
 [dependencies]
-schemars = { version = "0.8.3", optional = true }
+enumset = { version = "1.0.8", features = ["serde"] }
+schemars = { version = "0.8.7", features = ["enumset"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -237,7 +237,7 @@ pub enum Role {
 /// An action to be taken on an accessibility node.
 /// In contrast to [`DefaultActionVerb`], these describe what happens to the
 /// object, e.g. "focus".
-#[derive(EnumSetType, Debug, Hash)]
+#[derive(EnumSetType, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -364,7 +364,7 @@ pub enum DescriptionFrom {
 /// Function that can be performed when a dragged object is released
 /// on a drop target.
 /// Note: aria-dropeffect is deprecated in WAI-ARIA 1.1.
-#[derive(EnumSetType, Debug, Hash)]
+#[derive(EnumSetType, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -8,11 +8,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
+use enumset::{EnumSet, EnumSetType};
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::ops::Range;
 
 /// The type of an accessibility node.
@@ -237,10 +237,11 @@ pub enum Role {
 /// An action to be taken on an accessibility node.
 /// In contrast to [`DefaultActionVerb`], these describe what happens to the
 /// object, e.g. "focus".
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(EnumSetType, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", enumset(serialize_as_list))]
 pub enum Action {
     /// Do the default action for an object, typically this means "click".
     Default,
@@ -363,10 +364,11 @@ pub enum DescriptionFrom {
 /// Function that can be performed when a dragged object is released
 /// on a drop target.
 /// Note: aria-dropeffect is deprecated in WAI-ARIA 1.1.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(EnumSetType, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(feature = "serde", enumset(serialize_as_list))]
 pub enum DropEffect {
     Copy,
     Execute,
@@ -664,8 +666,8 @@ pub struct Node {
 
     /// Unordered set of actions supported by this node.
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "BTreeSet::is_empty"))]
-    pub actions: BTreeSet<Action>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "EnumSet::is_empty"))]
+    pub actions: EnumSet<Action>,
 
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub name: Option<Box<str>>,
@@ -811,8 +813,8 @@ pub struct Node {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub grabbed: Option<bool>,
     #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "BTreeSet::is_empty"))]
-    pub drop_effects: BTreeSet<DropEffect>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "EnumSet::is_empty"))]
+    pub drop_effects: EnumSet<DropEffect>,
 
     /// Indicates whether this node causes a hard line-break
     /// (e.g. block level elements, or <br>)
@@ -1136,7 +1138,7 @@ impl Node {
             role,
             bounds: None,
             children: Default::default(),
-            actions: BTreeSet::new(),
+            actions: EnumSet::new(),
             name: None,
             name_from: None,
             description: None,
@@ -1171,7 +1173,7 @@ impl Node {
             selected: None,
             selected_from_focus: false,
             grabbed: None,
-            drop_effects: BTreeSet::new(),
+            drop_effects: EnumSet::new(),
             is_line_breaking_object: false,
             is_page_breaking_object: false,
             has_aria_attribute: false,


### PR DESCRIPTION
In addition to simply being a better data type, this reduces the size of each `Node` by 40 bytes on x64.