### PR TITLE
fix(consumer): Drop printing of detached nodes before panic

### DIFF
--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -134,13 +134,7 @@ impl State {
             }
         }
 
-        if !pending_nodes.is_empty() {
-            for (node_id, data) in &pending_nodes {
-                println!("unattached: {:?} {:?}", node_id, data.role);
-            }
-            panic!("unattached nodes");
-        }
-
+        assert_eq!(pending_nodes.len(), 0);
         assert_eq!(pending_children.len(), 0);
 
         if update.focus != self.focus {


### PR DESCRIPTION
This is an easy fix. It removes some debug printing that I added early in the development of AccessKit, that was active even in release builds.