### PR TITLE
Basic hit testing

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -726,6 +726,8 @@ pub struct Node {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
     pub hovered: bool,
     /// Skip over this node in the accessibility tree, but keep its subtree.
+    /// This flag also indicates that this node, but not its descendants,
+    /// should be skipped when hit testing.
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
     pub ignored: bool,

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -2,6 +2,7 @@
 
 use std::{cell::RefCell, convert::TryInto, mem::drop, num::NonZeroU64, rc::Rc};
 
+use accesskit::kurbo::Rect;
 use accesskit::{
     Action, ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeId,
     TreeUpdate,
@@ -69,10 +70,31 @@ const BUTTON_1_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(2) });
 const BUTTON_2_ID: NodeId = NodeId(unsafe { NonZeroU64::new_unchecked(3) });
 const INITIAL_FOCUS: NodeId = BUTTON_1_ID;
 
+const BUTTON_1_RECT: Rect = Rect {
+    x0: 20.0,
+    y0: 20.0,
+    x1: 100.0,
+    y1: 60.0,
+};
+
+const BUTTON_2_RECT: Rect = Rect {
+    x0: 20.0,
+    y0: 60.0,
+    x1: 100.0,
+    y1: 100.0,
+};
+
 const SET_FOCUS_MSG: u32 = WM_USER;
 
 fn make_button(id: NodeId, name: &str) -> Node {
+    let rect = match id {
+        BUTTON_1_ID => BUTTON_1_RECT,
+        BUTTON_2_ID => BUTTON_2_RECT,
+        _ => unreachable!(),
+    };
+
     Node {
+        bounds: Some(rect),
         name: Some(name.into()),
         focusable: true,
         ..Node::new(id, Role::Button)


### PR DESCRIPTION
I decided to have AccessKit itself do hit testing, rather than calling back into the application.

This implementation doesn't handle all of the possible complexities of doing hit testing correctly. Known problems include transparency, cases where the z-order is different from the logical order of the children, and cases where children are clipped (e.g. a scrollable area). But I'm optimistic that we can iterate toward correct solutions to these problems. Non-rectangular bounding shapes could also be a problem, but that's quite literally a corner case. Notably, one case that this implementation already handles well is transformation of a bounding rectangle into a non-rectangular shape. Hit testing works correctly in this case because we apply the inverse transform to the point being tested.

I'm aware that with this decision, I'm perpetuating one of the known problems with Chromium's push-based accessibility architecture, and I'm not implementing Chromium's mitigation. Chromium's accessibility implementation does its own hit testing in the browser process in order to satisfy the synchronous request from the platform accessibility API, but then it also sends an asynchronous hit test request to Blink, and uses the result of that request for future hit tests in the same area. But IMO, while that mitigation might help when moving the mouse, it's a net negative for touch exploration. When exploring by touch, a user will do a single tap in a given location on the screen, then observe the screen reader's response. It seems to me that it would be confusing and unsettling to a blind user if some taps yield accurate information and some don't. So we should do our best to make hit testing work correctly, and when it's inaccurate, it should be consistently inaccurate, so the user can have a consistent mental model.

Another option, which I experimented with last week, would be for AccessKit to make a synchronous callback into the application to request the node at a given point. I ran into problems with this solution as soon as I tried to integrate it into winit. The first issue is determining which thread should run the callback. On Windows, I've decided that, for a variety of reasons, the UIA implementation should not be bound to the UI thread. But depending on the assistive technology being used, UIA methods may in fact be run on the UI thread. On Linux, my understanding is that @DataTriny's AT-SPI implementation doesn't handle incoming method calls on the UI thread, and forcing it to do so would significantly complicate integration into various GUI toolkits. On Mac, iOS, Android, and the web platform, accessibility methods will always run on the UI thread. So the only thing we could say at a cross-platform level is that this synchronous callback may or may not run on the UI thread, and implementations must be prepared to handle both cases without deadlock or reentrancy. But many GUI toolkits are bound to the UI thread, so when (and only when) the callback doesn't run on the UI thread, there has to be some code that dispatches the request to the UI thread and waits for the result. That's really tricky, and I didn't come up with a good way to handle it in winit. Besides the threading issue, there's also the fact that a synchronous callback, that has to run immediately and return a result, doesn't fit neatly into the normal flow of event handling in many GUI architectures.  I couldn't figure out a good way to fit this into the design of winit without foisting the full complexity of the threading problem onto the application.

So at this point I stopped to reconsider whether the callback solution was really what I wanted, and particularly whether it was a good fit for the concepts underlying AccessKit's design. And that's when I recalled one of my earliest inspirations for advocating the push-based approach to accessibility, possibly even pre-dating my exposure to the Chromium implementation. Rich Hickey, the designer of Clojure, has given many influential talks, and a recurring theme in the earlier talks is the distinction between perception and action, particularly in concurrent systems. His most in-depth discussion of this topic is in the talk [Are We There Yet? (transcript)](https://github.com/matthiasn/talk-transcripts/blob/master/Hickey_Rich/AreWeThereYet-mostly-text.md). To find the most relevant part of that talk, search that transcript for "0:29:38". When I was first exposed to his position, that perception should happen without coordination using immutable snapshots, it occurred to me that the way we do accessibility is very broken in this regard. After all, sighted people already perceive the GUI in the way that Rich describes, and the point of a screen reader is to make a GUI that's designed to be perceived in that way accessible. (Even with other assistive technologies, the AT itself needs to perceive the UI in order to help the user.) Furthermore, GUI toolkits already tacitly assume this model of perception, since they're designed to be seen, with accessibility generally being an afterthought. This is why I believe that AccessKit's push-based approach to accessibility will make it much easier for more GUIs to be made accessible.

My conclusion is that in an accessibility context, hit testing is a form of perception, not action, and should be treated as such. An AT needs to know what is at a particular point on the screen, usually because the user asked for that information (e.g. by tapping or moving the mouse), but possibly because the AT needs that information to implement some heuristic. It's true that this information may be used to perform some action, but that's really no different than any other information the AT may gather from the accessibility tree. And really, if AccessKit can't accurately determine what is at a particular point on the screen based solely on the accessibility tree, then that's an indication that the accessibility tree is somehow inaccurate, and that inaccuracy could be limiting the power of ATs in other ways as well. So to advance the state of the art in accessibility, we should fix the inaccuracy rather than compromising the conceptual integrity of AccessKit to work around the inaccuracy.

Also, I envision some future applications of AccessKit where calling back into the application might not be an option at all. I'm thinking in particular about enabling accessible screenshots, screencast videos, and live screen sharing. A blind user should be able to explore these by touch just as they can explore an application they're actually running. Note that these cases are also very analogous to the baseball game example in Rich Hickey's talk.

So that's my long-winded rationale for my approach to hit testing. Maybe I should publish this in some form more enduring than a PR comment.