### PR TITLE
Windows: Reliably handle all COM init scenarios on the UI thread

### DIFF
--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -9,7 +9,6 @@ use windows::{
     Win32::{
         Foundation::*,
         Graphics::Gdi::ValidateRect,
-        System::Com::*,
         System::LibraryLoader::GetModuleHandleW,
         UI::{Input::KeyboardAndMouse::*, WindowsAndMessaging::*},
     },
@@ -229,18 +228,6 @@ fn create_window(title: &str, initial_state: TreeUpdate, initial_focus: NodeId) 
 }
 
 fn main() -> Result<()> {
-    // There isn't a single correct answer to the question of how, or whether,
-    // to initialize COM. It's not clear whether this should even matter
-    // for a UI Automation provider that, like AccessKit, doesn't use
-    // COM threading. However, as discussed in #37, it apparently does matter,
-    // at least on some machines. If a program depends on legacy code
-    // that requires a single-threaded apartment (STA), then it should
-    // initialize COM that way. But that's not the case for AccessKit's
-    // examples and tests, and the multi-threaded apartment (MTA)
-    // is apparently more reliable for our use case, so we choose that.
-    unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED) }?;
-    let _com_guard = scopeguard::guard((), |_| unsafe { CoUninitialize() });
-
     let window = create_window(WINDOW_TITLE, get_initial_state(), INITIAL_FOCUS)?;
     unsafe { ShowWindow(window, SW_SHOW) };
 

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -191,16 +191,6 @@ where
 {
     let _lock_guard = MUTEX.lock();
 
-    // We must initialize COM before creating the UIA client. The MTA option
-    // is cleaner by far, especially when we want to wait for a UIA event handler
-    // to be called, and there's no reason not to use it here. Note that we don't
-    // initialize COM this way on the provider thread, as explained below.
-    unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED) }.unwrap();
-    let _com_guard = scopeguard::guard((), |_| unsafe { CoUninitialize() });
-
-    let uia: IUIAutomation =
-        unsafe { CoCreateInstance(&CUIAutomation8, None, CLSCTX_INPROC_SERVER) }?;
-
     let window_mutex: Mutex<Option<HWND>> = Mutex::new(None);
     let window_cv = Condvar::new();
 
@@ -239,6 +229,24 @@ where
         let _window_guard = scopeguard::guard((), |_| {
             unsafe { PostMessageW(window, WM_CLOSE, WPARAM(0), LPARAM(0)) }.unwrap()
         });
+
+        // We must initialize COM before creating the UIA client. The MTA option
+        // is cleaner by far, especially when we want to wait for a UIA event
+        // handler to be called, and there's no reason not to use it here.
+        // Note that we don't initialize COM this way on the provider thread,
+        // as explained above. It's also important that we let the provider
+        // thread do its forced initialization of UIA, in an environment
+        // where COM has not been initialized, before we create the UIA client,
+        // which also triggers UIA initialization, in a thread where COM
+        // _has_ been initialized. This way, we ensure that the provider side
+        // of UIA works even if it is set up in an environment where COM
+        // has not been initialized, and that this sequence of events
+        // doesn't prevent the UIA client from working.
+        unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED) }.unwrap();
+        let _com_guard = scopeguard::guard((), |_| unsafe { CoUninitialize() });
+
+        let uia: IUIAutomation =
+            unsafe { CoCreateInstance(&CUIAutomation8, None, CLSCTX_INPROC_SERVER) }?;
 
         let s = Scope { uia, window };
         f(&s)


### PR DESCRIPTION
This finally fixes #37. The key is to force UIA to initialize itself before we handle `WM_GETOBJECT`.