### PR TITLE
Use `Vec` again for child IDs

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -890,22 +890,22 @@ pub struct Node {
     pub popup_for: Option<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub controls: Box<[NodeId]>,
+    pub controls: Vec<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub details: Box<[NodeId]>,
+    pub details: Vec<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub described_by: Box<[NodeId]>,
+    pub described_by: Vec<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub flow_to: Box<[NodeId]>,
+    pub flow_to: Vec<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub labelled_by: Box<[NodeId]>,
+    pub labelled_by: Vec<NodeId>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub radio_groups: Box<[NodeId]>,
+    pub radio_groups: Vec<NodeId>,
 
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -689,7 +689,7 @@ pub struct Node {
     pub bounds: Option<RelativeBounds>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub children: Box<[NodeId]>,
+    pub children: Vec<NodeId>,
 
     /// Unordered set of actions supported by this node.
     #[cfg_attr(feature = "serde", serde(default))]
@@ -871,7 +871,7 @@ pub struct Node {
     /// column.
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
-    pub indirect_children: Box<[NodeId]>,
+    pub indirect_children: Vec<NodeId>,
 
     // Relationships between this node and other nodes.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -43,16 +43,16 @@ mod tests {
 
     pub fn test_tree() -> Arc<crate::tree::Tree> {
         let root = Node {
-            children: Box::new([
+            children: vec![
                 PARAGRAPH_0_ID,
                 PARAGRAPH_1_IGNORED_ID,
                 PARAGRAPH_2_ID,
                 PARAGRAPH_3_IGNORED_ID,
-            ]),
+            ],
             ..Node::new(ROOT_ID, Role::RootWebArea)
         };
         let paragraph_0 = Node {
-            children: Box::new([STATIC_TEXT_0_0_IGNORED_ID]),
+            children: vec![STATIC_TEXT_0_0_IGNORED_ID],
             ..Node::new(PARAGRAPH_0_ID, Role::Paragraph)
         };
         let static_text_0_0_ignored = Node {
@@ -71,7 +71,7 @@ mod tests {
                 },
                 transform: None,
             }),
-            children: Box::new([STATIC_TEXT_1_0_ID]),
+            children: vec![STATIC_TEXT_1_0_ID],
             ignored: true,
             ..Node::new(PARAGRAPH_1_IGNORED_ID, Role::Paragraph)
         };
@@ -90,7 +90,7 @@ mod tests {
             ..Node::new(STATIC_TEXT_1_0_ID, Role::StaticText)
         };
         let paragraph_2 = Node {
-            children: Box::new([STATIC_TEXT_2_0_ID]),
+            children: vec![STATIC_TEXT_2_0_ID],
             ..Node::new(PARAGRAPH_2_ID, Role::Paragraph)
         };
         let static_text_2_0 = Node {
@@ -98,12 +98,12 @@ mod tests {
             ..Node::new(STATIC_TEXT_2_0_ID, Role::StaticText)
         };
         let paragraph_3_ignored = Node {
-            children: Box::new([
+            children: vec![
                 EMPTY_CONTAINER_3_0_IGNORED_ID,
                 LINK_3_1_IGNORED_ID,
                 BUTTON_3_2_ID,
                 EMPTY_CONTAINER_3_3_IGNORED_ID,
-            ]),
+            ],
             ignored: true,
             ..Node::new(PARAGRAPH_3_IGNORED_ID, Role::Paragraph)
         };
@@ -112,7 +112,7 @@ mod tests {
             ..Node::new(EMPTY_CONTAINER_3_0_IGNORED_ID, Role::GenericContainer)
         };
         let link_3_1_ignored = Node {
-            children: Box::new([STATIC_TEXT_3_1_0_ID]),
+            children: vec![STATIC_TEXT_3_1_0_ID],
             ignored: true,
             linked: true,
             ..Node::new(LINK_3_1_IGNORED_ID, Role::Link)

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -387,7 +387,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2, NODE_ID_3]),
+                    children: vec![NODE_ID_2, NODE_ID_3],
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node::new(NODE_ID_2, Role::Button),
@@ -432,7 +432,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2]),
+                    children: vec![NODE_ID_2],
                     ..root_node
                 },
                 Node::new(NODE_ID_2, Role::RootWebArea),
@@ -445,8 +445,8 @@ mod tests {
         tree.update_and_process_changes(second_update, |change| {
             if let super::Change::NodeUpdated { old_node, new_node } = &change {
                 if new_node.id() == NODE_ID_1
-                    && old_node.data().children == Box::new([])
-                    && new_node.data().children == Box::new([NODE_ID_2])
+                    && old_node.data().children == vec![]
+                    && new_node.data().children == vec![NODE_ID_2]
                 {
                     got_updated_root_node = true;
                     return;
@@ -478,7 +478,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2]),
+                    children: vec![NODE_ID_2],
                     ..root_node.clone()
                 },
                 Node::new(NODE_ID_2, Role::RootWebArea),
@@ -503,8 +503,8 @@ mod tests {
         tree.update_and_process_changes(second_update, |change| {
             if let super::Change::NodeUpdated { old_node, new_node } = &change {
                 if new_node.id() == NODE_ID_1
-                    && old_node.data().children == Box::new([NODE_ID_2])
-                    && new_node.data().children == Box::new([])
+                    && old_node.data().children == vec![NODE_ID_2]
+                    && new_node.data().children == vec![]
                 {
                     got_updated_root_node = true;
                     return;
@@ -530,7 +530,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2, NODE_ID_3]),
+                    children: vec![NODE_ID_2, NODE_ID_3],
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node::new(NODE_ID_2, Role::Button),
@@ -599,7 +599,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2]),
+                    children: vec![NODE_ID_2],
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node {
@@ -658,7 +658,7 @@ mod tests {
             clear: None,
             nodes: vec![
                 Node {
-                    children: Box::new([NODE_ID_2, NODE_ID_3]),
+                    children: vec![NODE_ID_2, NODE_ID_3],
                     ..Node::new(NODE_ID_1, Role::Window)
                 },
                 Node::new(NODE_ID_2, Role::Button),

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -76,7 +76,7 @@ fn make_button(id: NodeId, name: &str) -> Node {
 
 fn get_initial_state() -> TreeUpdate {
     let root = Node {
-        children: Box::new([BUTTON_1_ID, BUTTON_2_ID]),
+        children: vec![BUTTON_1_ID, BUTTON_2_ID],
         name: Some(WINDOW_TITLE.into()),
         ..Node::new(WINDOW_ID, Role::Window)
     };

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -26,7 +26,7 @@ fn make_button(id: NodeId, name: &str) -> Node {
 
 fn get_initial_state() -> TreeUpdate {
     let root = Node {
-        children: Box::new([BUTTON_1_ID, BUTTON_2_ID]),
+        children: vec![BUTTON_1_ID, BUTTON_2_ID],
         name: Some(WINDOW_TITLE.into()),
         ..Node::new(WINDOW_ID, Role::Window)
     };


### PR DESCRIPTION
While working on my proof-of-concept integration with egui, I discovered that using a boxed slice for child IDs would make it inconvenient and inefficient to build up a tree as the immediate-mode GUI is being rendered. So I've gone back to using `Vec`. This does mean a small increase in the size of each `Node`, but I'll accept that tradeoff. There are other things I can do to decrease the size of each `Node`, when it's actually important to do so.