### PR TITLE
refactor!: Drop unused tree IDs

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -598,17 +598,6 @@ impl From<NonZeroU64> for NodeId {
     }
 }
 
-/// The globally unique ID of a [`Tree`].
-///
-/// The format of this ID is up to the implementer. A [v4 UUID] is a safe choice.
-///
-/// [v4 UUID]: https://datatracker.ietf.org/doc/html/rfc4122#section-4.4
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(JsonSchema))]
-#[cfg_attr(feature = "serde", serde(crate = "serde"))]
-pub struct TreeId(pub Box<str>);
-
 /// A marker spanning a range within text.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -983,9 +972,6 @@ pub struct Node {
     pub checked_state_description: Option<Box<str>>,
 
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub child_tree: Option<TreeId>,
-
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub class_name: Option<Box<str>>,
 
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
@@ -1265,7 +1251,6 @@ impl Node {
             auto_complete: None,
             checked_state: None,
             checked_state_description: None,
-            child_tree: None,
             class_name: None,
             container_live_relevant: None,
             container_live_status: None,
@@ -1350,7 +1335,6 @@ impl Node {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Tree {
-    pub id: TreeId,
     pub root: NodeId,
 
     /// The string encoding used by the tree source. This is required
@@ -1361,10 +1345,6 @@ pub struct Tree {
     /// the platform adapter will do this if needed.
     pub source_string_encoding: StringEncoding,
 
-    /// The ID of the tree that this tree is contained in, if any.
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub parent: Option<TreeId>,
-
     /// The node that's used as the root scroller, if any. On some platforms
     /// like Android we need to ignore accessibility scroll offsets for
     /// that node and get them from the viewport instead.
@@ -1373,12 +1353,10 @@ pub struct Tree {
 }
 
 impl Tree {
-    pub fn new(id: TreeId, root: NodeId, source_string_encoding: StringEncoding) -> Tree {
+    pub fn new(root: NodeId, source_string_encoding: StringEncoding) -> Tree {
         Tree {
-            id,
             root,
             source_string_encoding,
-            parent: None,
             root_scroller: None,
         }
     }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -21,7 +21,7 @@ pub use iterators::{
 mod tests {
     use accesskit::kurbo::{Affine, Rect, Vec2};
     use accesskit::{
-        ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate,
+        ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeUpdate,
     };
     use std::num::NonZeroU128;
     use std::sync::Arc;
@@ -146,7 +146,6 @@ mod tests {
                 empty_container_3_3_ignored,
             ],
             tree: Some(Tree::new(
-                TreeId("test_tree".into()),
                 ROOT_ID,
                 StringEncoding::Utf8,
             )),

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -145,10 +145,7 @@ mod tests {
                 button_3_2,
                 empty_container_3_3_ignored,
             ],
-            tree: Some(Tree::new(
-                ROOT_ID,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(ROOT_ID, StringEncoding::Utf8)),
             focus: None,
         };
         crate::tree::Tree::new(initial_update, Box::new(NullActionHandler {}))

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -178,10 +178,6 @@ impl<'a> Node<'a> {
         false
     }
 
-    pub fn global_id(&self) -> String {
-        format!("{}:{}", self.tree_reader.id().0, self.id().0)
-    }
-
     /// Returns the transform defined directly on this node, or the identity
     /// transform, without taking into account transforms on ancestors.
     pub fn direct_transform(&self) -> Affine {
@@ -537,12 +533,11 @@ impl Node<'_> {
 #[cfg(test)]
 mod tests {
     use accesskit::kurbo::{Point, Rect};
-    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate};
+    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeUpdate};
     use std::num::NonZeroU128;
 
     use crate::tests::*;
 
-    const TREE_ID: &str = "test_tree";
     const NODE_ID_1: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(1) });
     const NODE_ID_2: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(2) });
     const NODE_ID_3: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(3) });
@@ -798,7 +793,6 @@ mod tests {
                 Node::new(NODE_ID_2, Role::Button),
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -839,7 +833,6 @@ mod tests {
                 },
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -792,10 +792,7 @@ mod tests {
                 },
                 Node::new(NODE_ID_2, Role::Button),
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
@@ -832,10 +829,7 @@ mod tests {
                     ..Node::new(NODE_ID_5, Role::StaticText)
                 },
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(update, Box::new(NullActionHandler {}));

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, NodeId, TreeId, TreeUpdate};
+use accesskit::{ActionHandler, NodeId, TreeUpdate};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -49,7 +49,6 @@ impl State {
         let mut orphans = HashSet::new();
 
         if let Some(tree) = update.tree {
-            assert_eq!(tree.id, self.data.id);
             if tree.root != self.data.root {
                 orphans.insert(self.data.root);
             }
@@ -219,10 +218,6 @@ impl Reader<'_> {
         self.node_by_id(self.state.data.root).unwrap()
     }
 
-    pub fn id(&self) -> &TreeId {
-        &self.state.data.id
-    }
-
     pub fn focus(&self) -> Option<Node<'_>> {
         self.state.focus.map(|id| self.node_by_id(id).unwrap())
     }
@@ -350,12 +345,11 @@ impl Tree {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate};
+    use accesskit::{Node, NodeId, Role, StringEncoding, Tree, TreeUpdate};
     use std::num::NonZeroU128;
 
     use crate::tests::NullActionHandler;
 
-    const TREE_ID: &str = "test_tree";
     const NODE_ID_1: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(1) });
     const NODE_ID_2: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(2) });
     const NODE_ID_3: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(3) });
@@ -365,14 +359,12 @@ mod tests {
         let update = TreeUpdate {
             nodes: vec![Node::new(NODE_ID_1, Role::Window)],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
             focus: None,
         };
         let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
-        assert_eq!(&TreeId(TREE_ID.into()), tree.read().id());
         assert_eq!(NODE_ID_1, tree.read().root().id());
         assert_eq!(Role::Window, tree.read().root().role());
         assert!(tree.read().root().parent().is_none());
@@ -390,7 +382,6 @@ mod tests {
                 Node::new(NODE_ID_3, Role::Button),
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -415,7 +406,6 @@ mod tests {
         let first_update = TreeUpdate {
             nodes: vec![root_node.clone()],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -477,7 +467,6 @@ mod tests {
                 Node::new(NODE_ID_2, Role::RootWebArea),
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -528,7 +517,6 @@ mod tests {
                 Node::new(NODE_ID_3, Role::Button),
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -597,7 +585,6 @@ mod tests {
                 },
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),
@@ -652,7 +639,6 @@ mod tests {
                 Node::new(NODE_ID_3, Role::Button),
             ],
             tree: Some(Tree::new(
-                TreeId(TREE_ID.into()),
                 NODE_ID_1,
                 StringEncoding::Utf8,
             )),

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -358,10 +358,7 @@ mod tests {
     fn init_tree_with_root_node() {
         let update = TreeUpdate {
             nodes: vec![Node::new(NODE_ID_1, Role::Window)],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
@@ -381,10 +378,7 @@ mod tests {
                 Node::new(NODE_ID_2, Role::Button),
                 Node::new(NODE_ID_3, Role::Button),
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(update, Box::new(NullActionHandler {}));
@@ -405,10 +399,7 @@ mod tests {
         let root_node = Node::new(NODE_ID_1, Role::Window);
         let first_update = TreeUpdate {
             nodes: vec![root_node.clone()],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
@@ -466,10 +457,7 @@ mod tests {
                 },
                 Node::new(NODE_ID_2, Role::RootWebArea),
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
@@ -516,10 +504,7 @@ mod tests {
                 Node::new(NODE_ID_2, Role::Button),
                 Node::new(NODE_ID_3, Role::Button),
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: Some(NODE_ID_2),
         };
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
@@ -584,10 +569,7 @@ mod tests {
                     ..child_node.clone()
                 },
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: None,
         };
         let tree = super::Tree::new(first_update, Box::new(NullActionHandler {}));
@@ -638,10 +620,7 @@ mod tests {
                 Node::new(NODE_ID_2, Role::Button),
                 Node::new(NODE_ID_3, Role::Button),
             ],
-            tree: Some(Tree::new(
-                NODE_ID_1,
-                StringEncoding::Utf8,
-            )),
+            tree: Some(Tree::new(NODE_ID_1, StringEncoding::Utf8)),
             focus: Some(NODE_ID_2),
         };
         let tree = super::Tree::new(update.clone(), Box::new(NullActionHandler {}));

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -5,7 +5,7 @@ use std::{cell::RefCell, convert::TryInto, mem::drop, num::NonZeroU128, rc::Rc};
 use accesskit::kurbo::Rect;
 use accesskit::{
     Action, ActionHandler, ActionRequest, DefaultActionVerb, Node, NodeId, Role, StringEncoding,
-    Tree, TreeId, TreeUpdate,
+    Tree, TreeUpdate,
 };
 use lazy_static::lazy_static;
 use windows::{
@@ -106,7 +106,6 @@ fn get_initial_state() -> TreeUpdate {
     TreeUpdate {
         nodes: vec![root, button_1, button_2],
         tree: Some(Tree::new(
-            TreeId("test".into()),
             WINDOW_ID,
             StringEncoding::Utf8,
         )),

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -105,10 +105,7 @@ fn get_initial_state() -> TreeUpdate {
     let button_2 = make_button(BUTTON_2_ID, "Button 2");
     TreeUpdate {
         nodes: vec![root, button_1, button_2],
-        tree: Some(Tree::new(
-            WINDOW_ID,
-            StringEncoding::Utf8,
-        )),
+        tree: Some(Tree::new(WINDOW_ID, StringEncoding::Utf8)),
         focus: None,
     }
 }

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -36,10 +36,7 @@ fn get_initial_state() -> TreeUpdate {
     let button_2 = make_button(BUTTON_2_ID, "Button 2");
     TreeUpdate {
         nodes: vec![root, button_1, button_2],
-        tree: Some(Tree::new(
-            WINDOW_ID,
-            StringEncoding::Utf8,
-        )),
+        tree: Some(Tree::new(WINDOW_ID, StringEncoding::Utf8)),
         focus: None,
     }
 }

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -6,7 +6,7 @@
 use std::{convert::TryInto, num::NonZeroU128};
 
 use accesskit::{
-    ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeId, TreeUpdate,
+    ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeUpdate,
 };
 use windows::{core::*, Win32::UI::Accessibility::*};
 
@@ -37,7 +37,6 @@ fn get_initial_state() -> TreeUpdate {
     TreeUpdate {
         nodes: vec![root, button_1, button_2],
         tree: Some(Tree::new(
-            TreeId("test".into()),
             WINDOW_ID,
             StringEncoding::Utf8,
         )),


### PR DESCRIPTION
The concept of tree IDs isn't actually serving any purpose so far. It's just something I copied from Chromium. The Windows platform adapter doesn't do anything with it, and neither will any of the other platform adapters I plan to implement in the foreseeable future. I don't plan to actually implement support for child trees anytime soon. So to reduce clutter, and hopefully encourage actual adoption of AccessKit by GUI toolkits, I'm dropping this.