### PR TITLE
fix: Make VoiceOver move through nodes in logical order

### DIFF
--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -12,7 +12,12 @@ use objc2::{
 use once_cell::unsync::Lazy;
 use std::{ffi::c_void, ptr::null_mut, rc::Rc};
 
-use crate::{appkit::NSView, context::Context, event::QueuedEvents, node::filter};
+use crate::{
+    appkit::NSView,
+    context::Context,
+    event::QueuedEvents,
+    node::{can_be_focused, filter},
+};
 
 pub struct Adapter {
     context: Lazy<Rc<Context>, Box<dyn FnOnce() -> Rc<Context>>>,
@@ -92,7 +97,7 @@ impl Adapter {
         let context = Lazy::force(&self.context);
         let state = context.tree.read();
         if let Some(node) = state.focus() {
-            if filter(&node) == FilterResult::Include {
+            if can_be_focused(&node) {
                 return Id::autorelease_return(context.get_or_create_platform_node(node.id()))
                     as *mut _;
             }


### PR DESCRIPTION
By default, VoiceOver determines its navigation order based on the positions of the nodes. This is bad for complex layouts.

To make this work, the root node must not be filtered out of the platform tree. Luckily, VoiceOver doesn't present a top-level group as a separate thing that the user has to interact with. We still have to be careful not to expose that node as focused when the focus is on the window itself, though.