### PR TITLE
Handle WM_GETOBJECT while the window is being destroyed

### DIFF
--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -117,7 +117,14 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
             LRESULT(0)
         }
         WM_GETOBJECT => {
-            let window_state = unsafe { &*get_window_state(window) };
+            let window_state = unsafe { get_window_state(window) };
+            if window_state.is_null() {
+                // We need to be prepared to gracefully handle WM_GETOBJECT
+                // while the window is being destroyed; this can happen if
+                // the thread is using a COM STA.
+                return unsafe { DefWindowProcW(window, message, wparam, lparam) };
+            }
+            let window_state = unsafe { &*window_state };
             window_state.manager.handle_wm_getobject(wparam, lparam)
         }
         WM_SETFOCUS | WM_EXITMENULOOP | WM_EXITSIZEMOVE => {


### PR DESCRIPTION
This fixes the crash that @DataTriny reported on #37 . It has to be done in the window procedure, since that is what actually manages the lifecycle of the AccessKit manager. So we implement it in our tests and in the example, which provides a model for integrators.