### PR TITLE
Rename "manager" to "adapter"

### DIFF
--- a/platforms/mac/examples/hello_world.rs
+++ b/platforms/mac/examples/hello_world.rs
@@ -60,8 +60,8 @@ fn main() {
 
         // Set up accessibility
         let view = window.contentView();
-        let manager = accesskit_mac::Manager::new(view, initial_state);
-        manager.inject();
+        let adapter = accesskit_mac::Adapter::new(view, initial_state);
+        adapter.inject();
 
         window.makeKeyAndOrderFront_(nil);
         let current_app = NSRunningApplication::currentApplication(nil);

--- a/platforms/mac/jni/Makefile
+++ b/platforms/mac/jni/Makefile
@@ -1,6 +1,6 @@
 BUILD_TYPE ?= debug
 JAR = build/accesskit-mac.jar
-JAVA_SRC = java/dev/accesskit/mac/AccessKitMacManager.java
+JAVA_SRC = java/dev/accesskit/mac/AccessKitMacAdapter.java
 DYLIB = ../../../target/$(BUILD_TYPE)/libaccesskit_mac_jni.dylib
 RUST_SRC = src/lib.rs
 DIST_TGZ = build/accesskit-mac-jni-$(BUILD_TYPE).tar.gz

--- a/platforms/mac/jni/java/dev/accesskit/mac/AccessKitMacAdapter.java
+++ b/platforms/mac/jni/java/dev/accesskit/mac/AccessKitMacAdapter.java
@@ -5,15 +5,15 @@
 
 package dev.accesskit.mac;
 
-public final class AccessKitMacManager implements AutoCloseable {
-    public static AccessKitMacManager forNSWindow(long nsWindow, String initialStateJson) {
+public final class AccessKitMacAdapter implements AutoCloseable {
+    public static AccessKitMacAdapter forNSWindow(long nsWindow, String initialStateJson) {
         long ptr = nativeNewForNSWindow(nsWindow, initialStateJson);
-        return new AccessKitMacManager(ptr);
+        return new AccessKitMacAdapter(ptr);
     }
 
-    public static AccessKitMacManager forNSView(long nsView, String initialStateJson) {
+    public static AccessKitMacAdapter forNSView(long nsView, String initialStateJson) {
         long ptr = nativeNewForNSView(nsView, initialStateJson);
-        return new AccessKitMacManager(ptr);
+        return new AccessKitMacAdapter(ptr);
     }
 
     @Override
@@ -44,7 +44,7 @@ public final class AccessKitMacManager implements AutoCloseable {
 
     private long ptr;
 
-    private AccessKitMacManager(long ptr) {
+    private AccessKitMacAdapter(long ptr) {
         this.ptr = ptr;
     }
 

--- a/platforms/mac/jni/src/lib.rs
+++ b/platforms/mac/jni/src/lib.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::TreeUpdate;
-use accesskit_mac::Manager;
+use accesskit_mac::Adapter;
 use cocoa::appkit::NSWindow;
 use cocoa::base::id;
 use jni::objects::{JClass, JString};
@@ -14,12 +14,12 @@ use jni::JNIEnv;
 fn new_common(env: JNIEnv, view: id, initial_state_json: JString) -> jlong {
     let initial_state_json: String = env.get_string(initial_state_json).unwrap().into();
     let initial_state = serde_json::from_str::<TreeUpdate>(&initial_state_json).unwrap();
-    let manager = Manager::new(view, initial_state);
-    Box::into_raw(Box::new(manager)) as jlong
+    let adapter = Adapter::new(view, initial_state);
+    Box::into_raw(Box::new(adapter)) as jlong
 }
 
 #[no_mangle]
-pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeNewForNSWindow(
+pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacAdapter_nativeNewForNSWindow(
     env: JNIEnv,
     _class: JClass,
     window_ptr: jlong,
@@ -31,7 +31,7 @@ pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeNewForNS
 }
 
 #[no_mangle]
-pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeNewForNSView(
+pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacAdapter_nativeNewForNSView(
     env: JNIEnv,
     _class: JClass,
     view_ptr: jlong,
@@ -42,34 +42,34 @@ pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeNewForNS
 }
 
 #[no_mangle]
-pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeDestroy(
+pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacAdapter_nativeDestroy(
     _env: JNIEnv,
     _class: JClass,
     ptr: jlong,
 ) {
-    let _boxed_manager = unsafe { Box::from_raw(ptr as *mut Manager) };
+    let _boxed_adapter = unsafe { Box::from_raw(ptr as *mut Adapter) };
     // Let the box drop at the end of the scope.
 }
 
 #[no_mangle]
-pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeUpdate(
+pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacAdapter_nativeUpdate(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
     update_json: JString,
 ) {
-    let manager = unsafe { &mut *(ptr as *mut Manager) };
+    let adapter = unsafe { &mut *(ptr as *mut Adapter) };
     let update_json: String = env.get_string(update_json).unwrap().into();
     let update = serde_json::from_str::<TreeUpdate>(&update_json).unwrap();
-    manager.update(update);
+    adapter.update(update);
 }
 
 #[no_mangle]
-pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacManager_nativeInject(
+pub extern "system" fn Java_dev_accesskit_mac_AccessKitMacAdapter_nativeInject(
     _env: JNIEnv,
     _class: JClass,
     ptr: jlong,
 ) {
-    let manager = unsafe { &mut *(ptr as *mut Manager) };
-    manager.inject();
+    let adapter = unsafe { &mut *(ptr as *mut Adapter) };
+    adapter.inject();
 }

--- a/platforms/mac/src/adapter.rs
+++ b/platforms/mac/src/adapter.rs
@@ -14,12 +14,12 @@ use objc::{msg_send, sel, sel_impl};
 
 use crate::node::PlatformNode;
 
-pub struct Manager {
+pub struct Adapter {
     view: StrongPtr,
     tree: Arc<Tree>,
 }
 
-impl Manager {
+impl Adapter {
     pub fn new(view: id, initial_state: TreeUpdate) -> Self {
         assert!(!view.is_null());
         Self {

--- a/platforms/mac/src/lib.rs
+++ b/platforms/mac/src/lib.rs
@@ -6,5 +6,5 @@
 mod node;
 mod util;
 
-mod manager;
-pub use manager::Manager;
+mod adapter;
+pub use adapter::Adapter;

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -18,7 +18,7 @@ use crate::{
     util::Event,
 };
 
-pub struct Manager<Source = Box<dyn FnOnce() -> TreeUpdate>>
+pub struct Adapter<Source = Box<dyn FnOnce() -> TreeUpdate>>
 where
     Source: Into<TreeUpdate>,
 {
@@ -26,7 +26,7 @@ where
     tree: LazyTransform<Source, Arc<Tree>>,
 }
 
-impl<Source: Into<TreeUpdate>> Manager<Source> {
+impl<Source: Into<TreeUpdate>> Adapter<Source> {
     pub fn new(hwnd: HWND, source: Source) -> Self {
         // It's unfortunate that we have to force UIA to initialize early;
         // it would be more optimal to let UIA lazily initialize itself
@@ -118,7 +118,7 @@ impl<Source: Into<TreeUpdate>> Manager<Source> {
     /// The optional value is an `Into<LRESULT>` rather than simply an `LRESULT`
     /// so the necessary call to UIA, which may lead to a nested `WM_GETOBJECT`
     /// message, can be done outside of any lock that the caller might hold
-    /// on the `Manager` or window state, while still abstracting away
+    /// on the `Adapter` or window state, while still abstracting away
     /// the details of that call to UIA.
     ///
     /// Callers must avoid a second deadlock scenario. The tree is lazily

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -6,8 +6,8 @@
 mod node;
 mod util;
 
-mod manager;
-pub use manager::{Manager, QueuedEvents};
+mod adapter;
+pub use adapter::{Adapter, QueuedEvents};
 
 #[cfg(test)]
 mod tests;

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -18,7 +18,7 @@ use windows::{
     },
 };
 
-use super::Manager;
+use super::Adapter;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -73,7 +73,7 @@ struct InnerWindowState {
 }
 
 struct WindowState {
-    manager: Manager,
+    adapter: Adapter,
     inner_state: Rc<RefCell<InnerWindowState>>,
 }
 
@@ -87,7 +87,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
     inner_state.is_window_focused = is_window_focused;
     let focus = inner_state.focus;
     drop(inner_state);
-    let events = window_state.manager.update_if_active(|| TreeUpdate {
+    let events = window_state.adapter.update_if_active(|| TreeUpdate {
         clear: None,
         nodes: vec![],
         tree: None,
@@ -111,7 +111,7 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
             }));
             let inner_state_for_tree_init = inner_state.clone();
             let state = Box::new(WindowState {
-                manager: Manager::new(
+                adapter: Adapter::new(
                     window,
                     Box::new(move || {
                         let mut result = initial_state;
@@ -146,7 +146,7 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
                 return unsafe { DefWindowProcW(window, message, wparam, lparam) };
             }
             let window_state = unsafe { &*window_state };
-            let result = window_state.manager.handle_wm_getobject(wparam, lparam);
+            let result = window_state.adapter.handle_wm_getobject(wparam, lparam);
             result.map_or_else(
                 || unsafe { DefWindowProcW(window, message, wparam, lparam) },
                 |result| result.into(),


### PR DESCRIPTION
I never liked "manager", but for some reason the better name escaped me while I was coding, even though I had used "adapter" in the high-level overview.