### PR TITLE
fix(platforms/windows): Restore the optimization of the FragmentRoot …

### DIFF
--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -514,6 +514,7 @@ impl ResolvedPlatformNode<'_> {
     }
 }
 
+#[derive(Clone)]
 #[implement(
     Windows::Win32::UI::Accessibility::IRawElementProviderSimple,
     Windows::Win32::UI::Accessibility::IRawElementProviderFragment,
@@ -609,12 +610,12 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
 
     fn FragmentRoot(&self) -> Result<IRawElementProviderFragmentRoot> {
         enum FragmentRootResult {
-            This(PlatformNode),
+            This,
             Other(PlatformNode),
         }
         let result = self.resolve(|resolved| {
             if resolved.node.is_root() {
-                Ok(FragmentRootResult::This(resolved.downgrade()))
+                Ok(FragmentRootResult::This)
             } else {
                 let root = resolved.node.tree_reader.root();
                 Ok(FragmentRootResult::Other(
@@ -623,7 +624,7 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
             }
         })?;
         match result {
-            FragmentRootResult::This(node) => Ok(node.into()),
+            FragmentRootResult::This => Ok(self.clone().into()),
             FragmentRootResult::Other(node) => Ok(node.into()),
         }
     }


### PR DESCRIPTION
This addresses a slight regression in #102. The implementation of `PlatformNode::FragmentRoot` can't be quite the same as it was before the upgrade of windows-rs, but the original spirtit of the optimization is back.