### PR TITLE
chore: Update the release-please GitHub action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v3
         with:
           command: manifest


### PR DESCRIPTION
Hoping this will fix the ongoing failure to create change log entries and releases for the winit adapter. It looks like it will, based on my dry run of the latest release-please from the CLI on my own machine.