### PR TITLE
Enable the serde feature when the schemars feature is turned on

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -20,5 +20,5 @@ schemars_lib = { package = "schemars", version = "0.8.7", features = ["enumset"]
 serde_lib = { package = "serde", version = "1.0", features = ["derive"], optional = true }
 
 [features]
-schemars = ["schemars_lib", "kurbo/schemars"]
+schemars = ["serde", "schemars_lib", "kurbo/schemars"]
 serde = ["serde_lib", "enumset/serde", "kurbo/serde"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -431,7 +431,7 @@ pub enum TextDirection {
 /// [`aria-invalid`] attribute.
 ///
 /// [`aria-invalid`]: https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -589,7 +589,7 @@ impl From<NonZeroU64> for NodeId {
 }
 
 /// A marker spanning a range within text.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -605,7 +605,7 @@ pub struct TextMarker {
 ///
 /// For example, a list UI can allow a user to reorder items in the list by dragging the
 /// items.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -1315,7 +1315,7 @@ impl Node {
 
 /// The data associated with an accessibility tree that's global to the
 /// tree and not associated with any particular node.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]


### PR DESCRIPTION
When enabling the `schemars` feature on the `accesskit` crate, it is necessary to also enable the `serde` feature. Failing to do so will result in an invalid JSON schema being generated due to the fact that serde attributes that are applied on our types won't be present.

Here is a piece of the JSON schema that gets generated when the `serde(rename_all = "camelCase")` attribute is not applied to the `Role` enum:

```json
...
  "definitions": {
    "Role": {
      "description": "...",
      "type": "string",
      "enum": [
        "Unknown",
        "InlineTextBox",
...
```

This PR enables the `serde` feature if the `schemars` feature is enabled, so that it is impossible to accidentally forget to enable both of them.