### PR TITLE
Derive more traits on `TreeUpdate`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1304,7 +1304,7 @@ impl Node {
 
 /// The data associated with an accessibility tree that's global to the
 /// tree and not associated with any particular node.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -1348,7 +1348,7 @@ impl Tree {
 /// The sender and receiver must be in sync; the update is only meant
 /// to bring the tree from a specific previous state into its next state.
 /// Trying to apply it to the wrong tree should immediately panic.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]


### PR DESCRIPTION
My proof-of-concept integration of AccessKit into [egui](https://github.com/emilk/egui) will be easier if `TreeUpdate` implements `Default`. I realized it will also be helpful to implement `Debug`.