### PR TITLE
feat(common): Conversion from `NonZeroU64` to `NodeId`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,7 +19,10 @@ use schemars_lib::JsonSchema;
 use serde_lib as serde;
 #[cfg(feature = "serde")]
 use serde_lib::{Deserialize, Serialize};
-use std::{num::{NonZeroU64, NonZeroU128}, ops::Range};
+use std::{
+    num::{NonZeroU128, NonZeroU64},
+    ops::Range,
+};
 
 /// The type of an accessibility node.
 ///
@@ -589,7 +592,7 @@ pub type NodeIdContent = NonZeroU128;
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
 pub struct NodeId(pub NodeIdContent);
 
-impl  From<NonZeroU64> for NodeId {
+impl From<NonZeroU64> for NodeId {
     fn from(inner: NonZeroU64) -> Self {
         Self(inner.into())
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,7 +19,7 @@ use schemars_lib::JsonSchema;
 use serde_lib as serde;
 #[cfg(feature = "serde")]
 use serde_lib::{Deserialize, Serialize};
-use std::ops::Range;
+use std::{num::{NonZeroU64, NonZeroU128}, ops::Range};
 
 /// The type of an accessibility node.
 ///
@@ -580,7 +580,7 @@ pub enum StringEncoding {
 
 // This is NonZeroU128 because we regularly store Option<NodeId>.
 // 128-bit to handle UUIDs.
-pub type NodeIdContent = std::num::NonZeroU128;
+pub type NodeIdContent = NonZeroU128;
 
 /// The stable identity of a [`Node`], unique within the node's tree.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -588,6 +588,12 @@ pub type NodeIdContent = std::num::NonZeroU128;
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
 pub struct NodeId(pub NodeIdContent);
+
+impl  From<NonZeroU64> for NodeId {
+    fn from(inner: NonZeroU64) -> Self {
+        Self(inner.into())
+    }
+}
 
 /// The globally unique ID of a [`Tree`].
 ///


### PR DESCRIPTION
We're not sure what size `NodeId` should ultimately be. We may even end up making it configurable through a cargo feature. But we always want to make it easy to convert a `NonZeroU64` to a `NodeId`.

Suggested by @raphlinus.