### PR TITLE
fix: Re-export types from objc2

### DIFF
--- a/platforms/macos/src/lib.rs
+++ b/platforms/macos/src/lib.rs
@@ -17,3 +17,5 @@ pub use event::QueuedEvents;
 
 mod subclass;
 pub use subclass::SubclassingAdapter;
+
+pub use objc2::foundation::{NSArray, NSObject, NSPoint};


### PR DESCRIPTION
For the same reason as we now re-export windows-rs types in the Windows adapter.