### PR TITLE
fix(platforms/windows): Re-export more types from windows-rs

### DIFF
--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -13,7 +13,7 @@ pub use adapter::{Adapter, QueuedEvents};
 mod subclass;
 pub use subclass::SubclassingAdapter;
 
-pub use windows::Win32::Foundation::HWND;
+pub use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
I forgot that for a clean integration that doesn't require window subclassing, the caller needs more types from windows-rs.