### PR TITLE
fix: Handle views with flipped coordinates

### DIFF
--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -112,8 +112,15 @@ impl Adapter {
         let window = view.window().unwrap();
         let point = window.convert_point_from_screen(point);
         let point = view.convert_point_from_view(point, None);
-        let view_bounds = view.bounds();
-        let point = Point::new(point.x, view_bounds.size.height - point.y);
+        let point = Point::new(
+            point.x,
+            if view.is_flipped() {
+                point.y
+            } else {
+                let view_bounds = view.bounds();
+                view_bounds.size.height - point.y
+            },
+        );
 
         let state = context.tree.read();
         let root = state.root();

--- a/platforms/macos/src/appkit/view.rs
+++ b/platforms/macos/src/appkit/view.rs
@@ -41,5 +41,8 @@ extern_methods!(
             point: NSPoint,
             view: Option<&NSView>,
         ) -> NSPoint;
+
+        #[sel(isFlipped)]
+        pub(crate) fn is_flipped(&self) -> bool;
     }
 );

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -351,11 +351,15 @@ declare_class!(
                 };
 
                 node.bounding_box().map_or(NSRect::ZERO, |rect| {
-                    let view_bounds = view.bounds();
                     let rect = NSRect {
                         origin: NSPoint {
                             x: rect.x0,
-                            y: view_bounds.size.height - rect.y1,
+                            y: if view.is_flipped() {
+                                rect.y0
+                            } else {
+                                let view_bounds = view.bounds();
+                                view_bounds.size.height - rect.y1
+                            },
                         },
                         size: NSSize {
                             width: rect.width(),


### PR DESCRIPTION
I didn't realize that on macOS, a view's coordinates can be flipped so that y is top-down (as it is on other platforms). druid-shell and its successor glazier do this, so we need to handle it.