### PR TITLE
fix(platforms/windows)!: Update to windows-rs 0.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,25 +1311,25 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30acc718a52fb130fec72b1cb5f55ffeeec9253e1b785e94db222178a6acaa1"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
 dependencies = [
  "windows-implement",
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.40.0",
- "windows_i686_gnu 0.40.0",
- "windows_i686_msvc 0.40.0",
- "windows_x86_64_gnu 0.40.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.40.0",
+ "windows_x86_64_msvc 0.42.0",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078aff1e315cc3932851b545753a980803445ee0c15b10bcac3fe80a1803eaa"
+checksum = "9539b6bd3eadbd9de66c9666b22d802b833da7e996bc06896142e09854a61767"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1351,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3caa4a1a16561b714323ca6b0817403738583033a6a92e04c5d10d4ba37ca10"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1363,9 +1363,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328973c62dfcc50fb1aaa8e7100676e0b642fe56bac6bafff3327902db843ab4"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1375,9 +1375,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5b09fad70f0df85dea2ac2a525537e415e2bf63ee31cf9b8e263645ee9f3c1"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1387,9 +1387,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1ad4031c1a98491fa195d8d43d7489cb749f135f2e5c4eed58da094bd0d876"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1399,15 +1399,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520ff37edd72da8064b49d2281182898e17f0688ae9f4070bca27e4b5c162ac7"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046e5b82215102c44fd75f488f1b9158973d02aa34d06ed85c23d6f5520a2853"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1417,9 +1417,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0c9c6df55dd1bfa76e131cef44bdd8ec9c819ef3611f04dfe453fd5bfeda28"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winit"

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -19,7 +19,7 @@ parking_lot = "0.12.1"
 paste = "1.0"
 
 [dependencies.windows]
-version = "0.40.0"
+version = "0.42.0"
 features = [
     "implement",
     "Win32_Foundation",

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -344,7 +344,7 @@ fn create_window(title: &str, initial_state: TreeUpdate, initial_focus: NodeId) 
             None,
             None,
             *WIN32_INSTANCE,
-            Box::into_raw(create_params) as _,
+            Some(Box::into_raw(create_params) as _),
         )
     };
     if window.0 == 0 {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -68,7 +68,7 @@ impl<'a> NodeWrapper<'a> {
         Self { node }
     }
 
-    fn control_type(&self) -> i32 {
+    fn control_type(&self) -> UIA_CONTROLTYPE_ID {
         let role = self.node.role();
         // TODO: Handle special cases. (#14)
         match role {
@@ -453,7 +453,7 @@ impl<'a> NodeWrapper<'a> {
         &self,
         queue: &mut Vec<QueuedEvent>,
         element: &IRawElementProviderSimple,
-        property_id: i32,
+        property_id: UIA_PROPERTY_ID,
         old_value: VariantFactory,
         new_value: VariantFactory,
     ) {
@@ -572,11 +572,11 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
         Ok(ProviderOptions_ServerSideProvider)
     }
 
-    fn GetPatternProvider(&self, pattern_id: i32) -> Result<IUnknown> {
+    fn GetPatternProvider(&self, pattern_id: UIA_PATTERN_ID) -> Result<IUnknown> {
         self.pattern_provider(pattern_id)
     }
 
-    fn GetPropertyValue(&self, property_id: i32) -> Result<VARIANT> {
+    fn GetPropertyValue(&self, property_id: UIA_PROPERTY_ID) -> Result<VARIANT> {
         self.resolve(|wrapper| {
             let result = wrapper.get_property_value(property_id);
             Ok(result.into())
@@ -676,7 +676,7 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
 macro_rules! properties {
     ($(($base_id:ident, $m:ident)),+) => {
         impl NodeWrapper<'_> {
-            fn get_property_value(&self, property_id: i32) -> VariantFactory {
+            fn get_property_value(&self, property_id: UIA_PROPERTY_ID) -> VariantFactory {
                 match property_id {
                     $(paste! { [< UIA_ $base_id PropertyId>] } => {
                         self.$m().into()
@@ -715,7 +715,7 @@ macro_rules! patterns {
         $($extra_trait_method:item),*
     ))),+) => {
         impl PlatformNode {
-            fn pattern_provider(&self, pattern_id: i32) -> Result<IUnknown> {
+            fn pattern_provider(&self, pattern_id: UIA_PATTERN_ID) -> Result<IUnknown> {
                 self.resolve(|wrapper| {
                     match pattern_id {
                         $(paste! { [< UIA_ $base_pattern_id PatternId>] } => {

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -174,7 +174,7 @@ fn create_window(
             None,
             None,
             *WIN32_INSTANCE,
-            Box::into_raw(create_params) as _,
+            Some(Box::into_raw(create_params) as _),
         )
     };
     if window.0 == 0 {
@@ -263,7 +263,7 @@ where
         // of UIA works even if it is set up in an environment where COM
         // has not been initialized, and that this sequence of events
         // doesn't prevent the UIA client from working.
-        unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED) }.unwrap();
+        unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }.unwrap();
         let _com_guard = scopeguard::guard((), |_| unsafe { CoUninitialize() });
 
         let uia: IUIAutomation =

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -77,7 +77,7 @@ fn is_button_named(element: &IUIAutomationElement, expected_name: &str) -> bool 
     let control_type = unsafe { element.CurrentControlType() }.unwrap();
     let name = unsafe { element.CurrentName() }.unwrap();
     let name: String = name.try_into().unwrap();
-    control_type == UIA_ButtonControlTypeId && name == expected_name
+    control_type == (UIA_ButtonControlTypeId.0 as i32) && name == expected_name
 }
 
 fn is_button_1(element: &IUIAutomationElement) -> bool {

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -413,6 +413,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
     }
 
     fn GetAttributeValue(&self, id: i32) -> Result<VARIANT> {
+        let id = UIA_TEXTATTRIBUTE_ID(id as _);
         match id {
             UIA_IsReadOnlyAttributeId => {
                 // TBD: do we ever want to support mixed read-only/editable text?

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -108,6 +108,12 @@ impl From<CaretPosition> for VariantFactory {
     }
 }
 
+impl From<UIA_CONTROLTYPE_ID> for VariantFactory {
+    fn from(value: UIA_CONTROLTYPE_ID) -> Self {
+        (value.0 as i32).into()
+    }
+}
+
 const VARIANT_FALSE: i16 = 0i16;
 const VARIANT_TRUE: i16 = -1i16;
 
@@ -164,11 +170,11 @@ pub(crate) fn safe_array_from_com_slice(slice: &[IUnknown]) -> *mut SAFEARRAY {
 pub(crate) enum QueuedEvent {
     Simple {
         element: IRawElementProviderSimple,
-        event_id: i32,
+        event_id: UIA_EVENT_ID,
     },
     PropertyChanged {
         element: IRawElementProviderSimple,
-        property_id: i32,
+        property_id: UIA_PROPERTY_ID,
         old_value: VARIANT,
         new_value: VARIANT,
     },

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -19,7 +19,7 @@ winit = "0.27.3"
 accesskit_windows = { version = "0.7.0", path = "../windows" }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.40.0"
+version = "0.42.0"
 features = [
     "Win32_Foundation",
 ]


### PR DESCRIPTION
I'm not updating to 0.43.0 at this time because my actual goal in making this change now is to satisfy egui's CI, particularly the requirement that the egui workspace not have multiple versions of the same crate, and to do that, we need to use windows-rs 0.42.0.