### PR TITLE
Skip `ActionRequest::data` if it is `None` during serialization

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -431,7 +431,7 @@ pub enum TextDirection {
 /// [`aria-invalid`] attribute.
 ///
 /// [`aria-invalid`]: https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -589,7 +589,7 @@ impl From<NonZeroU64> for NodeId {
 }
 
 /// A marker spanning a range within text.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -605,7 +605,7 @@ pub struct TextMarker {
 ///
 /// For example, a list UI can allow a user to reorder items in the list by dragging the
 /// items.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]
@@ -1315,7 +1315,7 @@ impl Node {
 
 /// The data associated with an accessibility tree that's global to the
 /// tree and not associated with any particular node.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(crate = "serde"))]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1431,6 +1431,7 @@ pub enum ActionData {
 pub struct ActionRequest {
     pub action: Action,
     pub target: NodeId,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub data: Option<ActionData>,
 }
 


### PR DESCRIPTION
Currently, serializing an `ActionRequest` with a `data` field set to `None` using `serde_json` gives this:

```
{"action":"default","target":2,"data":null}
```

The `data` field is useless in this case and I would need to modify some auto-generated code from JSON schema to let my program accept this kind of input.

So this PR adds the necessary `serde` attribute to the `data` field, which is inlined with what we already do in a lot of place. This one might just have been forgotten.