### PR TITLE
refactor(platforms/windows)!: Refactor window subclassing to avoid lifetime issue

### DIFF
--- a/platforms/windows/examples/winit.rs
+++ b/platforms/windows/examples/winit.rs
@@ -1,7 +1,7 @@
 use accesskit::{
     Action, ActionHandler, ActionRequest, Node, NodeId, Role, StringEncoding, Tree, TreeUpdate,
 };
-use accesskit_windows::{Adapter, WindowSubclass};
+use accesskit_windows::{Adapter, SubclassingAdapter};
 use std::{
     num::NonZeroU128,
     sync::{Arc, Mutex},
@@ -94,20 +94,19 @@ fn main() {
     let adapter = {
         let state = Arc::clone(&state);
         let proxy = Mutex::new(event_loop.create_proxy());
-        Arc::new(Adapter::new(
+        Adapter::new(
             HWND(window.hwnd() as _),
             Box::new(move || {
                 let state = state.lock().unwrap();
                 initial_tree_update(&state)
             }),
             Box::new(WinitActionHandler(proxy)),
-        ))
+        )
     };
-    let _subclass = WindowSubclass::new(&*adapter);
+    let adapter = SubclassingAdapter::new(adapter);
 
     window.set_visible(true);
 
-    let adapter = Arc::clone(&adapter); // to move into the event handler
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -10,7 +10,7 @@ mod adapter;
 pub use adapter::{Adapter, QueuedEvents};
 
 mod subclass;
-pub use subclass::WindowSubclass;
+pub use subclass::SubclassingAdapter;
 
 #[cfg(test)]
 mod tests;

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use std::{cell::Cell, ffi::c_void, mem::transmute};
+use std::{cell::Cell, ffi::c_void, mem::transmute, ops::Deref};
 use windows::{
     core::*,
     Win32::{Foundation::*, UI::WindowsAndMessaging::*},
@@ -13,26 +13,67 @@ use crate::Adapter;
 
 const PROP_NAME: &str = "AccessKitAdapter";
 
-struct SubclassData<'a> {
-    adapter: &'a Adapter,
+struct SubclassImpl {
+    adapter: Adapter,
     prev_wnd_proc: WNDPROC,
     window_destroyed: Cell<bool>,
 }
 
 extern "system" fn wnd_proc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     let handle = unsafe { GetPropW(window, PROP_NAME) };
-    let data_ptr = handle.0 as *const SubclassData;
-    assert!(!data_ptr.is_null());
-    let data = unsafe { &*data_ptr };
+    let impl_ptr = handle.0 as *const SubclassImpl;
+    assert!(!impl_ptr.is_null());
+    let r#impl = unsafe { &*impl_ptr };
     if message == WM_GETOBJECT {
-        if let Some(result) = data.adapter.handle_wm_getobject(wparam, lparam) {
+        if let Some(result) = r#impl.adapter.handle_wm_getobject(wparam, lparam) {
             return result.into();
         }
     }
     if message == WM_NCDESTROY {
-        data.window_destroyed.set(true);
+        r#impl.window_destroyed.set(true);
     }
-    unsafe { CallWindowProcW(data.prev_wnd_proc, window, message, wparam, lparam) }
+    unsafe { CallWindowProcW(r#impl.prev_wnd_proc, window, message, wparam, lparam) }
+}
+
+impl SubclassImpl {
+    fn new(adapter: Adapter) -> Box<Self> {
+        Box::new(Self {
+            adapter,
+            prev_wnd_proc: None,
+            window_destroyed: Cell::new(false),
+        })
+    }
+
+    fn install(&mut self) {
+        let hwnd = self.adapter.window_handle();
+        unsafe { SetPropW(hwnd, PROP_NAME, HANDLE(self as *const SubclassImpl as _)) }.unwrap();
+        let result =
+            unsafe { SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wnd_proc as *const c_void as _) };
+        if result == 0 {
+            let result: Result<()> = Err(Error::from_win32());
+            result.unwrap();
+        }
+        self.prev_wnd_proc = unsafe { transmute::<isize, WNDPROC>(result) };
+    }
+
+    fn uninstall(&self) {
+        if self.window_destroyed.get() {
+            return;
+        }
+        let hwnd = self.adapter.window_handle();
+        let result = unsafe {
+            SetWindowLongPtrW(
+                hwnd,
+                GWLP_WNDPROC,
+                transmute::<WNDPROC, isize>(self.prev_wnd_proc),
+            )
+        };
+        if result == 0 {
+            let result: Result<()> = Err(Error::from_win32());
+            result.unwrap();
+        }
+        unsafe { RemovePropW(hwnd, PROP_NAME) }.unwrap();
+    }
 }
 
 /// Uses [Win32 subclassing] to handle `WM_GETOBJECT` messages on a window
@@ -40,44 +81,38 @@ extern "system" fn wnd_proc(window: HWND, message: u32, wparam: WPARAM, lparam: 
 ///
 /// [Win32 subclassing]: https://docs.microsoft.com/en-us/windows/win32/controls/subclassing-overview
 #[repr(transparent)]
-pub struct WindowSubclass<'a>(Box<SubclassData<'a>>);
+pub struct SubclassingAdapter(Option<Box<SubclassImpl>>);
 
-impl<'a> WindowSubclass<'a> {
-    pub fn new(adapter: &'a Adapter) -> Self {
-        let hwnd = adapter.window_handle();
-        let mut data = Box::new(SubclassData {
-            adapter,
-            prev_wnd_proc: None,
-            window_destroyed: Cell::new(false),
-        });
-        unsafe { SetPropW(hwnd, PROP_NAME, HANDLE(&*data as *const SubclassData as _)) }.unwrap();
-        let result =
-            unsafe { SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wnd_proc as *const c_void as _) };
-        if result == 0 {
-            let result: Result<()> = Err(Error::from_win32());
-            result.unwrap();
-        }
-        data.prev_wnd_proc = unsafe { transmute::<isize, WNDPROC>(result) };
-        Self(data)
+impl SubclassingAdapter {
+    pub fn new(adapter: Adapter) -> Self {
+        let mut r#impl = SubclassImpl::new(adapter);
+        r#impl.install();
+        Self(Some(r#impl))
+    }
+
+    pub fn inner(&self) -> &Adapter {
+        &self.0.as_ref().unwrap().adapter
+    }
+
+    pub fn into_inner(mut self) -> Adapter {
+        let r#impl = self.0.take().unwrap();
+        r#impl.uninstall();
+        r#impl.adapter
     }
 }
 
-impl Drop for WindowSubclass<'_> {
+impl Deref for SubclassingAdapter {
+    type Target = Adapter;
+
+    fn deref(&self) -> &Adapter {
+        self.inner()
+    }
+}
+
+impl Drop for SubclassingAdapter {
     fn drop(&mut self) {
-        if !self.0.window_destroyed.get() {
-            let hwnd = self.0.adapter.window_handle();
-            let result = unsafe {
-                SetWindowLongPtrW(
-                    hwnd,
-                    GWLP_WNDPROC,
-                    transmute::<WNDPROC, isize>(self.0.prev_wnd_proc),
-                )
-            };
-            if result == 0 {
-                let result: Result<()> = Err(Error::from_win32());
-                result.unwrap();
-            }
-            unsafe { RemovePropW(hwnd, PROP_NAME) }.unwrap();
+        if let Some(r#impl) = self.0.as_ref() {
+            r#impl.uninstall();
         }
     }
 }

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -15,7 +15,7 @@ use winit::{
     window::WindowBuilder,
 };
 
-use crate::{Adapter, WindowSubclass};
+use crate::{Adapter, SubclassingAdapter};
 
 const WINDOW_TITLE: &str = "Simple test";
 
@@ -71,12 +71,12 @@ fn has_native_uia() {
         Box::new(get_initial_state),
         Box::new(NullActionHandler {}),
     );
-    let subclass = WindowSubclass::new(&adapter);
+    let adapter = SubclassingAdapter::new(adapter);
     assert!(unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
-    drop(subclass);
+    let adapter = adapter.into_inner(); // stops subclassing
     assert!(!unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
-    let subclass = WindowSubclass::new(&adapter);
+    let adapter = SubclassingAdapter::new(adapter);
     assert!(unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
     drop(window);
-    drop(subclass);
+    drop(adapter);
 }


### PR DESCRIPTION
Replaced `WindowSubclass` with `SubclassingAdapter`, which takes ownership of the main adapter. There's no loss of functionality though, because `SubclassingAdapter::into_inner` uninstalls the subclass and returns ownership of the main adapter. This also slightly simplifies the main winit example, and will make the main winit adapter, which must encapsulate everything in a struct, possible.