### PR TITLE
fix: Expose which accessibility selectors are actually allowed for a particular node

### DIFF
--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -18,7 +18,8 @@ use objc2::{
     foundation::{NSArray, NSCopying, NSNumber, NSObject, NSPoint, NSRect, NSSize, NSString},
     msg_send_id, ns_string,
     rc::{Id, Owned, Shared},
-    ClassType,
+    runtime::Sel,
+    sel, ClassType,
 };
 use std::{
     ptr::null_mut,
@@ -510,6 +511,39 @@ declare_class!(
         #[sel(accessibilityNotifiesWhenDestroyed)]
         fn notifies_when_destroyed(&self) -> bool {
             true
+        }
+
+        #[sel(isAccessibilitySelectorAllowed:)]
+        fn is_selector_allowed(&self, selector: Sel) -> bool {
+            self.resolve(|node| {
+                if selector == sel!(setAccessibilityFocused:) {
+                    return node.is_focusable();
+                }
+                if selector == sel!(accessibilityPerformPress) {
+                    return node.is_clickable();
+                }
+                if selector == sel!(accessibilityPerformIncrement) {
+                    return node.supports_increment();
+                }
+                if selector == sel!(accessibilityPerformDecrement) {
+                    return node.supports_decrement();
+                }
+                selector == sel!(accessibilityParent)
+                    || selector == sel!(accessibilityChildren)
+                    || selector == sel!(accessibilityChildrenInNavigationOrder)
+                    || selector == sel!(accessibilityFrame)
+                    || selector == sel!(accessibilityRole)
+                    || selector == sel!(accessibilityRoleDescription)
+                    || selector == sel!(accessibilityTitle)
+                    || selector == sel!(accessibilityValue)
+                    || selector == sel!(accessibilityMinValue)
+                    || selector == sel!(accessibilityMaxValue)
+                    || selector == sel!(isAccessibilityElement)
+                    || selector == sel!(isAccessibilityFocused)
+                    || selector == sel!(accessibilityNotifiesWhenDestroyed)
+                    || selector == sel!(isAccessibilitySelectorAllowed:)
+            })
+            .unwrap_or(false)
         }
     }
 );


### PR DESCRIPTION
I think this is a good thing to add before implementing the `NSAccessibility` text methods, which an AT shouldn't try to call on nodes that don't support text ranges. Since I've chosen to have a single Objective-C class for all types of AccessKit nodes, it's useful to let ATs know which methods are and are not supported for a particular node.

I know this method is being used, because before I added `accessibilityRoleDescription` to the list of selectors that are allowed by default, VoiceOver didn't speak some role descriptions, like "slider", "stepper", and "button". Maybe we'll eventually discover more selectors that need to be on the default allow list.