### PR TITLE
fix(consumer): Don't compare node contents during tree update

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1198,6 +1198,12 @@ impl Tree {
 /// The sender and receiver must be in sync; the update is only meant
 /// to bring the tree from a specific previous state into its next state.
 /// Trying to apply it to the wrong tree should immediately panic.
+///
+/// Note that for performance, an update should only include nodes that are
+/// new or changed. AccessKit platform adapters will avoid raising extraneous
+/// events for nodes that have not changed since the previous update,
+/// but there is still a cost in processing these nodes and replacing
+/// the previous instances.
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -113,11 +113,9 @@ impl State {
                         orphans.insert(*child_id);
                     }
                 }
-                if *node_state.data != *node_data {
-                    node_state.data = node_data;
-                    if let Some(changes) = &mut changes {
-                        changes.updated_node_ids.insert(node_id);
-                    }
+                node_state.data = node_data;
+                if let Some(changes) = &mut changes {
+                    changes.updated_node_ids.insert(node_id);
                 }
             } else if let Some(parent_and_index) = pending_children.remove(&node_id) {
                 add_node(
@@ -675,45 +673,5 @@ mod tests {
             Some("bar".into()),
             tree.read().node_by_id(NODE_ID_2).unwrap().name()
         );
-    }
-
-    // Verify that if an update consists entirely of node data and tree data
-    // that's the same as before, no changes are reported. This would be useful
-    // for a provider that constructs a fresh tree every time, such as
-    // an immediate-mode GUI.
-    #[test]
-    fn no_change_update() {
-        let update = TreeUpdate {
-            nodes: vec![
-                (
-                    NODE_ID_1,
-                    Arc::new(Node {
-                        role: Role::Window,
-                        children: vec![NODE_ID_2, NODE_ID_3],
-                        ..Default::default()
-                    }),
-                ),
-                (
-                    NODE_ID_2,
-                    Arc::new(Node {
-                        role: Role::Button,
-                        ..Default::default()
-                    }),
-                ),
-                (
-                    NODE_ID_3,
-                    Arc::new(Node {
-                        role: Role::Button,
-                        ..Default::default()
-                    }),
-                ),
-            ],
-            tree: Some(Tree::new(NODE_ID_1)),
-            focus: Some(NODE_ID_2),
-        };
-        let tree = super::Tree::new(update.clone(), Box::new(NullActionHandler {}));
-        tree.update_and_process_changes(update, |_| {
-            panic!("expected no changes");
-        });
     }
 }


### PR DESCRIPTION
I'm making this change for two reasons:

* Comparing instances of the current, huge `Node` struct is expensive. Eliminating this comparison reduces the size of the Windows example by several kilobytes, whether optimizing for speed or size.
* When I implement the transition to a `Node` trait, comparing across implementations of that trait would be even more expensive, since it would require dynamically dispatched method calls for every property.

This change does eliminate an optimization for immediate-mode GUIs. But honestly, sending a whole tree for every frame isn't good enough for performance anyway; if nothing else, it wastes memory allocations. So I think toolkits will just have to do their own optimizations to avoid sending full trees unnecessarily.