### PR TITLE
fix: Correctly apply the DPI scale factor to coordinates

### DIFF
--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -96,13 +96,16 @@ impl Adapter {
         let window = view.window().unwrap();
         let point = window.convert_point_from_screen(point);
         let point = view.convert_point_from_view(point, None);
+        // AccessKit coordinates are in physical (DPI-dependent) pixels, but
+        // macOS provides logical (DPI-independent) coordinates here.
+        let factor = view.backing_scale_factor();
         let point = Point::new(
-            point.x,
+            point.x * factor,
             if view.is_flipped() {
-                point.y
+                point.y * factor
             } else {
                 let view_bounds = view.bounds();
-                view_bounds.size.height - point.y
+                (view_bounds.size.height - point.y) * factor
             },
         );
 

--- a/platforms/macos/src/appkit/view.rs
+++ b/platforms/macos/src/appkit/view.rs
@@ -5,7 +5,7 @@
 
 use objc2::{
     extern_class, extern_methods,
-    foundation::{NSObject, NSPoint, NSRect},
+    foundation::{CGFloat, NSObject, NSPoint, NSRect},
     msg_send_id,
     rc::{Id, Shared},
     ClassType,
@@ -44,5 +44,8 @@ extern_methods!(
 
         #[sel(isFlipped)]
         pub(crate) fn is_flipped(&self) -> bool;
+
+        #[sel(backingScaleFactor)]
+        pub(crate) fn backing_scale_factor(&self) -> CGFloat;
     }
 );

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -345,19 +345,23 @@ declare_class!(
                 };
 
                 node.bounding_box().map_or(NSRect::ZERO, |rect| {
+                    // AccessKit coordinates are in physical (DPI-dependent)
+                    // pixels, but macOS expects logical (DPI-independent)
+                    // coordinates here.
+                    let factor = view.backing_scale_factor();
                     let rect = NSRect {
                         origin: NSPoint {
-                            x: rect.x0,
+                            x: rect.x0 / factor,
                             y: if view.is_flipped() {
-                                rect.y0
+                                rect.y0 / factor
                             } else {
                                 let view_bounds = view.bounds();
-                                view_bounds.size.height - rect.y1
+                                view_bounds.size.height - rect.y1 / factor
                             },
                         },
                         size: NSSize {
-                            width: rect.width(),
-                            height: rect.height(),
+                            width: rect.width() / factor,
+                            height: rect.height() / factor,
                         },
                     };
                     let rect = view.convert_rect_to_view(rect, None);


### PR DESCRIPTION
I incorrectly assumed that the relevant accessibility methods used physical (DPI-dependent) coordinates. A Retina Mac user noticed that the VoiceOver highlight was wrong. I already asked him to test this fix.