### PR TITLE
fix(consumer): Allow editable spin buttons

### DIFF
--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -737,7 +737,10 @@ impl<'a> Node<'a> {
 
     pub fn supports_text_ranges(&self) -> bool {
         let role = self.role();
-        if role != Role::StaticText && role != Role::TextField && role != Role::Document {
+        if !matches!(
+            role,
+            Role::StaticText | Role::TextField | Role::Document | Role::SpinButton
+        ) {
             return false;
         }
         self.inline_text_boxes().next().is_some()

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -736,14 +736,10 @@ impl<'a> Node<'a> {
     }
 
     pub fn supports_text_ranges(&self) -> bool {
-        let role = self.role();
-        if !matches!(
-            role,
+        matches!(
+            self.role(),
             Role::StaticText | Role::TextField | Role::Document | Role::SpinButton
-        ) {
-            return false;
-        }
-        self.inline_text_boxes().next().is_some()
+        ) && self.inline_text_boxes().next().is_some()
     }
 
     fn document_start(&self) -> InnerPosition<'a> {


### PR DESCRIPTION
On Windows, spin buttons are usually editable, and JAWS assumes that they are. So this PR adds spin buttons to the set of roles that can support text ranges.