### PR TITLE
Fix new 'redundant closure' clippy warning

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -259,7 +259,7 @@ impl WeakNode {
     {
         self.tree
             .upgrade()
-            .map(|tree| tree.read().node_by_id(self.id).map(|node| f(node)))
+            .map(|tree| tree.read().node_by_id(self.id).map(f))
             .flatten()
     }
 }


### PR DESCRIPTION
Rust 1.57 introduced this warning, breaking CI. This fix is trivial enough that I'll merge it as soon as CI passes.