### PR TITLE
refactor(consumer)!: Eliminate the dependency on `im` due to licensing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,6 @@ name = "accesskit_consumer"
 version = "0.7.1"
 dependencies = [
  "accesskit",
- "im",
  "parking_lot",
 ]
 
@@ -83,15 +82,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "block"
@@ -462,20 +452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,21 +813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,16 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slotmap"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,12 +1070,6 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-xid"

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -12,5 +12,4 @@ edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.7.0", path = "../common" }
-im = "15.0.0"
 parking_lot = "0.12.1"

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -7,7 +7,7 @@ pub(crate) mod tree;
 pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
 
 pub(crate) mod node;
-pub use node::Node;
+pub use node::{DetachedNode, Node, NodeState};
 
 pub(crate) mod iterators;
 pub use iterators::FilterResult;


### PR DESCRIPTION
The `im` crate is under the MPL, which isn't permissive enough for some users. To eliminate the dependency on this crate, we can no longer have a complete snapshot of the old version of the tree when processing tree changes. So we need to introduce the concept of a detached node, and create detached nodes for the old versions of nodes that have been changed or removed.

In the Windows adapter, this change also clarifies the purpose of `NodeWrapper`; that type (now an enum) is now only used when we might need to get a property of a detached node.