### PR TITLE
refactor(consumer)!: Make `Node::data` private to the crate

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -3,8 +3,6 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-pub use accesskit::{Node as NodeData, Tree as TreeData};
-
 pub(crate) mod tree;
 pub use tree::{Change as TreeChange, Reader as TreeReader, Tree};
 

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -13,7 +13,8 @@ use std::sync::{Arc, Weak};
 
 use accesskit::kurbo::{Affine, Point, Rect};
 use accesskit::{
-    Action, ActionData, ActionRequest, CheckedState, DefaultActionVerb, Live, NodeId, Role,
+    Action, ActionData, ActionRequest, CheckedState, DefaultActionVerb, Live, Node as NodeData,
+    NodeId, Role,
 };
 
 use crate::iterators::{
@@ -21,7 +22,6 @@ use crate::iterators::{
     UnignoredChildren,
 };
 use crate::tree::{NodeState, ParentAndIndex, Reader as TreeReader, Tree};
-use crate::NodeData;
 
 #[derive(Copy, Clone)]
 pub struct Node<'a> {
@@ -30,7 +30,7 @@ pub struct Node<'a> {
 }
 
 impl<'a> Node<'a> {
-    pub fn data(&self) -> &NodeData {
+    pub(crate) fn data(&self) -> &NodeData {
         &self.state.data
     }
 
@@ -275,8 +275,6 @@ impl<'a> Node<'a> {
             })
     }
 
-    // Convenience getters
-
     pub fn id(&self) -> NodeId {
         self.state.id
     }
@@ -485,6 +483,10 @@ impl<'a> Node<'a> {
         self.data()
             .live
             .unwrap_or_else(|| self.parent().map_or(Live::Off, |parent| parent.live()))
+    }
+
+    pub fn is_selected(&self) -> Option<bool> {
+        self.data().selected
     }
 
     pub(crate) fn first_unignored_child(self) -> Option<Node<'a>> {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,12 +3,12 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, NodeId, TreeUpdate};
+use accesskit::{ActionHandler, Node as NodeData, NodeId, Tree as TreeData, TreeUpdate};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use crate::{Node, NodeData, TreeData};
+use crate::Node;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -357,7 +357,7 @@ impl ResolvedPlatformNode<'_> {
             | Role::ListItem
             | Role::MenuListOption
             | Role::Tab
-            | Role::TreeItem => self.node.data().selected.is_some(),
+            | Role::TreeItem => self.node.is_selected().is_some(),
             _ => false,
         }
     }
@@ -385,7 +385,7 @@ impl ResolvedPlatformNode<'_> {
             // https://www.w3.org/TR/wai-aria-1.1/#aria-selected
             // SelectionItem.IsSelected is set according to the True or False
             // value of aria-selected.
-            _ => self.node.data().selected.unwrap_or(false),
+            _ => self.node.is_selected().unwrap_or(false),
         }
     }
 


### PR DESCRIPTION
This way, when we switch from a big `Node` struct with many fields, to something with getter methods, the platform adapters won't be affected. This was already almost true; I just had to expose the `selected` field.

This PR also drops unnecessary exports of `accesskit::Node` and `accesskit::Tree` as `NodeData` and `TreeData`. Users of the consumer crate should not be concerned with these structs.