### PR TITLE
fix(platforms/windows): Change default minimum and maximum for range value pattern

### DIFF
--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -379,13 +379,13 @@ impl<'a> NodeWrapper<'a> {
     fn min_numeric_value(&self) -> f64 {
         self.node_state()
             .min_numeric_value()
-            .unwrap_or(std::f64::MIN)
+            .unwrap_or(0.0)
     }
 
     fn max_numeric_value(&self) -> f64 {
         self.node_state()
             .max_numeric_value()
-            .unwrap_or(std::f64::MAX)
+            .unwrap_or(0.0)
     }
 
     fn numeric_value_step(&self) -> f64 {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -377,15 +377,11 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn min_numeric_value(&self) -> f64 {
-        self.node_state()
-            .min_numeric_value()
-            .unwrap_or(0.0)
+        self.node_state().min_numeric_value().unwrap_or(0.0)
     }
 
     fn max_numeric_value(&self) -> f64 {
-        self.node_state()
-            .max_numeric_value()
-            .unwrap_or(0.0)
+        self.node_state().max_numeric_value().unwrap_or(0.0)
     }
 
     fn numeric_value_step(&self) -> f64 {


### PR DESCRIPTION
Narrator doesn't read a spinner if the minimum and maximum values are set to negative and positive infinity. So, following the example set by Edge, the default minimum and maximum are now both 0. Of course, it's better for a toolkit to expose the minimum and maximum if they're set.