### PR TITLE
refactor(consumer)!: Optimize tree access and change handling

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 pub(crate) mod tree;
-pub use tree::{Change as TreeChange, State as TreeState, Tree};
+pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
 
 pub(crate) mod node;
 pub use node::Node;

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -4,10 +4,10 @@
 // the LICENSE-MIT file), at your option.
 
 pub(crate) mod tree;
-pub use tree::{Change as TreeChange, Reader as TreeReader, Tree};
+pub use tree::{Change as TreeChange, State as TreeState, Tree};
 
 pub(crate) mod node;
-pub use node::{Node, WeakNode};
+pub use node::Node;
 
 pub(crate) mod iterators;
 pub use iterators::{
@@ -44,7 +44,7 @@ mod tests {
         fn do_action(&self, _request: ActionRequest) {}
     }
 
-    pub fn test_tree() -> Arc<crate::tree::Tree> {
+    pub fn test_tree() -> crate::tree::Tree {
         let root = Arc::new(Node {
             role: Role::RootWebArea,
             children: vec![

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -54,12 +54,17 @@ impl<'a> Node<'a> {
         self.id() == self.tree_state.root_id()
     }
 
-    pub fn parent(self) -> Option<Node<'a>> {
+    pub fn parent_id(&self) -> Option<NodeId> {
         if let Some(ParentAndIndex(parent, _)) = &self.state.parent_and_index {
-            Some(self.tree_state.node_by_id(*parent).unwrap())
+            Some(*parent)
         } else {
             None
         }
+    }
+
+    pub fn parent(&self) -> Option<Node<'a>> {
+        self.parent_id()
+            .map(|id| self.tree_state.node_by_id(id).unwrap())
     }
 
     pub fn unignored_parent(self) -> Option<Node<'a>> {
@@ -83,17 +88,25 @@ impl<'a> Node<'a> {
             })
     }
 
+    pub fn child_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = NodeId>
+           + ExactSizeIterator<Item = NodeId>
+           + FusedIterator<Item = NodeId>
+           + 'a {
+        let data = &self.state.data;
+        data.children.iter().copied()
+    }
+
     pub fn children(
-        self,
+        &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
            + ExactSizeIterator<Item = Node<'a>>
            + FusedIterator<Item = Node<'a>>
            + 'a {
-        let data = &self.state.data;
         let state = self.tree_state;
-        data.children
-            .iter()
-            .map(move |id| state.node_by_id(*id).unwrap())
+        self.child_ids()
+            .map(move |id| state.node_by_id(id).unwrap())
     }
 
     pub fn unignored_children(
@@ -102,14 +115,24 @@ impl<'a> Node<'a> {
         UnignoredChildren::new(self)
     }
 
+    pub fn following_sibling_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = NodeId>
+           + ExactSizeIterator<Item = NodeId>
+           + FusedIterator<Item = NodeId>
+           + 'a {
+        FollowingSiblings::new(*self)
+    }
+
     pub fn following_siblings(
-        self,
+        &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
            + ExactSizeIterator<Item = Node<'a>>
            + FusedIterator<Item = Node<'a>>
            + 'a {
         let state = self.tree_state;
-        FollowingSiblings::new(self).map(move |id| state.node_by_id(id).unwrap())
+        self.following_sibling_ids()
+            .map(move |id| state.node_by_id(id).unwrap())
     }
 
     pub fn following_unignored_siblings(
@@ -118,14 +141,24 @@ impl<'a> Node<'a> {
         FollowingUnignoredSiblings::new(self)
     }
 
+    pub fn preceding_sibling_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = NodeId>
+           + ExactSizeIterator<Item = NodeId>
+           + FusedIterator<Item = NodeId>
+           + 'a {
+        PrecedingSiblings::new(*self)
+    }
+
     pub fn preceding_siblings(
-        self,
+        &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
            + ExactSizeIterator<Item = Node<'a>>
            + FusedIterator<Item = Node<'a>>
            + 'a {
         let state = self.tree_state;
-        PrecedingSiblings::new(self).map(move |id| state.node_by_id(id).unwrap())
+        self.preceding_sibling_ids()
+            .map(move |id| state.node_by_id(id).unwrap())
     }
 
     pub fn preceding_unignored_siblings(

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -55,11 +55,10 @@ impl<'a> Node<'a> {
     }
 
     pub fn parent_id(&self) -> Option<NodeId> {
-        if let Some(ParentAndIndex(parent, _)) = &self.state.parent_and_index {
-            Some(*parent)
-        } else {
-            None
-        }
+        self.state
+            .parent_and_index
+            .as_ref()
+            .map(|ParentAndIndex(id, _)| *id)
     }
 
     pub fn parent(&self) -> Option<Node<'a>> {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -229,17 +229,11 @@ impl State {
     }
 }
 
-pub enum Change<'a> {
-    NodeAdded(Node<'a>),
-    NodeUpdated {
-        old_node: Node<'a>,
-        new_node: Node<'a>,
-    },
-    FocusMoved {
-        old_node: Option<Node<'a>>,
-        new_node: Option<Node<'a>>,
-    },
-    NodeRemoved(Node<'a>),
+pub trait ChangeHandler {
+    fn node_added(&mut self, node: &Node);
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node);
+    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>);
+    fn node_removed(&mut self, node: &Node);
 }
 
 pub struct Tree {
@@ -266,10 +260,7 @@ impl Tree {
         state.update(update, None);
     }
 
-    pub fn update_and_process_changes<F>(&self, update: TreeUpdate, mut f: F)
-    where
-        for<'a> F: FnMut(Change<'a>),
-    {
+    pub fn update_and_process_changes(&self, update: TreeUpdate, handler: &mut impl ChangeHandler) {
         let mut changes = InternalChanges::default();
         let mut state = self.state.write();
         let old_state = state.clone();
@@ -277,12 +268,12 @@ impl Tree {
         let state = RwLockWriteGuard::downgrade(state);
         for id in &changes.added_node_ids {
             let node = state.node_by_id(*id).unwrap();
-            f(Change::NodeAdded(node));
+            handler.node_added(&node);
         }
         for id in &changes.updated_node_ids {
             let old_node = old_state.node_by_id(*id).unwrap();
             let new_node = state.node_by_id(*id).unwrap();
-            f(Change::NodeUpdated { old_node, new_node });
+            handler.node_updated(&old_node, &new_node);
         }
         if changes.focus_moved {
             let old_node = old_state.focus();
@@ -292,10 +283,7 @@ impl Tree {
                     && !changes.removed_node_ids.contains(&id)
                 {
                     if let Some(old_node_new_version) = state.node_by_id(id) {
-                        f(Change::NodeUpdated {
-                            old_node,
-                            new_node: old_node_new_version,
-                        });
+                        handler.node_updated(&old_node, &old_node_new_version);
                     }
                 }
             }
@@ -305,18 +293,15 @@ impl Tree {
                 if !changes.added_node_ids.contains(&id) && !changes.updated_node_ids.contains(&id)
                 {
                     if let Some(new_node_old_version) = old_state.node_by_id(id) {
-                        f(Change::NodeUpdated {
-                            old_node: new_node_old_version,
-                            new_node,
-                        });
+                        handler.node_updated(&new_node_old_version, &new_node);
                     }
                 }
             }
-            f(Change::FocusMoved { old_node, new_node });
+            handler.focus_moved(old_node.as_ref(), new_node.as_ref());
         }
         for id in &changes.removed_node_ids {
             let node = old_state.node_by_id(*id).unwrap();
-            f(Change::NodeRemoved(node));
+            handler.node_removed(&node);
         }
     }
 
@@ -463,28 +448,49 @@ mod tests {
             tree: None,
             focus: None,
         };
-        let mut got_updated_root_node = false;
-        let mut got_new_child_node = false;
-        tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::NodeUpdated { old_node, new_node } = &change {
+        struct Handler {
+            got_new_child_node: bool,
+            got_updated_root_node: bool,
+        }
+        fn unexpected_change() {
+            panic!("expected only new child node and updated root node");
+        }
+        impl super::ChangeHandler for Handler {
+            fn node_added(&mut self, node: &crate::Node) {
+                if node.id() == NODE_ID_2 {
+                    self.got_new_child_node = true;
+                    return;
+                }
+                unexpected_change();
+            }
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NODE_ID_1
                     && old_node.data().children == vec![]
                     && new_node.data().children == vec![NODE_ID_2]
                 {
-                    got_updated_root_node = true;
+                    self.got_updated_root_node = true;
                     return;
                 }
+                unexpected_change();
             }
-            if let super::Change::NodeAdded(node) = &change {
-                if node.id() == NODE_ID_2 {
-                    got_new_child_node = true;
-                    return;
-                }
+            fn focus_moved(
+                &mut self,
+                _old_node: Option<&crate::Node>,
+                _new_node: Option<&crate::Node>,
+            ) {
+                unexpected_change();
             }
-            panic!("expected only new child node and updated root node");
-        });
-        assert!(got_updated_root_node);
-        assert!(got_new_child_node);
+            fn node_removed(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+        }
+        let mut handler = Handler {
+            got_new_child_node: false,
+            got_updated_root_node: false,
+        };
+        tree.update_and_process_changes(second_update, &mut handler);
+        assert!(handler.got_new_child_node);
+        assert!(handler.got_updated_root_node);
         let state = tree.read();
         assert_eq!(1, state.root().children().count());
         assert_eq!(NODE_ID_2, state.root().children().next().unwrap().id());
@@ -527,28 +533,49 @@ mod tests {
             tree: None,
             focus: None,
         };
-        let mut got_updated_root_node = false;
-        let mut got_removed_child_node = false;
-        tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::NodeUpdated { old_node, new_node } = &change {
+        struct Handler {
+            got_updated_root_node: bool,
+            got_removed_child_node: bool,
+        }
+        fn unexpected_change() {
+            panic!("expected only removed child node and updated root node");
+        }
+        impl super::ChangeHandler for Handler {
+            fn node_added(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NODE_ID_1
                     && old_node.data().children == vec![NODE_ID_2]
                     && new_node.data().children == vec![]
                 {
-                    got_updated_root_node = true;
+                    self.got_updated_root_node = true;
                     return;
                 }
+                unexpected_change();
             }
-            if let super::Change::NodeRemoved(node) = &change {
+            fn focus_moved(
+                &mut self,
+                _old_node: Option<&crate::Node>,
+                _new_node: Option<&crate::Node>,
+            ) {
+                unexpected_change();
+            }
+            fn node_removed(&mut self, node: &crate::Node) {
                 if node.id() == NODE_ID_2 {
-                    got_removed_child_node = true;
+                    self.got_removed_child_node = true;
                     return;
                 }
+                unexpected_change();
             }
-            panic!("expected only removed child node and updated root node");
-        });
-        assert!(got_updated_root_node);
-        assert!(got_removed_child_node);
+        }
+        let mut handler = Handler {
+            got_updated_root_node: false,
+            got_removed_child_node: false,
+        };
+        tree.update_and_process_changes(second_update, &mut handler);
+        assert!(handler.got_updated_root_node);
+        assert!(handler.got_removed_child_node);
         assert_eq!(0, tree.read().root().children().count());
         assert!(tree.read().node_by_id(NODE_ID_2).is_none());
     }
@@ -590,17 +617,25 @@ mod tests {
             tree: None,
             focus: Some(NODE_ID_3),
         };
-        let mut got_old_focus_node_update = false;
-        let mut got_new_focus_node_update = false;
-        let mut got_focus_change = false;
-        tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::NodeUpdated { old_node, new_node } = change {
+        struct Handler {
+            got_old_focus_node_update: bool,
+            got_new_focus_node_update: bool,
+            got_focus_change: bool,
+        }
+        fn unexpected_change() {
+            panic!("expected only focus change");
+        }
+        impl super::ChangeHandler for Handler {
+            fn node_added(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if old_node.id() == NODE_ID_2
                     && new_node.id() == NODE_ID_2
                     && old_node.is_focused()
                     && !new_node.is_focused()
                 {
-                    got_old_focus_node_update = true;
+                    self.got_old_focus_node_update = true;
                     return;
                 }
                 if old_node.id() == NODE_ID_3
@@ -608,25 +643,37 @@ mod tests {
                     && !old_node.is_focused()
                     && new_node.is_focused()
                 {
-                    got_new_focus_node_update = true;
+                    self.got_new_focus_node_update = true;
                     return;
                 }
+                unexpected_change();
             }
-            if let super::Change::FocusMoved {
-                old_node: Some(old_node),
-                new_node: Some(new_node),
-            } = &change
-            {
-                if old_node.id() == NODE_ID_2 && new_node.id() == NODE_ID_3 {
-                    got_focus_change = true;
-                    return;
+            fn focus_moved(
+                &mut self,
+                old_node: Option<&crate::Node>,
+                new_node: Option<&crate::Node>,
+            ) {
+                if let (Some(old_node), Some(new_node)) = (old_node, new_node) {
+                    if old_node.id() == NODE_ID_2 && new_node.id() == NODE_ID_3 {
+                        self.got_focus_change = true;
+                        return;
+                    }
                 }
+                unexpected_change();
             }
-            panic!("expected only focus change");
-        });
-        assert!(got_old_focus_node_update);
-        assert!(got_new_focus_node_update);
-        assert!(got_focus_change);
+            fn node_removed(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+        }
+        let mut handler = Handler {
+            got_old_focus_node_update: false,
+            got_new_focus_node_update: false,
+            got_focus_change: false,
+        };
+        tree.update_and_process_changes(second_update, &mut handler);
+        assert!(handler.got_old_focus_node_update);
+        assert!(handler.got_new_focus_node_update);
+        assert!(handler.got_focus_change);
         assert!(tree.read().node_by_id(NODE_ID_3).unwrap().is_focused());
         assert!(!tree.read().node_by_id(NODE_ID_2).unwrap().is_focused());
     }
@@ -674,20 +721,42 @@ mod tests {
             tree: None,
             focus: None,
         };
-        let mut got_updated_child_node = false;
-        tree.update_and_process_changes(second_update, |change| {
-            if let super::Change::NodeUpdated { old_node, new_node } = &change {
+        struct Handler {
+            got_updated_child_node: bool,
+        }
+        fn unexpected_change() {
+            panic!("expected only updated child node");
+        }
+        impl super::ChangeHandler for Handler {
+            fn node_added(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NODE_ID_2
                     && old_node.name() == Some("foo".into())
                     && new_node.name() == Some("bar".into())
                 {
-                    got_updated_child_node = true;
+                    self.got_updated_child_node = true;
                     return;
                 }
+                unexpected_change();
             }
-            panic!("expected only updated child node");
-        });
-        assert!(got_updated_child_node);
+            fn focus_moved(
+                &mut self,
+                _old_node: Option<&crate::Node>,
+                _new_node: Option<&crate::Node>,
+            ) {
+                unexpected_change();
+            }
+            fn node_removed(&mut self, _node: &crate::Node) {
+                unexpected_change();
+            }
+        }
+        let mut handler = Handler {
+            got_updated_child_node: false,
+        };
+        tree.update_and_process_changes(second_update, &mut handler);
+        assert!(handler.got_updated_child_node);
         assert_eq!(
             Some("bar".into()),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -201,6 +201,10 @@ impl State {
         }
     }
 
+    pub fn has_node(&self, id: NodeId) -> bool {
+        self.nodes.contains_key(&id)
+    }
+
     pub fn node_by_id(&self, id: NodeId) -> Option<Node<'_>> {
         self.nodes.get(&id).map(|node_state| Node {
             tree_state: self,

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -126,8 +126,8 @@ impl Adapter {
                 TreeChange::NodeUpdated { old_node, new_node } => {
                     let platform_node = PlatformNode::new(tree, new_node.id(), self.hwnd);
                     let element: IRawElementProviderSimple = platform_node.into();
-                    let old_resolved_node = ResolvedPlatformNode::new(old_node, self.hwnd);
-                    let new_resolved_node = ResolvedPlatformNode::new(new_node, self.hwnd);
+                    let old_resolved_node = ResolvedPlatformNode::new(old_node);
+                    let new_resolved_node = ResolvedPlatformNode::new(new_node);
                     new_resolved_node.enqueue_property_changes(
                         &mut queue,
                         &element,

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -118,8 +118,8 @@ impl Adapter {
             fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
                 let platform_node = PlatformNode::new(self.tree, new_node.id(), self.hwnd);
                 let element: IRawElementProviderSimple = platform_node.into();
-                let old_wrapper = NodeWrapper::new(*old_node);
-                let new_wrapper = NodeWrapper::new(*new_node);
+                let old_wrapper = NodeWrapper::new(old_node);
+                let new_wrapper = NodeWrapper::new(new_node);
                 new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
                 if !new_node.is_invisible_or_ignored()
                     && new_node.name().is_some()

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -124,17 +124,21 @@ impl Adapter {
                     }
                 }
                 TreeChange::NodeUpdated { old_node, new_node } => {
-                    let old_platform_node = ResolvedPlatformNode::new(tree, old_node, self.hwnd);
-                    let new_platform_node = ResolvedPlatformNode::new(tree, new_node, self.hwnd);
-                    new_platform_node.enqueue_property_changes(&mut queue, &old_platform_node);
+                    let platform_node = PlatformNode::new(tree, new_node.id(), self.hwnd);
+                    let element: IRawElementProviderSimple = platform_node.into();
+                    let old_resolved_node = ResolvedPlatformNode::new(old_node, self.hwnd);
+                    let new_resolved_node = ResolvedPlatformNode::new(new_node, self.hwnd);
+                    new_resolved_node.enqueue_property_changes(
+                        &mut queue,
+                        &element,
+                        &old_resolved_node,
+                    );
                     if !new_node.is_invisible_or_ignored()
                         && new_node.name().is_some()
                         && new_node.live() != Live::Off
                         && (new_node.name() != old_node.name()
                             || new_node.live() != old_node.live())
                     {
-                        let element: IRawElementProviderSimple =
-                            new_platform_node.downgrade().into();
                         queue.push(QueuedEvent::Simple {
                             element,
                             event_id: UIA_LiveRegionChangedEventId,

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -14,7 +14,7 @@ use windows::Win32::{
 };
 
 use crate::{
-    node::{PlatformNode, ResolvedPlatformNode},
+    node::{NodeWrapper, PlatformNode},
     util::QueuedEvent,
 };
 
@@ -126,13 +126,9 @@ impl Adapter {
                 TreeChange::NodeUpdated { old_node, new_node } => {
                     let platform_node = PlatformNode::new(tree, new_node.id(), self.hwnd);
                     let element: IRawElementProviderSimple = platform_node.into();
-                    let old_resolved_node = ResolvedPlatformNode::new(old_node);
-                    let new_resolved_node = ResolvedPlatformNode::new(new_node);
-                    new_resolved_node.enqueue_property_changes(
-                        &mut queue,
-                        &element,
-                        &old_resolved_node,
-                    );
+                    let old_wrapper = NodeWrapper::new(old_node);
+                    let new_wrapper = NodeWrapper::new(new_node);
+                    new_wrapper.enqueue_property_changes(&mut queue, &element, &old_wrapper);
                     if !new_node.is_invisible_or_ignored()
                         && new_node.name().is_some()
                         && new_node.live() != Live::Off

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -37,11 +37,11 @@ fn runtime_id_from_node_id(id: NodeId) -> impl std::ops::Deref<Target = [i32]> {
 }
 
 pub(crate) struct NodeWrapper<'a> {
-    node: Node<'a>,
+    node: &'a Node<'a>,
 }
 
 impl<'a> NodeWrapper<'a> {
-    pub(crate) fn new(node: Node<'a>) -> Self {
+    pub(crate) fn new(node: &'a Node<'a>) -> Self {
         Self { node }
     }
 
@@ -484,7 +484,7 @@ impl PlatformNode {
         let tree = self.upgrade_tree()?;
         let state = tree.read();
         if let Some(node) = state.node_by_id(self.node_id) {
-            f(NodeWrapper::new(node))
+            f(NodeWrapper::new(&node))
         } else {
             Err(element_not_available())
         }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -552,8 +552,8 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
     }
 
     fn HostRawElementProvider(&self) -> Result<IRawElementProviderSimple> {
-        self.resolve(|wrapper| {
-            if wrapper.node.is_root() {
+        self.with_tree_state(|state| {
+            if self.node_id == state.root_id() {
                 unsafe { UiaHostProviderFromHwnd(self.hwnd) }
             } else {
                 Err(Error::OK)

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -592,7 +592,7 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
         let result = if root_id == self.node_id {
             self.clone()
         } else {
-            PlatformNode::new(&tree, root_id, self.hwnd)
+            self.relative(root_id)
         };
         Ok(result.into())
     }
@@ -621,7 +621,7 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
         let state = tree.read();
         if let Some(id) = state.focus_id() {
             if id != self.node_id {
-                return Ok(PlatformNode::new(&tree, id, self.hwnd).into());
+                return Ok(self.relative(id).into());
             }
         }
         Err(Error::OK)

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -430,13 +430,13 @@ impl<'a> NodeWrapper<'a> {
         });
     }
 
-    fn navigate(&self, direction: NavigateDirection) -> Option<Node> {
+    fn navigate(&self, direction: NavigateDirection) -> Option<NodeId> {
         match direction {
-            NavigateDirection_Parent => self.node.parent(),
-            NavigateDirection_NextSibling => self.node.following_siblings().next(),
-            NavigateDirection_PreviousSibling => self.node.preceding_siblings().next(),
-            NavigateDirection_FirstChild => self.node.children().next(),
-            NavigateDirection_LastChild => self.node.children().next_back(),
+            NavigateDirection_Parent => self.node.parent_id(),
+            NavigateDirection_NextSibling => self.node.following_sibling_ids().next(),
+            NavigateDirection_PreviousSibling => self.node.preceding_sibling_ids().next(),
+            NavigateDirection_FirstChild => self.node.child_ids().next(),
+            NavigateDirection_LastChild => self.node.child_ids().next_back(),
             _ => None,
         }
     }
@@ -565,7 +565,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
 impl IRawElementProviderFragment_Impl for PlatformNode {
     fn Navigate(&self, direction: NavigateDirection) -> Result<IRawElementProviderFragment> {
         self.resolve(|wrapper| match wrapper.navigate(direction) {
-            Some(result) => Ok(self.relative(result.id()).into()),
+            Some(result) => Ok(self.relative(result).into()),
             None => Err(Error::OK),
         })
     }


### PR DESCRIPTION
This PR has the following high-level design changes:

* Removed `WeakNode` from `accesskit_consumer`. I found that this approach forced AccessKit to do the full node lookup process whether or not it was necessary for a particular platform adapter method. Also, for some future uses of `accesskit_consumer`, such as an in-process self-voicing module, something like `WeakNode` won't be needed at all.
* In `accesskit_consumer`, the methods to perform actions are now on `Tree` rather than `Node`. This change combined with the previous one means that `Node` no longer needs a reference (whether direct or indirect) back to `Tree`.
* As a result of these changes, we can drop the `TreeReader` struct. `Node` only needs a reference to `tree::State`, which is now exported as `TreeState`, and `Tree::read` now returns the `RwLock` read guard as an opaque object that dereferences to `TreeState`.
* `Tree::update_and_process_changes` now takes an implementation of a trait with multiple functions, rather than a single closure. The functions in this trait correspond to the variants of the old `Change` enum. This way, the compiler can separately decide whether to inline each function at the place(s) where it's called, instead of having to work with one big closure that does pattern-matching.
* The consumer API now avoids copying node IDs in function parameters and return values.
* `accesskit_consumer::Node` has new methods for returning parent, child, and sibling IDs, without resolving them to full nodes. This is only possible when not checking the node's ignored status.
* Dropped the `FollowingSiblings` and `PrecedingSiblings` iterator implementations; we can just use slices.
* The remaining iterators are no longer exported separately. These should be internal implementation details.

There are also many changes to the Windows platform adapter to take advantage of these design changes, and some smaller optimizations. Some UIA method implementations no longer need to look up a full node. In a few cases, this PR reverses a previous decision to resolve the node even though we didn't need to, because I now think that the optimization benefit outweighs the theoretical risk of leaking implementation details about how we handle nodes that no longer exist.