### PR TITLE
refactor!: Drop the `ignored` field and implement generic filtered tree traversal

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -748,16 +748,11 @@ pub struct Node {
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
     pub hovered: bool,
-    /// Skip over this node in the accessibility tree, but keep its subtree.
-    ///
-    /// This flag also indicates that this node, but not its descendants,
-    /// should be skipped when hit testing.
+    /// Exclude this node and its descendants from the tree presented to
+    /// assistive technologies, and from hit testing.
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
-    pub ignored: bool,
-    #[cfg_attr(feature = "serde", serde(default))]
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
-    pub invisible: bool,
+    pub hidden: bool,
     #[cfg_attr(feature = "serde", serde(default))]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "is_false"))]
     pub linked: bool,

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -10,10 +10,7 @@ pub(crate) mod node;
 pub use node::Node;
 
 pub(crate) mod iterators;
-pub use iterators::{
-    FollowingSiblings, FollowingUnignoredSiblings, PrecedingSiblings, PrecedingUnignoredSiblings,
-    UnignoredChildren,
-};
+pub use iterators::FilterResult;
 
 #[cfg(test)]
 mod tests {
@@ -21,6 +18,8 @@ mod tests {
     use accesskit::{ActionHandler, ActionRequest, Node, NodeId, Role, Tree, TreeUpdate};
     use std::num::NonZeroU128;
     use std::sync::Arc;
+
+    use crate::FilterResult;
 
     pub const ROOT_ID: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(1) });
     pub const PARAGRAPH_0_ID: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(2) });
@@ -62,7 +61,6 @@ mod tests {
         });
         let static_text_0_0_ignored = Arc::new(Node {
             role: Role::StaticText,
-            ignored: true,
             name: Some("static_text_0_0_ignored".into()),
             ..Default::default()
         });
@@ -76,7 +74,6 @@ mod tests {
                 y1: 40.0,
             }),
             children: vec![STATIC_TEXT_1_0_ID],
-            ignored: true,
             ..Default::default()
         });
         let static_text_1_0 = Arc::new(Node {
@@ -108,18 +105,15 @@ mod tests {
                 BUTTON_3_2_ID,
                 EMPTY_CONTAINER_3_3_IGNORED_ID,
             ],
-            ignored: true,
             ..Default::default()
         });
         let empty_container_3_0_ignored = Arc::new(Node {
             role: Role::GenericContainer,
-            ignored: true,
             ..Default::default()
         });
         let link_3_1_ignored = Arc::new(Node {
             role: Role::Link,
             children: vec![STATIC_TEXT_3_1_0_ID],
-            ignored: true,
             linked: true,
             ..Default::default()
         });
@@ -135,7 +129,6 @@ mod tests {
         });
         let empty_container_3_3_ignored = Arc::new(Node {
             role: Role::GenericContainer,
-            ignored: true,
             ..Default::default()
         });
         let initial_update = TreeUpdate {
@@ -158,5 +151,20 @@ mod tests {
             focus: None,
         };
         crate::tree::Tree::new(initial_update, Box::new(NullActionHandler {}))
+    }
+
+    pub fn test_tree_filter(node: &crate::Node) -> FilterResult {
+        let id = node.id();
+        if id == STATIC_TEXT_0_0_IGNORED_ID
+            || id == PARAGRAPH_1_IGNORED_ID
+            || id == PARAGRAPH_3_IGNORED_ID
+            || id == EMPTY_CONTAINER_3_0_IGNORED_ID
+            || id == LINK_3_1_IGNORED_ID
+            || id == EMPTY_CONTAINER_3_3_IGNORED_ID
+        {
+            FilterResult::ExcludeNode
+        } else {
+            FilterResult::Include
+        }
     }
 }


### PR DESCRIPTION
I think the `ignored` field doesn't belong in the schema. Toolkit and application developers shouldn't be required to indicate which nodes should be excluded from the platform tree. This highlights a difference in design requirements between AccessKit and the Chromium accessibility schema; the latter is only intended for internal use within Chromium, not to be approachable to arbitrary toolkit or application developers.

Also, the criteria for determining which nodes should be excluded from the platform tree may be platform-dependent. And there may be cases where we want to traverse only the nodes that meet very specific criteria. So I believe we need to modify `following_unignored_siblings` and related functions to take a caller-supplied filter function.

It was convenient to mark arbitrary nodes as ignored for our tests, but we can accomplish the same thing using a test-only filter function alongside the test tree.

This PR does reverse an earlier optimization in the Windows adapter, that allowed it to navigate without resolving the target node. But this change enables a bigger optimization. By completely filtering out nodes that UIA clients don't need to see, we eliminate the process of allocating a platform node object, returning it, then going through all the steps for resolving the node when UIA calls a method like GetPropertyValue, all for a node that the UIA client doesn't need to see in the first place. This change will become important when we have numerous inline text box nodes, which don't need to be exposed as UIA elements. The same principle will likely apply to other platform adapters.