### PR TITLE
Migrate to 2021 edition

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "accessibility"]
 repository = "https://github.com/AccessKit/accesskit"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 features = ["schemars", "serde"]

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "accessibility"]
 repository = "https://github.com/AccessKit/accesskit"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.3.0", path = "../common" }

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["gui"]
 keywords = ["gui", "ui", "accessibility"]
 repository = "https://github.com/AccessKit/accesskit"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.3.0", path = "../../common" }


### PR DESCRIPTION
Unless I missed something, updating the `Cargo.toml` files is all we need to transition to the latest edition.

I think we are better off doing it now while the codebase is still small.