### PR TITLE
fix: Don't expose the window title in our root element on macOS

### DIFF
--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -259,7 +259,19 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn is_root(&self) -> bool {
+        match self {
+            Self::Node(node) => node.is_root(),
+            Self::DetachedNode(node) => node.is_root(),
+        }
+    }
+
     fn name(&self) -> Option<String> {
+        if self.is_root() && self.node_state().role() == Role::Window {
+            // If the group element that we expose for the top-level window
+            // includes a title, VoiceOver behavior is broken.
+            return None;
+        }
         match self {
             Self::Node(node) => node.name(),
             Self::DetachedNode(node) => node.name(),


### PR DESCRIPTION
If we expose the window title on the group element that we expose for the root of the window, VoiceOver behavior is broken. On macOS, VoiceOver gets the window title from the Cocoa `NSWindow`.