### PR TITLE
fix(platforms/winit): Eliminate some problematic indirect dependencies

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 accesskit = { version = "0.7.0", path = "../../common" }
 parking_lot = "0.12.1"
-winit = "0.27.3"
+winit = { version = "0.27.3", default-features = false, features = ["x11", "wayland", "wayland-dlopen"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.8.0", path = "../windows" }
@@ -23,3 +23,6 @@ version = "0.42.0"
 features = [
     "Win32_Foundation",
 ]
+
+[dev-dependencies]
+winit = "0.27.3"


### PR DESCRIPTION
winit's wayland-csd-adwaita feature, which is enabled by default, introduces some dependencies which are rejected by the Bevy game engine's CI. So the accesskit_winit crate now disables this feature. But users of accesskit_winit can still enable this feature if they want.