### PR TITLE
chore: Automate releases with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          command: manifest

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "common": "0.2.0",
+  "consumer": "0.2.0",
+  "platforms/windows": "0.2.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,10 @@
+{
+  "bootstrap-sha": "dbfa4bce848ece5976cc17f7068b57c68b7a449d",
+  "plugins": ["cargo-workspace"],
+  "release-type": "rust",
+  "packages": {
+    "common": {},
+    "consumer": {},
+    "platforms/windows": {}
+  }
+}


### PR DESCRIPTION
[release-please](https://github.com/googleapis/release-please) will automatically create release PRs and maintain a changelog. This requires us to use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in our PR titles from now on.