### PR TITLE
fix(platforms/winit): Derive `Debug` on `ActionRequestEvent`

### DIFF
--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -11,6 +11,7 @@ use winit::{
 
 mod platform_impl;
 
+#[derive(Debug)]
 pub struct ActionRequestEvent {
     pub window_id: WindowId,
     pub request: ActionRequest,


### PR DESCRIPTION
I need this for my egui integration, because egui's official winit integration expects the user event type to derive `Debug`. And of course, this is good to have anyway.