### PR TITLE
Handle action requests, starting with focus

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1432,7 +1432,22 @@ pub enum ActionData {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct ActionRequest {
-    action: Action,
-    target: NodeId,
-    data: Option<ActionData>,
+    pub action: Action,
+    pub target: NodeId,
+    pub data: Option<ActionData>,
+}
+
+/// Handles requests from assistive technologies or other clients.
+pub trait ActionHandler: Send + Sync {
+    /// Perform the requested action. If the requested action is not supported,
+    /// this method must do nothing.
+    ///
+    /// This method may be called on any thread. In particular, on platforms
+    /// with a designated UI thread, this method may or may not be called
+    /// on that thread. Implementations must correctly handle both cases.
+    ///
+    /// This method may queue the request and handle it asynchronously.
+    /// This behavior is preferred over blocking, e.g. when dispatching
+    /// the request to another thread.
+    fn action(&self, request: ActionRequest);
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1449,5 +1449,5 @@ pub trait ActionHandler: Send + Sync {
     /// This method may queue the request and handle it asynchronously.
     /// This behavior is preferred over blocking, e.g. when dispatching
     /// the request to another thread.
-    fn action(&self, request: ActionRequest);
+    fn do_action(&self, request: ActionRequest);
 }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -45,7 +45,7 @@ mod tests {
     pub struct NullActionHandler;
 
     impl ActionHandler for NullActionHandler {
-        fn action(&self, _request: ActionRequest) {}
+        fn do_action(&self, _request: ActionRequest) {}
     }
 
     pub fn test_tree() -> Arc<crate::tree::Tree> {

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -42,7 +42,7 @@ mod tests {
     pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId =
         NodeId(unsafe { NonZeroU64::new_unchecked(13) });
 
-    pub struct NullActionHandler();
+    pub struct NullActionHandler;
 
     impl ActionHandler for NullActionHandler {
         fn action(&self, _request: ActionRequest) {}
@@ -153,6 +153,6 @@ mod tests {
             )),
             focus: None,
         };
-        crate::tree::Tree::new(initial_update, Box::new(NullActionHandler()))
+        crate::tree::Tree::new(initial_update, Box::new(NullActionHandler {}))
     }
 }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -20,7 +20,9 @@ pub use iterators::{
 #[cfg(test)]
 mod tests {
     use accesskit::kurbo::{Affine, Rect, Vec2};
-    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate};
+    use accesskit::{
+        ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate,
+    };
     use std::num::NonZeroU64;
     use std::sync::Arc;
 
@@ -39,6 +41,12 @@ mod tests {
     pub const BUTTON_3_2_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(12) });
     pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId =
         NodeId(unsafe { NonZeroU64::new_unchecked(13) });
+
+    pub struct NullActionHandler();
+
+    impl ActionHandler for NullActionHandler {
+        fn action(&self, _request: ActionRequest) {}
+    }
 
     pub fn test_tree() -> Arc<crate::tree::Tree> {
         let root = Node {
@@ -145,6 +153,6 @@ mod tests {
             )),
             focus: None,
         };
-        crate::tree::Tree::new(initial_update)
+        crate::tree::Tree::new(initial_update, Box::new(NullActionHandler()))
     }
 }

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -7,7 +7,7 @@ use std::iter::FusedIterator;
 use std::sync::{Arc, Weak};
 
 use accesskit::kurbo::{Affine, Rect};
-use accesskit::{CheckedState, NodeId, Role};
+use accesskit::{Action, ActionRequest, CheckedState, NodeId, Role};
 
 use crate::iterators::{
     FollowingSiblings, FollowingUnignoredSiblings, PrecedingSiblings, PrecedingUnignoredSiblings,
@@ -201,6 +201,14 @@ impl<'a> Node<'a> {
             .bounds
             .as_ref()
             .map(|rect| self.transform().transform_rect_bbox(*rect))
+    }
+
+    pub fn set_focus(&self) {
+        self.tree_reader.tree.action_handler.action(ActionRequest {
+            action: Action::Focus,
+            target: self.id(),
+            data: None,
+        })
     }
 
     // Convenience getters
@@ -538,7 +546,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update);
+        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
         assert_eq!(None, tree.read().node_by_id(NODE_ID_2).unwrap().name());
     }
 
@@ -580,7 +588,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update);
+        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
         assert_eq!(
             Some([LABEL_1, LABEL_2].join(" ")),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -546,7 +546,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
         assert_eq!(None, tree.read().node_by_id(NODE_ID_2).unwrap().name());
     }
 
@@ -588,7 +588,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
         assert_eq!(
             Some([LABEL_1, LABEL_2].join(" ")),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -204,11 +204,14 @@ impl<'a> Node<'a> {
     }
 
     pub fn set_focus(&self) {
-        self.tree_reader.tree.action_handler.do_action(ActionRequest {
-            action: Action::Focus,
-            target: self.id(),
-            data: None,
-        })
+        self.tree_reader
+            .tree
+            .action_handler
+            .do_action(ActionRequest {
+                action: Action::Focus,
+                target: self.id(),
+                data: None,
+            })
     }
 
     // Convenience getters

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -204,7 +204,7 @@ impl<'a> Node<'a> {
     }
 
     pub fn set_focus(&self) {
-        self.tree_reader.tree.action_handler.action(ActionRequest {
+        self.tree_reader.tree.action_handler.do_action(ActionRequest {
             action: Action::Focus,
             target: self.id(),
             data: None,

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{NodeId, TreeId, TreeUpdate};
+use accesskit::{ActionHandler, NodeId, TreeId, TreeUpdate};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -247,10 +247,11 @@ pub enum Change<'a> {
 
 pub struct Tree {
     state: RwLock<State>,
+    pub(crate) action_handler: Box<dyn ActionHandler>,
 }
 
 impl Tree {
-    pub fn new(mut initial_state: TreeUpdate) -> Arc<Self> {
+    pub fn new(mut initial_state: TreeUpdate, action_handler: Box<dyn ActionHandler>) -> Arc<Self> {
         assert!(initial_state.clear.is_none());
 
         let mut state = State {
@@ -261,6 +262,7 @@ impl Tree {
         state.update(initial_state, None);
         Arc::new(Self {
             state: RwLock::new(state),
+            action_handler,
         })
     }
 
@@ -357,6 +359,8 @@ mod tests {
     use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate};
     use std::num::NonZeroU64;
 
+    use crate::tests::NullActionHandler;
+
     const TREE_ID: &str = "test_tree";
     const NODE_ID_1: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(1) });
     const NODE_ID_2: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(2) });
@@ -374,7 +378,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update);
+        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
         assert_eq!(&TreeId(TREE_ID.into()), tree.read().id());
         assert_eq!(NODE_ID_1, tree.read().root().id());
         assert_eq!(Role::Window, tree.read().root().role());
@@ -400,7 +404,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update);
+        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
         let reader = tree.read();
         assert_eq!(
             NODE_ID_1,
@@ -426,7 +430,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update);
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
         assert_eq!(0, tree.read().root().children().count());
         let second_update = TreeUpdate {
             clear: None,
@@ -490,7 +494,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update);
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
         assert_eq!(1, tree.read().root().children().count());
         let second_update = TreeUpdate {
             clear: None,
@@ -543,7 +547,7 @@ mod tests {
             )),
             focus: Some(NODE_ID_2),
         };
-        let tree = super::Tree::new(first_update);
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
         assert!(tree.read().node_by_id(NODE_ID_2).unwrap().is_focused());
         let second_update = TreeUpdate {
             clear: None,
@@ -614,7 +618,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update);
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
         assert_eq!(
             Some("foo".into()),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()
@@ -671,7 +675,7 @@ mod tests {
             )),
             focus: Some(NODE_ID_2),
         };
-        let tree = super::Tree::new(update.clone());
+        let tree = super::Tree::new(update.clone(), Box::new(NullActionHandler()));
         tree.update_and_process_changes(update, |_| {
             panic!("expected no changes");
         });

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -378,7 +378,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
         assert_eq!(&TreeId(TREE_ID.into()), tree.read().id());
         assert_eq!(NODE_ID_1, tree.read().root().id());
         assert_eq!(Role::Window, tree.read().root().role());
@@ -404,7 +404,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
         let reader = tree.read();
         assert_eq!(
             NODE_ID_1,
@@ -430,7 +430,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert_eq!(0, tree.read().root().children().count());
         let second_update = TreeUpdate {
             clear: None,
@@ -494,7 +494,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert_eq!(1, tree.read().root().children().count());
         let second_update = TreeUpdate {
             clear: None,
@@ -547,7 +547,7 @@ mod tests {
             )),
             focus: Some(NODE_ID_2),
         };
-        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert!(tree.read().node_by_id(NODE_ID_2).unwrap().is_focused());
         let second_update = TreeUpdate {
             clear: None,
@@ -618,7 +618,7 @@ mod tests {
             )),
             focus: None,
         };
-        let tree = super::Tree::new(first_update, Box::new(NullActionHandler()));
+        let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert_eq!(
             Some("foo".into()),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()
@@ -675,7 +675,7 @@ mod tests {
             )),
             focus: Some(NODE_ID_2),
         };
-        let tree = super::Tree::new(update.clone(), Box::new(NullActionHandler()));
+        let tree = super::Tree::new(update.clone(), Box::new(NullActionHandler {}));
         tree.update_and_process_changes(update, |_| {
             panic!("expected no changes");
         });

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -135,7 +135,7 @@ pub struct SimpleActionHandler {
 }
 
 impl ActionHandler for SimpleActionHandler {
-    fn action(&self, request: ActionRequest) {
+    fn do_action(&self, request: ActionRequest) {
         if request.action == Action::Focus {
             unsafe {
                 PostMessageW(

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -358,7 +358,7 @@ impl ResolvedPlatformNode<'_> {
     }
 
     fn set_focus(&self) {
-        // TODO: request action (#53)
+        self.node.set_focus()
     }
 
     fn hit_test(&self, _x: f64, _y: f64) -> Option<ResolvedPlatformNode> {

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -46,7 +46,7 @@ fn get_initial_state() -> TreeUpdate {
     }
 }
 
-pub struct NullActionHandler();
+pub struct NullActionHandler;
 
 impl ActionHandler for NullActionHandler {
     fn action(&self, _request: ActionRequest) {}
@@ -60,7 +60,7 @@ where
         WINDOW_TITLE,
         get_initial_state(),
         BUTTON_1_ID,
-        Box::new(NullActionHandler()),
+        Box::new(NullActionHandler {}),
         f,
     )
 }

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -49,7 +49,7 @@ fn get_initial_state() -> TreeUpdate {
 pub struct NullActionHandler;
 
 impl ActionHandler for NullActionHandler {
-    fn action(&self, _request: ActionRequest) {}
+    fn do_action(&self, _request: ActionRequest) {}
 }
 
 fn scope<F>(f: F) -> Result<()>


### PR DESCRIPTION
This defines a trait that providers implement to handle actions requested by assistive technologies, uses that trait to implement UIA's `SetFocus` method, and implements the trait in the Windows example.