### PR TITLE
Support value and range value patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "crossbeam-utils",
  "lazy-init",
  "lazy_static",
+ "libc",
  "parking_lot",
  "paste",
  "scopeguard",
@@ -361,9 +362,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "lock_api"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -263,9 +263,9 @@ pub enum Action {
     /// Requires [`ActionRequest::data`] to be set to [`ActionData::CustomAction`].
     CustomAction,
 
-    /// Decrement a slider or range control by one step value.
+    /// Decrement a numeric value by one step.
     Decrement,
-    /// Increment a slider or range control by one step value.
+    /// Increment a numeric value by one step.
     Increment,
 
     HideTooltip,
@@ -318,7 +318,7 @@ pub enum Action {
 
     /// Replace the value of the control with the specified value and
     /// reset the selection, if applicable. Requires [`ActionRequest::data`]
-    /// to be set to [`ActionData::Value`] or [`ActionData::ValueForRange`].
+    /// to be set to [`ActionData::Value`] or [`ActionData::NumericValue`].
     SetValue,
 
     ShowContextMenu,
@@ -1127,17 +1127,17 @@ pub struct Node {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub next_focus: Option<NodeId>,
 
-    // Range attributes.
+    // Numeric value attributes.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub value_for_range: Option<f64>,
+    pub numeric_value: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub min_value_for_range: Option<f64>,
+    pub min_numeric_value: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub max_value_for_range: Option<f64>,
+    pub max_numeric_value: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub step_value_for_range: Option<f64>,
+    pub numeric_value_step: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub jump_value_for_range: Option<f64>,
+    pub numeric_value_jump: Option<f64>,
 
     // Text attributes.
     /// Font size is in pixels.
@@ -1288,11 +1288,11 @@ impl Node {
             underline: None,
             previous_focus: None,
             next_focus: None,
-            value_for_range: None,
-            min_value_for_range: None,
-            max_value_for_range: None,
-            step_value_for_range: None,
-            jump_value_for_range: None,
+            numeric_value: None,
+            min_numeric_value: None,
+            max_numeric_value: None,
+            numeric_value_step: None,
+            numeric_value_jump: None,
             font_size: None,
             font_weight: None,
             text_indent: None,
@@ -1418,7 +1418,7 @@ impl<T: FnOnce() -> TreeUpdate> From<T> for TreeUpdate {
 pub enum ActionData {
     CustomAction(i32),
     Value(Box<str>),
-    ValueForRange(f64),
+    NumericValue(f64),
     /// Optional target rectangle for [`Action::ScrollIntoView`], in
     /// the coordinate space of the action's target node.
     ScrollTargetRect(Rect),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -318,7 +318,7 @@ pub enum Action {
 
     /// Replace the value of the control with the specified value and
     /// reset the selection, if applicable. Requires [`ActionRequest::data`]
-    /// to be set to [`ActionData::Value`].
+    /// to be set to [`ActionData::Value`] or [`ActionData::ValueForRange`].
     SetValue,
 
     ShowContextMenu,
@@ -1129,13 +1129,15 @@ pub struct Node {
 
     // Range attributes.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub value_for_range: Option<f32>,
+    pub value_for_range: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub min_value_for_range: Option<f32>,
+    pub min_value_for_range: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub max_value_for_range: Option<f32>,
+    pub max_value_for_range: Option<f64>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub step_value_for_range: Option<f32>,
+    pub step_value_for_range: Option<f64>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub jump_value_for_range: Option<f64>,
 
     // Text attributes.
     /// Font size is in pixels.
@@ -1290,6 +1292,7 @@ impl Node {
             min_value_for_range: None,
             max_value_for_range: None,
             step_value_for_range: None,
+            jump_value_for_range: None,
             font_size: None,
             font_weight: None,
             text_indent: None,
@@ -1415,6 +1418,7 @@ impl<T: FnOnce() -> TreeUpdate> From<T> for TreeUpdate {
 pub enum ActionData {
     CustomAction(i32),
     Value(Box<str>),
+    ValueForRange(f64),
     /// Optional target rectangle for [`Action::ScrollIntoView`], in
     /// the coordinate space of the action's target node.
     ScrollTargetRect(Rect),

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -266,14 +266,14 @@ impl<'a> Node<'a> {
             })
     }
 
-    pub fn set_value_for_range(&self, value: f64) {
+    pub fn set_numeric_value(&self, value: f64) {
         self.tree_reader
             .tree
             .action_handler
             .do_action(ActionRequest {
                 action: Action::SetValue,
                 target: self.id(),
-                data: Some(ActionData::ValueForRange(value)),
+                data: Some(ActionData::NumericValue(value)),
             })
     }
 
@@ -318,24 +318,24 @@ impl<'a> Node<'a> {
         self.data().value.as_deref()
     }
 
-    pub fn value_for_range(&self) -> Option<f64> {
-        self.data().value_for_range
+    pub fn numeric_value(&self) -> Option<f64> {
+        self.data().numeric_value
     }
 
-    pub fn min_value_for_range(&self) -> Option<f64> {
-        self.data().min_value_for_range
+    pub fn min_numeric_value(&self) -> Option<f64> {
+        self.data().min_numeric_value
     }
 
-    pub fn max_value_for_range(&self) -> Option<f64> {
-        self.data().max_value_for_range
+    pub fn max_numeric_value(&self) -> Option<f64> {
+        self.data().max_numeric_value
     }
 
-    pub fn step_value_for_range(&self) -> Option<f64> {
-        self.data().step_value_for_range
+    pub fn numeric_value_step(&self) -> Option<f64> {
+        self.data().numeric_value_step
     }
 
-    pub fn jump_value_for_range(&self) -> Option<f64> {
-        self.data().jump_value_for_range
+    pub fn numeric_value_jump(&self) -> Option<f64> {
+        self.data().numeric_value_jump
     }
 
     pub fn is_text_field(&self) -> bool {

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -12,7 +12,7 @@ use std::iter::FusedIterator;
 use std::sync::{Arc, Weak};
 
 use accesskit::kurbo::{Affine, Point, Rect};
-use accesskit::{Action, ActionRequest, CheckedState, DefaultActionVerb, NodeId, Role};
+use accesskit::{Action, ActionData, ActionRequest, CheckedState, DefaultActionVerb, NodeId, Role};
 
 use crate::iterators::{
     FollowingSiblings, FollowingUnignoredSiblings, PrecedingSiblings, PrecedingUnignoredSiblings,
@@ -255,6 +255,28 @@ impl<'a> Node<'a> {
             })
     }
 
+    pub fn set_value(&self, value: impl Into<Box<str>>) {
+        self.tree_reader
+            .tree
+            .action_handler
+            .do_action(ActionRequest {
+                action: Action::SetValue,
+                target: self.id(),
+                data: Some(ActionData::Value(value.into())),
+            })
+    }
+
+    pub fn set_value_for_range(&self, value: f64) {
+        self.tree_reader
+            .tree
+            .action_handler
+            .do_action(ActionRequest {
+                action: Action::SetValue,
+                target: self.id(),
+                data: Some(ActionData::ValueForRange(value)),
+            })
+    }
+
     // Convenience getters
 
     pub fn id(&self) -> NodeId {
@@ -273,9 +295,9 @@ impl<'a> Node<'a> {
         self.data().disabled
     }
 
-    pub fn is_read_only_or_disabled(&self) -> bool {
+    pub fn is_read_only(&self) -> bool {
         let data = self.data();
-        if data.read_only || self.is_disabled() {
+        if data.read_only {
             true
         } else if !data.editable {
             false
@@ -284,8 +306,36 @@ impl<'a> Node<'a> {
         }
     }
 
+    pub fn is_read_only_or_disabled(&self) -> bool {
+        self.is_read_only() || self.is_disabled()
+    }
+
     pub fn checked_state(&self) -> Option<CheckedState> {
         self.data().checked_state
+    }
+
+    pub fn value(&self) -> Option<&str> {
+        self.data().value.as_deref()
+    }
+
+    pub fn value_for_range(&self) -> Option<f64> {
+        self.data().value_for_range
+    }
+
+    pub fn min_value_for_range(&self) -> Option<f64> {
+        self.data().min_value_for_range
+    }
+
+    pub fn max_value_for_range(&self) -> Option<f64> {
+        self.data().max_value_for_range
+    }
+
+    pub fn step_value_for_range(&self) -> Option<f64> {
+        self.data().step_value_for_range
+    }
+
+    pub fn jump_value_for_range(&self) -> Option<f64> {
+        self.data().jump_value_for_range
     }
 
     pub fn is_text_field(&self) -> bool {

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -15,6 +15,7 @@ accesskit = { version = "0.1.1", path = "../../common" }
 accesskit_consumer = { version = "0.1.1", path = "../../consumer" }
 arrayvec = "0.7.1"
 lazy-init = "0.5.0"
+libc = "0.2.112"
 paste = "1.0"
 
 [dependencies.windows]

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -295,7 +295,7 @@ impl ResolvedPlatformNode<'_> {
     }
 
     fn is_range_value_pattern_supported(&self) -> bool {
-        self.node.value_for_range().is_some()
+        self.node.numeric_value().is_some()
     }
 
     fn value(&self) -> &str {
@@ -306,26 +306,26 @@ impl ResolvedPlatformNode<'_> {
         self.node.is_read_only()
     }
 
-    fn value_for_range(&self) -> f64 {
-        self.node.value_for_range().unwrap()
+    fn numeric_value(&self) -> f64 {
+        self.node.numeric_value().unwrap()
     }
 
-    fn min_value_for_range(&self) -> f64 {
-        self.node.min_value_for_range().unwrap_or(std::f64::MIN)
+    fn min_numeric_value(&self) -> f64 {
+        self.node.min_numeric_value().unwrap_or(std::f64::MIN)
     }
 
-    fn max_value_for_range(&self) -> f64 {
-        self.node.max_value_for_range().unwrap_or(std::f64::MAX)
+    fn max_numeric_value(&self) -> f64 {
+        self.node.max_numeric_value().unwrap_or(std::f64::MAX)
     }
 
-    fn step_value_for_range(&self) -> f64 {
-        self.node.step_value_for_range().unwrap_or(0.0)
+    fn numeric_value_step(&self) -> f64 {
+        self.node.numeric_value_step().unwrap_or(0.0)
     }
 
-    fn jump_value_for_range(&self) -> f64 {
+    fn numeric_value_jump(&self) -> f64 {
         self.node
-            .jump_value_for_range()
-            .unwrap_or_else(|| self.step_value_for_range())
+            .numeric_value_jump()
+            .unwrap_or_else(|| self.numeric_value_step())
     }
 
     pub(crate) fn enqueue_property_changes(
@@ -438,8 +438,8 @@ impl ResolvedPlatformNode<'_> {
         self.node.set_value(value)
     }
 
-    fn set_value_for_range(&self, value: f64) {
-        self.node.set_value_for_range(value)
+    fn set_numeric_value(&self, value: f64) {
+        self.node.set_numeric_value(value)
     }
 }
 
@@ -677,12 +677,12 @@ patterns! {
         (IsReadOnly, is_read_only, BOOL)
     )),
     (RangeValue, is_range_value_pattern_supported, (
-        (Value, value_for_range, f64),
+        (Value, numeric_value, f64),
         (IsReadOnly, is_read_only, BOOL),
-        (Minimum, min_value_for_range, f64),
-        (Maximum, max_value_for_range, f64),
-        (SmallChange, step_value_for_range, f64),
-        (LargeChange, jump_value_for_range, f64)
+        (Minimum, min_numeric_value, f64),
+        (Maximum, max_numeric_value, f64),
+        (SmallChange, numeric_value_step, f64),
+        (LargeChange, numeric_value_jump, f64)
     ))
 }
 
@@ -728,7 +728,7 @@ impl ValueProvider {
 impl RangeValueProvider {
     fn SetValue(&self, value: f64) -> Result<()> {
         self.0.resolve(|resolved| {
-            resolved.set_value_for_range(value);
+            resolved.set_numeric_value(value);
             Ok(())
         })
     }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -323,7 +323,9 @@ impl ResolvedPlatformNode<'_> {
     }
 
     fn jump_value_for_range(&self) -> f64 {
-        self.node.jump_value_for_range().unwrap_or_else(|| self.step_value_for_range())
+        self.node
+            .jump_value_for_range()
+            .unwrap_or_else(|| self.step_value_for_range())
     }
 
     pub(crate) fn enqueue_property_changes(

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -68,6 +68,12 @@ impl From<i32> for VariantFactory {
     }
 }
 
+impl From<f64> for VariantFactory {
+    fn from(value: f64) -> Self {
+        Self(VT_R8, VARIANT_0_0_0 { dblVal: value })
+    }
+}
+
 impl From<ToggleState> for VariantFactory {
     fn from(value: ToggleState) -> Self {
         value.0.into()


### PR DESCRIPTION
The UIA value pattern allows access to the value of a text edit control. This will let the screen reader read the current content; full support for text editing will come later. The range value pattern is for progress bars and sliders.

As part of this work, I had to refactor the UIA implementation to use a separate struct for each pattern, to avoid method name conflicts.