### PR TITLE
Refactor node transform and bounds using the kurbo crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "accesskit"
 version = "0.1.0"
 dependencies = [
  "enumset",
+ "kurbo",
  "schemars",
  "serde",
 ]
@@ -334,6 +335,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "kurbo"
+version = "0.8.2"
+source = "git+https://github.com/linebender/kurbo#c229a914d303c5989c9e6b1d766def2df27a8185"
+dependencies = [
+ "arrayvec",
+ "schemars",
+ "serde",
+]
 
 [[package]]
 name = "lazy-init"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,8 +338,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "kurbo"
-version = "0.8.2"
-source = "git+https://github.com/linebender/kurbo#c229a914d303c5989c9e6b1d766def2df27a8185"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449"
 dependencies = [
  "arrayvec",
  "schemars",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Matt Campbell <mattcampbell@pobox.com>"]
 edition = "2018"
 
 [dependencies]
-enumset = { version = "1.0.8", features = ["serde"] }
-schemars = { version = "0.8.7", features = ["enumset"], optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+enumset = "1.0.8"
+kurbo = { git = "https://github.com/linebender/kurbo" }
+schemars_lib = { package = "schemars", version = "0.8.7", features = ["enumset"], optional = true }
+serde_lib = { package = "serde", version = "1.0", features = ["derive"], optional = true }
+
+[features]
+schemars = ["schemars_lib", "kurbo/schemars"]
+serde = ["serde_lib", "enumset/serde", "kurbo/serde"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 enumset = "1.0.8"
-kurbo = { git = "https://github.com/linebender/kurbo" }
+kurbo = "0.8.3"
 schemars_lib = { package = "schemars", version = "0.8.7", features = ["enumset"], optional = true }
 serde_lib = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -676,8 +676,7 @@ pub struct Node {
     /// in their [`transform`] field, implies that the [`bounds`] field
     /// of most nodes should be in the coordinate space of the nearest ancestor
     /// with a non-`None` [`Transform`] field, or if there is no such ancestor,
-    /// the tree's container (e.g. window). This field should be `None`
-    /// if this node is a transparent container.
+    /// the tree's container (e.g. window).
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub bounds: Option<Rect>,
     #[cfg_attr(feature = "serde", serde(default))]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,10 +9,16 @@
 // found in the LICENSE.chromium file.
 
 use enumset::{EnumSet, EnumSetType};
+pub use kurbo;
+use kurbo::{Affine, Point, Rect};
 #[cfg(feature = "schemars")]
-use schemars::JsonSchema;
+use schemars_lib as schemars;
+#[cfg(feature = "schemars")]
+use schemars_lib::JsonSchema;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde_lib as serde;
+#[cfg(feature = "serde")]
+use serde_lib::{Deserialize, Serialize};
 use std::ops::Range;
 
 /// The type of an accessibility node.
@@ -28,6 +34,7 @@ use std::ops::Range;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum Role {
     Unknown,
@@ -240,6 +247,7 @@ pub enum Role {
 #[derive(EnumSetType, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", enumset(serialize_as_list))]
 pub enum Action {
@@ -292,8 +300,9 @@ pub enum Action {
     /// [`ActionData::ScrollTargetRect`].
     ScrollIntoView,
 
-    /// Scroll the given object to a specified point on the screen.
-    /// Requires [`ActionRequest::data`] to be set to [`ActionData::ScrollToPoint`].
+    /// Scroll the given object to a specified point in the tree's container
+    /// (e.g. window).  /// Requires [`ActionRequest::data`] to be set to
+    /// [`ActionData::ScrollToPoint`].
     ScrollToPoint,
 
     /// Requires [`ActionRequest::data`] to be set to [`ActionData::ScrollOffset`].
@@ -318,6 +327,7 @@ pub enum Action {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum Orientation {
     /// E.g. most toolbars and separators.
@@ -329,6 +339,7 @@ pub enum Orientation {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum NameFrom {
     /// E.g. `aria-label`.
@@ -350,6 +361,7 @@ pub enum NameFrom {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum DescriptionFrom {
     AriaDescription,
@@ -370,6 +382,7 @@ pub enum DescriptionFrom {
 #[derive(EnumSetType, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "serde", enumset(serialize_as_list))]
 pub enum DropEffect {
@@ -383,6 +396,7 @@ pub enum DropEffect {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum MarkerType {
     SpellingError,
@@ -395,6 +409,7 @@ pub enum MarkerType {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum TextDirection {
     LeftToRight,
@@ -408,6 +423,7 @@ pub enum TextDirection {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum InvalidState {
     False,
@@ -418,6 +434,7 @@ pub enum InvalidState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum CheckedState {
     False,
@@ -433,6 +450,7 @@ pub enum CheckedState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum DefaultActionVerb {
     Activate,
@@ -453,6 +471,7 @@ pub enum DefaultActionVerb {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum SortDirection {
     Unsorted,
@@ -464,6 +483,7 @@ pub enum SortDirection {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum AriaCurrent {
     False,
@@ -478,6 +498,7 @@ pub enum AriaCurrent {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum HasPopup {
     True,
@@ -491,6 +512,7 @@ pub enum HasPopup {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum ListStyle {
     Circle,
@@ -505,6 +527,7 @@ pub enum ListStyle {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum TextAlign {
     Left,
@@ -516,6 +539,7 @@ pub enum TextAlign {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum VerticalOffset {
     Subscript,
@@ -525,6 +549,7 @@ pub enum VerticalOffset {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum TextDecoration {
     Solid,
@@ -537,6 +562,7 @@ pub enum TextDecoration {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum StringEncoding {
     Utf8,
@@ -550,6 +576,7 @@ pub type NodeIdContent = std::num::NonZeroU64;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 pub struct NodeId(pub NodeIdContent);
 
 /// The globally unique ID of a tree. The format of this ID
@@ -557,78 +584,14 @@ pub struct NodeId(pub NodeIdContent);
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 pub struct TreeId(pub Box<str>);
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Point {
-    pub x: f32,
-    pub y: f32,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Rect {
-    pub left: f32,
-    pub top: f32,
-    pub width: f32,
-    pub height: f32,
-}
-
-/// 4x4 transformation matrix.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Transform {
-    /// Column major order.
-    pub matrix: [f32; 16],
-}
-
-/// The relative bounding box of a [`Node`].
-///
-/// This is an efficient, compact, serializable representation of a node's
-/// bounding box that requires minimal changes to the tree when layers are
-/// moved or scrolled. Computing the absolute bounding box of a node requires
-/// walking up the tree and applying node offsets and transforms until reaching
-/// the top.
-///
-/// If [`RelativeBounds::offset_container`] is present, the bounds
-/// are relative to the node with that ID.
-///
-/// Otherwise, for a node other than the root, the bounds are relative to
-/// the root of the tree, and for the root of a tree, the bounds are relative
-/// to its immediate containing node.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct RelativeBounds {
-    /// The ID of an ancestor node in the same Tree that this object's
-    /// bounding box is relative to.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub offset_container: Option<NodeId>,
-    /// The relative bounding box of this node.
-    pub rect: Rect,
-    /// An additional transform to apply to position this object and its subtree.
-    /// This is rarely used and should be omitted if not needed, i.e. if
-    /// the transform would be the identity matrix. It's rare enough
-    // that we box it to reduce memory usage.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub transform: Option<Box<Transform>>,
-}
 
 /// A marker spanning a range within text.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TextMarker {
@@ -643,6 +606,7 @@ pub struct TextMarker {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct CustomAction {
@@ -667,6 +631,7 @@ fn is_empty<T>(slice: &[T]) -> bool {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TextSelection {
@@ -680,13 +645,38 @@ pub struct TextSelection {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Node {
     pub id: NodeId,
     pub role: Role,
+    /// An affine transform to apply to any coordinates within this node
+    /// and its descendants, including the [`bounds`] field. Coordinates
+    /// to which the transforms of this node and its ancestors have not
+    /// been applied, such as the coordinates in the [`bounds`] field,
+    /// are referred to as node-local. This value, if present, is implicitly
+    /// combined with the transforms of the node's ancestors. This field
+    /// should be `None` if it would be set to the identity transform.
+    /// This field should be `None` for most nodes.
+    ///
+    /// AccessKit is not opinionated about the resolution dependence
+    /// or y direction of any coordinates; these requirements are
+    /// ultimately determined by the platform accessibility API.
+    /// This implies that for a tree generated by cross-platform code,
+    /// a platform-specific layer between that cross-platform code
+    /// and the AccessKit platform adapter must add an appropriate transform to
+    /// the root node. However, AccessKit expects the final transformed
+    /// coordinates to be relative to the origin of the tree's container
+    /// (e.g. window).
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub bounds: Option<RelativeBounds>,
+    pub transform: Option<Box<Affine>>,
+    /// The relative bounding box of this node. The combined transform
+    /// of this node and its ancestors is implicitly applied to the value
+    /// of this field. This field should be omitted if and only if the node is
+    /// a transparent container.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub bounds: Option<Rect>,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_empty"))]
     pub children: Vec<NodeId>,
@@ -1161,6 +1151,7 @@ impl Node {
         Node {
             id,
             role,
+            transform: None,
             bounds: None,
             children: Default::default(),
             actions: EnumSet::new(),
@@ -1307,6 +1298,7 @@ impl Node {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Tree {
@@ -1351,6 +1343,7 @@ impl Tree {
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TreeUpdate {
@@ -1413,14 +1406,16 @@ impl<T: FnOnce() -> TreeUpdate> From<T> for TreeUpdate {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub enum ActionData {
     CustomAction(i32),
     Value(Box<str>),
-    /// Optional target rectangle for [`Action::ScrollIntoView`], in node-local
-    /// coordinates.
+    /// Optional target rectangle for [`Action::ScrollIntoView`], in
+    /// node-local coordinates.
     ScrollTargetRect(Rect),
-    /// Target for [`Action::ScrollToPoint`], in screen coordinates.
+    /// Target for [`Action::ScrollToPoint`], in platform-native coordinates
+    /// relative to the origin of the tree's container (e.g. window).
     ScrollToPoint(Point),
     /// Target for [`Action::SetScrollOffset`], in node-local coordinates.
     SetScrollOffset(Point),
@@ -1430,6 +1425,7 @@ pub enum ActionData {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ActionRequest {

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -19,9 +19,8 @@ pub use iterators::{
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{
-        Node, NodeId, Rect, RelativeBounds, Role, StringEncoding, Tree, TreeId, TreeUpdate,
-    };
+    use accesskit::kurbo::{Affine, Rect, Vec2};
+    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate};
     use std::num::NonZeroU64;
     use std::sync::Arc;
 
@@ -61,30 +60,23 @@ mod tests {
             ..Node::new(STATIC_TEXT_0_0_IGNORED_ID, Role::StaticText)
         };
         let paragraph_1_ignored = Node {
-            bounds: Some(RelativeBounds {
-                offset_container: None,
-                rect: Rect {
-                    left: 10.0f32,
-                    top: 40.0f32,
-                    width: 800.0f32,
-                    height: 40.0f32,
-                },
-                transform: None,
+            transform: Some(Box::new(Affine::translate(Vec2::new(10.0, 40.0)))),
+            bounds: Some(Rect {
+                x0: 0.0,
+                y0: 0.0,
+                x1: 800.0,
+                y1: 40.0,
             }),
             children: vec![STATIC_TEXT_1_0_ID],
             ignored: true,
             ..Node::new(PARAGRAPH_1_IGNORED_ID, Role::Paragraph)
         };
         let static_text_1_0 = Node {
-            bounds: Some(RelativeBounds {
-                offset_container: Some(PARAGRAPH_1_IGNORED_ID),
-                rect: Rect {
-                    left: 10.0f32,
-                    top: 10.0f32,
-                    width: 80.0f32,
-                    height: 20.0f32,
-                },
-                transform: None,
+            bounds: Some(Rect {
+                x0: 10.0,
+                y0: 10.0,
+                x1: 90.0,
+                y1: 30.0,
             }),
             name: Some("static_text_1_0".into()),
             ..Node::new(STATIC_TEXT_1_0_ID, Role::StaticText)

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -189,9 +189,9 @@ impl<'a> Node<'a> {
                 .map_or(Affine::IDENTITY, |parent| parent.transform())
     }
 
-    /// Returns the node's transformed bounds relative to the tree's container
-    /// (e.g. window).
-    pub fn bounds(&self) -> Option<Rect> {
+    /// Returns the node's transformed bounding box relative to the tree's
+    /// container (e.g. window).
+    pub fn bounding_box(&self) -> Option<Rect> {
         self.data()
             .bounds
             .as_ref()
@@ -481,9 +481,9 @@ mod tests {
     }
 
     #[test]
-    fn bounds() {
+    fn bounding_box() {
         let tree = test_tree();
-        assert!(tree.read().node_by_id(ROOT_ID).unwrap().bounds().is_none());
+        assert!(tree.read().node_by_id(ROOT_ID).unwrap().bounding_box().is_none());
         assert_eq!(
             Some(Rect {
                 x0: 10.0,
@@ -494,7 +494,7 @@ mod tests {
             tree.read()
                 .node_by_id(PARAGRAPH_1_IGNORED_ID)
                 .unwrap()
-                .bounds()
+                .bounding_box()
         );
         assert_eq!(
             Some(Rect {
@@ -503,7 +503,7 @@ mod tests {
                 x1: 100.0,
                 y1: 70.0,
             }),
-            tree.read().node_by_id(STATIC_TEXT_1_0_ID).unwrap().bounds()
+            tree.read().node_by_id(STATIC_TEXT_1_0_ID).unwrap().bounding_box()
         );
     }
 

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -483,7 +483,12 @@ mod tests {
     #[test]
     fn bounding_box() {
         let tree = test_tree();
-        assert!(tree.read().node_by_id(ROOT_ID).unwrap().bounding_box().is_none());
+        assert!(tree
+            .read()
+            .node_by_id(ROOT_ID)
+            .unwrap()
+            .bounding_box()
+            .is_none());
         assert_eq!(
             Some(Rect {
                 x0: 10.0,
@@ -503,7 +508,10 @@ mod tests {
                 x1: 100.0,
                 y1: 70.0,
             }),
-            tree.read().node_by_id(STATIC_TEXT_1_0_ID).unwrap().bounding_box()
+            tree.read()
+                .node_by_id(STATIC_TEXT_1_0_ID)
+                .unwrap()
+                .bounding_box()
         );
     }
 

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -180,13 +180,13 @@ impl<'a> Node<'a> {
     /// Returns the combined affine transform of this node and its ancestors,
     /// up to and including the root of this node's tree.
     pub fn transform(&self) -> Affine {
-        self.data()
-            .transform
-            .as_ref()
-            .map_or(Affine::IDENTITY, |t| **t)
+        self.parent()
+            .map_or(Affine::IDENTITY, |parent| parent.transform())
             * self
-                .parent()
-                .map_or(Affine::IDENTITY, |parent| parent.transform())
+                .data()
+                .transform
+                .as_ref()
+                .map_or(Affine::IDENTITY, |t| **t)
     }
 
     /// Returns the node's transformed bounding box relative to the tree's

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -177,16 +177,21 @@ impl<'a> Node<'a> {
         format!("{}:{}", self.tree_reader.id().0, self.id().0)
     }
 
+    /// Returns the transform defined directly on this node, or the identity
+    /// transform, without taking into account transforms on ancestors.
+    pub fn direct_transform(&self) -> Affine {
+        self.data()
+            .transform
+            .as_ref()
+            .map_or(Affine::IDENTITY, |t| **t)
+    }
+
     /// Returns the combined affine transform of this node and its ancestors,
     /// up to and including the root of this node's tree.
     pub fn transform(&self) -> Affine {
         self.parent()
             .map_or(Affine::IDENTITY, |parent| parent.transform())
-            * self
-                .data()
-                .transform
-                .as_ref()
-                .map_or(Affine::IDENTITY, |t| **t)
+            * self.direct_transform()
     }
 
     /// Returns the node's transformed bounding box relative to the tree's

--- a/platforms/mac/src/node.rs
+++ b/platforms/mac/src/node.rs
@@ -70,18 +70,14 @@ fn get_screen_bounds(state: &State, node: &Node) -> Option<NSRect> {
     }
 
     node.bounds().map(|rect| {
-        let root_bounds = node.tree_reader.root().bounds().unwrap();
-        let root_bottom = root_bounds.top + root_bounds.height;
-        let bottom = rect.top + rect.height;
-        let y = root_bottom - bottom;
         let rect = NSRect {
             origin: NSPoint {
-                x: rect.left as f64,
-                y: y as f64,
+                x: rect.x0,
+                y: rect.y0,
             },
             size: NSSize {
-                width: rect.width as f64,
-                height: rect.height as f64,
+                width: rect.width(),
+                height: rect.height(),
             },
         };
         let rect: NSRect = unsafe { msg_send![*view, convertRect:rect toView:nil] };

--- a/platforms/mac/src/node.rs
+++ b/platforms/mac/src/node.rs
@@ -63,13 +63,13 @@ fn get_identifier(_state: &State, node: &Node) -> id {
     make_nsstring(&id)
 }
 
-fn get_screen_bounds(state: &State, node: &Node) -> Option<NSRect> {
+fn get_screen_bounding_box(state: &State, node: &Node) -> Option<NSRect> {
     let view = state.view.load();
     if view.is_null() {
         return None;
     }
 
-    node.bounds().map(|rect| {
+    node.bounding_box().map(|rect| {
         let rect = NSRect {
             origin: NSPoint {
                 x: rect.x0,
@@ -87,7 +87,7 @@ fn get_screen_bounds(state: &State, node: &Node) -> Option<NSRect> {
 }
 
 fn get_position(state: &State, node: &Node) -> id {
-    if let Some(rect) = get_screen_bounds(state, node) {
+    if let Some(rect) = get_screen_bounding_box(state, node) {
         unsafe { NSValue::valueWithPoint(nil, rect.origin) }
     } else {
         nil
@@ -95,7 +95,7 @@ fn get_position(state: &State, node: &Node) -> id {
 }
 
 fn get_size(state: &State, node: &Node) -> id {
-    if let Some(rect) = get_screen_bounds(state, node) {
+    if let Some(rect) = get_screen_bounding_box(state, node) {
         unsafe { NSValue::valueWithSize(nil, rect.size) }
     } else {
         nil

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -345,7 +345,7 @@ impl ResolvedPlatformNode<'_> {
     }
 
     fn bounding_rectangle(&self) -> UiaRect {
-        self.node.bounds().map_or(UiaRect::default(), |rect| {
+        self.node.bounding_box().map_or(UiaRect::default(), |rect| {
             let mut client_top_left = POINT::default();
             unsafe { ClientToScreen(self.hwnd, &mut client_top_left) }.unwrap();
             UiaRect {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -346,17 +346,14 @@ impl ResolvedPlatformNode<'_> {
 
     fn bounding_rectangle(&self) -> UiaRect {
         self.node.bounds().map_or(UiaRect::default(), |rect| {
-            let mut result = UiaRect {
-                left: rect.left.into(),
-                top: rect.top.into(),
-                width: rect.width.into(),
-                height: rect.height.into(),
-            };
             let mut client_top_left = POINT::default();
             unsafe { ClientToScreen(self.hwnd, &mut client_top_left) }.unwrap();
-            result.left += f64::from(client_top_left.x);
-            result.top += f64::from(client_top_left.y);
-            result
+            UiaRect {
+                left: rect.x0 + f64::from(client_top_left.x),
+                top: rect.y0 + f64::from(client_top_left.y),
+                width: rect.width(),
+                height: rect.height(),
+            }
         })
     }
 


### PR DESCRIPTION
Now we actually implement transforms, which are now decoupled from the bounding rectangle. Now that we support transforms, the old `offset_container` field of `RelativeBounds` is redundant.

We now use [kurbo](https://github.com/linebender/kurbo) rather than defining our own structures for points, rectangles, and transforms. This reduces the duplicated effort in the Rust graphics ecosystem, and gives us useful functions for manipulating these things.

I'm hoping that an updated version of kurbo with my contributed schemars support will be published to crates.io before I merge this PR.