### PR TITLE
fix(platforms/windows): Re-export the windows-rs HWND type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "accesskit_macos",
  "accesskit_windows",
  "parking_lot",
- "windows",
  "winit",
 ]
 

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -13,5 +13,7 @@ pub use adapter::{Adapter, QueuedEvents};
 mod subclass;
 pub use subclass::SubclassingAdapter;
 
+pub use windows::Win32::Foundation::HWND;
+
 #[cfg(test)]
 mod tests;

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -18,12 +18,6 @@ winit = { version = "0.27.3", default-features = false, features = ["x11", "wayl
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.9.0", path = "../windows" }
 
-[target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.42.0"
-features = [
-    "Win32_Foundation",
-]
-
 [target.'cfg(target_os = "macos")'.dependencies]
 accesskit_macos = { version = "0.0.0", path = "../macos" }
 

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -3,8 +3,7 @@
 // the LICENSE-APACHE file).
 
 use accesskit::{ActionHandler, TreeUpdate};
-use accesskit_windows::{Adapter as WindowsAdapter, SubclassingAdapter};
-use windows::Win32::Foundation::HWND;
+use accesskit_windows::{Adapter as WindowsAdapter, SubclassingAdapter, HWND};
 use winit::{platform::windows::WindowExtWindows, window::Window};
 
 pub struct Adapter {


### PR DESCRIPTION
This simplifies dependency maintenance in downstream crates, including our own `accesskit_winit`.