### PR TITLE
fix(common): Write a README specifically for the accesskit crate

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -1,1 +1,10 @@
-../README.md
+# AccessKit
+
+This is the shared cross-platform crate for [AccessKit](https://accesskit.dev/). It defines the data structures that represent an accessibility tree, and the trait for handling action requests from assistive technologies.
+
+To use AccessKit in your application or toolkit, you will also need a platform adapter. The following platform adapters are currently available:
+
+* [accesskit_windows](https://crates.io/crates/accesskit_windows): exposes an AccessKit tree on Windows using the UI Automation API
+* [accesskit_winit](https://crates.io/crates/accesskit_winit): wraps other platform adapters for use with the [winit](https://crates.io/crates/winit) windowing library
+
+All platform adapters include simple examples.


### PR DESCRIPTION
In the last two published versions of the crate, the README wasn't properly sent to the registry because I had set up the crate to use the top-level README via a symbolic link, but then published the crate on Windows, where (at least in my configuration) the symlink doesn't work. I could just publish this crate on Linux, as I did in previous versions, and even automate that step through CI. Ideally we should still do the latter. But I decided that this crate should have its own README, so I wrote one.

fixes #129