### PR TITLE
fix: Reduce the winit version requirement to match egui

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 accesskit = { version = "0.8.0", path = "../../common" }
 parking_lot = "0.12.1"
-winit = { version = "0.27.3", default-features = false, features = ["x11", "wayland", "wayland-dlopen"] }
+winit = { version = "0.27.2", default-features = false, features = ["x11", "wayland", "wayland-dlopen"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.9.3", path = "../windows" }
@@ -22,4 +22,4 @@ accesskit_windows = { version = "0.9.3", path = "../windows" }
 accesskit_macos = { version = "0.1.3", path = "../macos" }
 
 [dev-dependencies]
-winit = "0.27.3"
+winit = "0.27.2"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap-sha": "dbfa4bce848ece5976cc17f7068b57c68b7a449d",
+  "bootstrap-sha": "24519ef87c1ff69bcb7133587a1a82f6dfbc8836",
   "bump-minor-pre-major": true,
   "plugins": ["cargo-workspace"],
   "release-type": "rust",


### PR DESCRIPTION
The main reason for this PR is to try to re-bootstrap release-please. I just have to change _something_ in platforms/winit to see if this will fix the problem with automatically creating releases of this crate.