### PR TITLE
Allow lazy initialization of trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "accesskit_provider"
+version = "0.1.0"
+dependencies = [
+ "accesskit_schema",
+]
+
+[[package]]
 name = "accesskit_schema"
 version = "0.1.0"
 dependencies = [
@@ -48,9 +55,11 @@ name = "accesskit_windows"
 version = "0.1.0"
 dependencies = [
  "accesskit_consumer",
+ "accesskit_provider",
  "accesskit_schema",
  "arrayvec",
  "crossbeam-utils",
+ "lazy-init",
  "lazy_static",
  "parking_lot",
  "scopeguard",
@@ -332,6 +341,12 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "lazy-init"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23517540be87a91d06324e6bf6286ba8214171123ee8862ae9a5e7d938d71815"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "schema",
     "consumer",
+    "provider",
     "platforms/mac",
     "platforms/mac/jni",
     "platforms/windows",
@@ -9,6 +10,7 @@ members = [
 default-members = [
     "schema",
     "consumer",
+    "provider",
 ]
 
 [profile.release]

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2018"
 
 [dependencies]
 accesskit_consumer = { path = "../../consumer" }
+accesskit_provider = { path = "../../provider" }
 accesskit_schema = { path = "../../schema" }
 arrayvec = "0.7.1"
+lazy-init = "0.5.0"
 
 [dependencies.windows]
 version = "0.27.0"

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -152,7 +152,8 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
                 return unsafe { DefWindowProcW(window, message, wparam, lparam) };
             }
             let window_state = unsafe { &*window_state };
-            window_state.manager.handle_wm_getobject(wparam, lparam)
+            let result = window_state.manager.handle_wm_getobject(wparam, lparam);
+            result.unwrap_or_else(|| unsafe { DefWindowProcW(window, message, wparam, lparam) })
         }
         WM_SETFOCUS | WM_EXITMENULOOP | WM_EXITSIZEMOVE => {
             update_focus(window, true);

--- a/platforms/windows/src/manager.rs
+++ b/platforms/windows/src/manager.rs
@@ -6,18 +6,20 @@
 use std::sync::Arc;
 
 use accesskit_consumer::{Tree, TreeChange};
+use accesskit_provider::InitTree;
 use accesskit_schema::TreeUpdate;
+use lazy_init::LazyTransform;
 use windows::Win32::{Foundation::*, UI::Accessibility::*};
 
 use crate::node::{PlatformNode, ResolvedPlatformNode};
 
-pub struct Manager {
+pub struct Manager<Init: InitTree = TreeUpdate> {
     hwnd: HWND,
-    tree: Arc<Tree>,
+    tree: LazyTransform<Init, Arc<Tree>>,
 }
 
-impl Manager {
-    pub fn new(hwnd: HWND, initial_state: TreeUpdate) -> Self {
+impl<Init: InitTree> Manager<Init> {
+    pub fn new(hwnd: HWND, init: Init) -> Self {
         // It's unfortunate that we have to force UIA to initialize early;
         // it would be more optimal to let UIA lazily initialize itself
         // when we receive the first `WM_GETOBJECT`. But if we don't do this,
@@ -28,12 +30,32 @@ impl Manager {
 
         Self {
             hwnd,
-            tree: Tree::new(initial_state),
+            tree: LazyTransform::new(init),
         }
     }
 
+    fn get_or_create_tree(&self) -> &Arc<Tree> {
+        self.tree
+            .get_or_create(|init| Tree::new(init.init_accesskit_tree()))
+    }
+
     pub fn update(&self, update: TreeUpdate) {
-        self.tree.update_and_process_changes(update, |change| {
+        let tree = self.get_or_create_tree();
+        self.update_internal(tree, update);
+    }
+
+    pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
+        let tree = match self.tree.get() {
+            Some(tree) => tree,
+            None => {
+                return;
+            }
+        };
+        self.update_internal(tree, updater());
+    }
+
+    fn update_internal(&self, tree: &Arc<Tree>, update: TreeUpdate) {
+        tree.update_and_process_changes(update, |change| {
             match change {
                 TreeChange::FocusMoved {
                     old_node: _,
@@ -56,7 +78,8 @@ impl Manager {
     }
 
     fn root_platform_node(&self) -> PlatformNode {
-        let reader = self.tree.read();
+        let tree = self.get_or_create_tree();
+        let reader = tree.read();
         let node = reader.root();
         PlatformNode::new(&node, self.hwnd)
     }

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -125,7 +125,8 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
                 return unsafe { DefWindowProcW(window, message, wparam, lparam) };
             }
             let window_state = unsafe { &*window_state };
-            window_state.manager.handle_wm_getobject(wparam, lparam)
+            let result = window_state.manager.handle_wm_getobject(wparam, lparam);
+            result.unwrap_or_else(|| unsafe { DefWindowProcW(window, message, wparam, lparam) })
         }
         WM_SETFOCUS | WM_EXITMENULOOP | WM_EXITSIZEMOVE => {
             update_focus(window, true);

--- a/provider/Cargo.toml
+++ b/provider/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "accesskit_provider"
+version = "0.1.0"
+authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+edition = "2018"
+
+[dependencies]
+accesskit_schema = { path = "../schema" }

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -14,9 +14,3 @@ impl InitTree for TreeUpdate {
         self
     }
 }
-
-impl<T: FnOnce() -> TreeUpdate> InitTree for T {
-    fn init_accesskit_tree(self) -> TreeUpdate {
-        self()
-    }
-}

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -14,3 +14,9 @@ impl InitTree for TreeUpdate {
         self
     }
 }
+
+impl<T: FnOnce() -> TreeUpdate> InitTree for T {
+    fn init_accesskit_tree(self) -> TreeUpdate {
+        self()
+    }
+}

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -5,7 +5,7 @@
 
 use accesskit_schema::TreeUpdate;
 
-pub trait InitTree {
+pub trait InitTree: Send {
     fn init_accesskit_tree(self) -> TreeUpdate;
 }
 
@@ -15,7 +15,7 @@ impl InitTree for TreeUpdate {
     }
 }
 
-impl<T: FnOnce() -> TreeUpdate> InitTree for T {
+impl<T: FnOnce() -> TreeUpdate + Send> InitTree for T {
     fn init_accesskit_tree(self) -> TreeUpdate {
         self()
     }

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright 2021 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit_schema::TreeUpdate;
+
+pub trait InitTree {
+    fn init_accesskit_tree(self) -> TreeUpdate;
+}
+
+impl InitTree for TreeUpdate {
+    fn init_accesskit_tree(self) -> Self {
+        self
+    }
+}

--- a/provider/src/lib.rs
+++ b/provider/src/lib.rs
@@ -5,7 +5,7 @@
 
 use accesskit_schema::TreeUpdate;
 
-pub trait InitTree: Send {
+pub trait InitTree {
     fn init_accesskit_tree(self) -> TreeUpdate;
 }
 
@@ -15,7 +15,7 @@ impl InitTree for TreeUpdate {
     }
 }
 
-impl<T: FnOnce() -> TreeUpdate + Send> InitTree for T {
+impl<T: FnOnce() -> TreeUpdate> InitTree for T {
     fn init_accesskit_tree(self) -> TreeUpdate {
         self()
     }


### PR DESCRIPTION
When integrating AccessKit with Druid, we'll need to be able to lazily initialize the accessibility tree when the first `WM_GETOBJECT` message on Windows, or equivalent request on other platforms, is received. I think this requirement will be common enough that it's worth supporting directly in AccessKit. So that's what this branch does.

I've implemented this in a backward-compatible way, so it doesn't break the tests and example, but I suppose I really should update them to lazily initialize and update the tree.