### PR TITLE
feat(platforms/winit): Allow a custom action handler

### DIFF
--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -47,7 +47,19 @@ impl Adapter {
             window_id: window.id(),
             proxy: Mutex::new(event_loop_proxy),
         };
-        let adapter = platform_impl::Adapter::new(window, source, Box::new(action_handler));
+        Self::with_action_handler(window, source, Box::new(action_handler))
+    }
+
+    /// Use this if you need to provide your own AccessKit action handler
+    /// rather than dispatching action requests through the winit event loop.
+    /// Remember that an AccessKit action handler can be called on any thread,
+    /// depending on the underlying AccessKit platform adapter.
+    pub fn with_action_handler(
+        window: &Window,
+        source: Box<dyn FnOnce() -> TreeUpdate + Send>,
+        action_handler: Box<dyn ActionHandler>,
+    ) -> Self {
+        let adapter = platform_impl::Adapter::new(window, source, action_handler);
         Self { adapter }
     }
 


### PR DESCRIPTION
When integrating AccessKit with some winit-based projects, such as the Bevy game engine, it's more convenient to define a custom implementation of the `ActionHandler` trait than to plumb a winit `EventHandlerProxy` that supports a custom user event type. It's easy to refactor the winit adapter to allow this.