### PR TITLE
refactor!: Drop `TreeUpdate::clear`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1356,13 +1356,6 @@ impl Tree {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TreeUpdate {
-    /// The optional ID of a node to clear, before applying any updates.
-    /// Clearing a node means deleting all of its children and their descendants,
-    /// but leaving that node in the tree. It's an error to clear a node but not
-    /// subsequently update it as part of the same `TreeUpdate`.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub clear: Option<NodeId>,
-
     /// An ordered list of zero or more node updates to apply to the tree.
     ///
     /// Suppose that the next [`Node`] to be applied is `node`. The following

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -130,7 +130,6 @@ mod tests {
             ..Node::new(EMPTY_CONTAINER_3_3_IGNORED_ID, Role::GenericContainer)
         };
         let initial_update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 root,
                 paragraph_0,

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -791,7 +791,6 @@ mod tests {
     #[test]
     fn no_name_or_labelled_by() {
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2],
@@ -818,7 +817,6 @@ mod tests {
         const LABEL_2: &str = "minutes";
 
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2, NODE_ID_3, NODE_ID_4, NODE_ID_5],

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -46,9 +46,6 @@ impl State {
     }
 
     fn update(&mut self, update: TreeUpdate, mut changes: Option<&mut InternalChanges>) {
-        // TODO: handle TreeUpdate::clear
-        assert!(update.clear.is_none());
-
         let mut orphans = HashSet::new();
 
         if let Some(tree) = update.tree {
@@ -198,7 +195,6 @@ impl State {
         assert_eq!(nodes.len(), self.nodes.len());
 
         TreeUpdate {
-            clear: None,
             nodes,
             tree: Some(self.data.clone()),
             focus: self.focus,
@@ -252,8 +248,6 @@ pub struct Tree {
 
 impl Tree {
     pub fn new(mut initial_state: TreeUpdate, action_handler: Box<dyn ActionHandler>) -> Arc<Self> {
-        assert!(initial_state.clear.is_none());
-
         let mut state = State {
             nodes: im::HashMap::new(),
             data: initial_state.tree.take().unwrap(),
@@ -369,7 +363,6 @@ mod tests {
     #[test]
     fn init_tree_with_root_node() {
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![Node::new(NODE_ID_1, Role::Window)],
             tree: Some(Tree::new(
                 TreeId(TREE_ID.into()),
@@ -388,7 +381,6 @@ mod tests {
     #[test]
     fn root_node_has_children() {
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2, NODE_ID_3],
@@ -421,7 +413,6 @@ mod tests {
     fn add_child_to_root_node() {
         let root_node = Node::new(NODE_ID_1, Role::Window);
         let first_update = TreeUpdate {
-            clear: None,
             nodes: vec![root_node.clone()],
             tree: Some(Tree::new(
                 TreeId(TREE_ID.into()),
@@ -433,7 +424,6 @@ mod tests {
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert_eq!(0, tree.read().root().children().count());
         let second_update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2],
@@ -479,7 +469,6 @@ mod tests {
     fn remove_child_from_root_node() {
         let root_node = Node::new(NODE_ID_1, Role::Window);
         let first_update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2],
@@ -497,7 +486,6 @@ mod tests {
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert_eq!(1, tree.read().root().children().count());
         let second_update = TreeUpdate {
-            clear: None,
             nodes: vec![root_node],
             tree: None,
             focus: None,
@@ -531,7 +519,6 @@ mod tests {
     #[test]
     fn move_focus_between_siblings() {
         let first_update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2, NODE_ID_3],
@@ -550,7 +537,6 @@ mod tests {
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
         assert!(tree.read().node_by_id(NODE_ID_2).unwrap().is_focused());
         let second_update = TreeUpdate {
-            clear: None,
             nodes: vec![],
             tree: None,
             focus: Some(NODE_ID_3),
@@ -600,7 +586,6 @@ mod tests {
     fn update_node() {
         let child_node = Node::new(NODE_ID_2, Role::Button);
         let first_update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2],
@@ -624,7 +609,6 @@ mod tests {
             tree.read().node_by_id(NODE_ID_2).unwrap().name()
         );
         let second_update = TreeUpdate {
-            clear: None,
             nodes: vec![Node {
                 name: Some("bar".into()),
                 ..child_node
@@ -659,7 +643,6 @@ mod tests {
     #[test]
     fn no_change_update() {
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![
                 Node {
                     children: vec![NODE_ID_2, NODE_ID_3],

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -112,7 +112,6 @@ fn get_initial_state() -> TreeUpdate {
     let button_1 = make_button(BUTTON_1_ID, "Button 1");
     let button_2 = make_button(BUTTON_2_ID, "Button 2");
     TreeUpdate {
-        clear: None,
         nodes: vec![root, button_1, button_2],
         tree: Some(Tree::new(
             TreeId("test".into()),
@@ -156,7 +155,6 @@ impl WindowState {
         };
         let node = make_button(id, name);
         let update = TreeUpdate {
-            clear: None,
             nodes: vec![node],
             tree: None,
             focus: is_window_focused.then(|| focus),
@@ -177,7 +175,6 @@ fn update_focus(window: HWND, is_window_focused: bool) {
     let focus = inner_state.focus;
     drop(inner_state);
     let events = window_state.adapter.update_if_active(|| TreeUpdate {
-        clear: None,
         nodes: vec![],
         tree: None,
         focus: is_window_focused.then(|| focus),

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -88,7 +88,6 @@ fn update_focus(window: HWND, is_window_focused: bool) {
     let focus = inner_state.focus;
     drop(inner_state);
     let events = window_state.adapter.update_if_active(|| TreeUpdate {
-        clear: None,
         nodes: vec![],
         tree: None,
         focus: is_window_focused.then(|| focus),

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -35,7 +35,6 @@ fn get_initial_state() -> TreeUpdate {
     let button_1 = make_button(BUTTON_1_ID, "Button 1");
     let button_2 = make_button(BUTTON_2_ID, "Button 2");
     TreeUpdate {
-        clear: None,
         nodes: vec![root, button_1, button_2],
         tree: Some(Tree::new(
             TreeId("test".into()),


### PR DESCRIPTION
I'm not sure why Chromium has this field, but I don't believe we need it.