### PR TITLE
fix: Gracefully handle nodes that only support text ranges some of the time

### DIFF
--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -652,7 +652,9 @@ impl WeakRange {
     }
 
     pub fn upgrade_node<'a>(&self, tree_state: &'a TreeState) -> Option<Node<'a>> {
-        tree_state.node_by_id(self.node_id)
+        tree_state
+            .node_by_id(self.node_id)
+            .filter(Node::supports_text_ranges)
     }
 
     pub fn upgrade<'a>(&self, tree_state: &'a TreeState) -> Option<Range<'a>> {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -554,7 +554,10 @@ impl PlatformNode {
         for<'a> F: FnOnce(Node<'a>) -> Result<T>,
     {
         self.with_tree_state(|state| {
-            if let Some(node) = state.node_by_id(self.node_id).filter(Node::supports_text_ranges) {
+            if let Some(node) = state
+                .node_by_id(self.node_id)
+                .filter(Node::supports_text_ranges)
+            {
                 f(node)
             } else {
                 Err(element_not_available())

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -549,6 +549,19 @@ impl PlatformNode {
         })
     }
 
+    fn resolve_for_text_pattern<F, T>(&self, f: F) -> Result<T>
+    where
+        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+    {
+        self.with_tree_state(|state| {
+            if let Some(node) = state.node_by_id(self.node_id).filter(Node::supports_text_ranges) {
+                f(node)
+            } else {
+                Err(element_not_available())
+            }
+        })
+    }
+
     fn validate_for_action(&self) -> Result<Arc<Tree>> {
         let tree = self.upgrade_tree()?;
         let state = tree.read();
@@ -868,7 +881,7 @@ patterns! {
     )),
     (Text, is_text_pattern_supported, (), (
         fn GetSelection(&self) -> Result<*mut SAFEARRAY> {
-            self.resolve(|node| {
+            self.resolve_for_text_pattern(|node| {
                 if let Some(range) = node.text_selection() {
                     let platform_range: ITextRangeProvider = PlatformTextRange::new(&self.tree, range, self.hwnd).into();
                     let iunknown: IUnknown = platform_range.into();
@@ -892,7 +905,7 @@ patterns! {
         },
 
         fn RangeFromPoint(&self, point: &UiaPoint) -> Result<ITextRangeProvider> {
-            self.resolve(|node| {
+            self.resolve_for_text_pattern(|node| {
                 let client_top_left = self.client_top_left();
                 let point = Point::new(point.x - client_top_left.x, point.y - client_top_left.y);
                 let point = node.transform().inverse() * point;
@@ -903,14 +916,14 @@ patterns! {
         },
 
         fn DocumentRange(&self) -> Result<ITextRangeProvider> {
-            self.resolve(|node| {
+            self.resolve_for_text_pattern(|node| {
                 let range = node.document_range();
                 Ok(PlatformTextRange::new(&self.tree, range, self.hwnd).into())
             })
         },
 
         fn SupportedTextSelection(&self) -> Result<SupportedTextSelection> {
-            self.resolve(|node| {
+            self.resolve_for_text_pattern(|node| {
                 if node.has_text_selection() {
                     Ok(SupportedTextSelection_Single)
                 } else {


### PR DESCRIPTION
The egui `DragValue` widget will be like this.

BTW, I'm no longer including the parenthesized part in the prefix at the beginning of commit messages, because it doesn't have the purpose that I thought it did in release-please; it just clutters the change logs.