### PR TITLE
refactor(platforms/windows)!: Simplify the adapter API by always boxi…

### DIFF
--- a/platforms/windows/examples/winit.rs
+++ b/platforms/windows/examples/winit.rs
@@ -91,7 +91,7 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    let adapter: Arc<Adapter> = {
+    let adapter = {
         let state = Arc::clone(&state);
         let proxy = Mutex::new(event_loop.create_proxy());
         Arc::new(Adapter::new(

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -3,7 +3,6 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::TreeUpdate;
 use std::{cell::Cell, ffi::c_void, mem::transmute};
 use windows::{
     core::*,
@@ -14,20 +13,15 @@ use crate::Adapter;
 
 const PROP_NAME: &str = "AccessKitAdapter";
 
-struct SubclassData<'a, Source: Into<TreeUpdate>> {
-    adapter: &'a Adapter<Source>,
+struct SubclassData<'a> {
+    adapter: &'a Adapter,
     prev_wnd_proc: WNDPROC,
     window_destroyed: Cell<bool>,
 }
 
-extern "system" fn wnd_proc<Source: Into<TreeUpdate>>(
-    window: HWND,
-    message: u32,
-    wparam: WPARAM,
-    lparam: LPARAM,
-) -> LRESULT {
+extern "system" fn wnd_proc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     let handle = unsafe { GetPropW(window, PROP_NAME) };
-    let data_ptr = handle.0 as *const SubclassData<'_, Source>;
+    let data_ptr = handle.0 as *const SubclassData;
     assert!(!data_ptr.is_null());
     let data = unsafe { &*data_ptr };
     if message == WM_GETOBJECT {
@@ -46,29 +40,19 @@ extern "system" fn wnd_proc<Source: Into<TreeUpdate>>(
 ///
 /// [Win32 subclassing]: https://docs.microsoft.com/en-us/windows/win32/controls/subclassing-overview
 #[repr(transparent)]
-pub struct WindowSubclass<'a, Source: Into<TreeUpdate> = Box<dyn FnOnce() -> TreeUpdate>>(
-    Box<SubclassData<'a, Source>>,
-);
+pub struct WindowSubclass<'a>(Box<SubclassData<'a>>);
 
-impl<'a, Source: Into<TreeUpdate>> WindowSubclass<'a, Source> {
-    pub fn new(adapter: &'a Adapter<Source>) -> Self {
+impl<'a> WindowSubclass<'a> {
+    pub fn new(adapter: &'a Adapter) -> Self {
         let hwnd = adapter.window_handle();
         let mut data = Box::new(SubclassData {
             adapter,
             prev_wnd_proc: None,
             window_destroyed: Cell::new(false),
         });
-        unsafe {
-            SetPropW(
-                hwnd,
-                PROP_NAME,
-                HANDLE(&*data as *const SubclassData<'_, Source> as _),
-            )
-        }
-        .unwrap();
-        let result = unsafe {
-            SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wnd_proc::<Source> as *const c_void as _)
-        };
+        unsafe { SetPropW(hwnd, PROP_NAME, HANDLE(&*data as *const SubclassData as _)) }.unwrap();
+        let result =
+            unsafe { SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wnd_proc as *const c_void as _) };
         if result == 0 {
             let result: Result<()> = Err(Error::from_win32());
             result.unwrap();
@@ -78,7 +62,7 @@ impl<'a, Source: Into<TreeUpdate>> WindowSubclass<'a, Source> {
     }
 }
 
-impl<Source: Into<TreeUpdate>> Drop for WindowSubclass<'_, Source> {
+impl Drop for WindowSubclass<'_> {
     fn drop(&mut self) {
         if !self.0.window_destroyed.get() {
             let hwnd = self.0.adapter.window_handle();

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -66,7 +66,11 @@ fn has_native_uia() {
         .unwrap();
     let hwnd = HWND(window.hwnd() as _);
     assert!(!unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
-    let adapter = Adapter::new(hwnd, get_initial_state(), Box::new(NullActionHandler {}));
+    let adapter = Adapter::new(
+        hwnd,
+        Box::new(get_initial_state),
+        Box::new(NullActionHandler {}),
+    );
     let subclass = WindowSubclass::new(&adapter);
     assert!(unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
     drop(subclass);


### PR DESCRIPTION
I decided that the old API was over-complicated, with no real performance benefit. I decided it was time to simplify it before implementing the winit adapter.