### PR TITLE
feat: Text support on macOS

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -409,6 +409,10 @@ impl NodeState {
         }
     }
 
+    pub fn is_multiline(&self) -> bool {
+        self.data().multiline
+    }
+
     pub fn default_action_verb(&self) -> Option<DefaultActionVerb> {
         self.data().default_action_verb
     }

--- a/platforms/macos/src/appkit/accessibility_constants.rs
+++ b/platforms/macos/src/appkit/accessibility_constants.rs
@@ -12,6 +12,7 @@ extern "C" {
     pub(crate) static NSAccessibilityFocusedUIElementChangedNotification: &'static NSString;
     pub(crate) static NSAccessibilityTitleChangedNotification: &'static NSString;
     pub(crate) static NSAccessibilityValueChangedNotification: &'static NSString;
+    pub(crate) static NSAccessibilitySelectedTextChangedNotification: &'static NSString;
 
     // Roles
     pub(crate) static NSAccessibilityButtonRole: &'static NSString;

--- a/platforms/macos/src/appkit/accessibility_constants.rs
+++ b/platforms/macos/src/appkit/accessibility_constants.rs
@@ -42,6 +42,7 @@ extern "C" {
     pub(crate) static NSAccessibilityStaticTextRole: &'static NSString;
     pub(crate) static NSAccessibilityTabGroupRole: &'static NSString;
     pub(crate) static NSAccessibilityTableRole: &'static NSString;
+    pub(crate) static NSAccessibilityTextAreaRole: &'static NSString;
     pub(crate) static NSAccessibilityTextFieldRole: &'static NSString;
     pub(crate) static NSAccessibilityToolbarRole: &'static NSString;
     pub(crate) static NSAccessibilityUnknownRole: &'static NSString;

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -115,6 +115,15 @@ impl TreeChangeHandler for EventGenerator {
                 notification: unsafe { NSAccessibilityValueChangedNotification },
             });
         }
+        if old_wrapper.supports_text_ranges()
+            && new_wrapper.supports_text_ranges()
+            && old_wrapper.raw_text_selection() != new_wrapper.raw_text_selection()
+        {
+            self.events.push(QueuedEvent::Generic {
+                node_id,
+                notification: unsafe { NSAccessibilitySelectedTextChangedNotification },
+            });
+        }
     }
 
     fn focus_moved(&mut self, _old_node: Option<&DetachedNode>, new_node: Option<&Node>) {

--- a/platforms/macos/src/lib.rs
+++ b/platforms/macos/src/lib.rs
@@ -8,6 +8,7 @@
 mod appkit;
 mod context;
 mod node;
+mod util;
 
 mod adapter;
 pub use adapter::Adapter;

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -421,6 +421,12 @@ declare_class!(
             .unwrap_or_else(null_mut)
         }
 
+        #[sel(setAccessibilityValue:)]
+        fn set_value(&self, _value: &NSObject) {
+            // This isn't yet implemented. See the comment on this selector
+            // in `is_selector_allowed`.
+        }
+
         #[sel(accessibilityMinValue)]
         fn min_value(&self) -> *mut NSNumber {
             self.resolve(|node| {
@@ -701,10 +707,10 @@ declare_class!(
                     return node.supports_text_ranges();
                 }
                 if selector == sel!(setAccessibilityValue:) {
-                    // We don't implement this selector, and it's not clear
-                    // if VoiceOver ever actually uses it, but it must be
-                    // allowed for editable text in order to get the expected
-                    // VoiceOver behavior.
+                    // Our implementation of this currently does nothing,
+                    // and it's not clear if VoiceOver ever actually uses it,
+                    // but it must be allowed for editable text in order to get
+                    // the expected VoiceOver behavior.
                     return node.supports_text_ranges() && !node.is_read_only();
                 }
                 selector == sel!(accessibilityParent)

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -16,8 +16,8 @@ use objc2::{
     declare::{Ivar, IvarDrop},
     declare_class,
     foundation::{
-        NSArray, NSAttributedString, NSCopying, NSInteger, NSNumber, NSObject, NSPoint, NSRange,
-        NSRect, NSSize, NSString,
+        NSArray, NSCopying, NSInteger, NSNumber, NSObject, NSPoint, NSRange, NSRect, NSSize,
+        NSString,
     },
     msg_send_id, ns_string,
     rc::{Id, Owned, Shared},
@@ -670,24 +670,6 @@ declare_class!(
             .unwrap_or_else(null_mut)
         }
 
-        #[sel(accessibilityAttributedStringForRange:)]
-        fn attributed_string_for_range(&self, range: NSRange) -> *mut NSAttributedString {
-            self.resolve(|node| {
-                if node.supports_text_ranges() {
-                    if let Some(range) = text_range_from_ns_range(node, range) {
-                        let text = range.text();
-                        // TODO: Expose formatting information.
-                        let ns_string = NSString::from_str(&text);
-                        return Id::autorelease_return(NSAttributedString::from_nsstring(
-                            &ns_string,
-                        ));
-                    }
-                }
-                null_mut()
-            })
-            .unwrap_or_else(null_mut)
-        }
-
         #[sel(accessibilityFrameForRange:)]
         fn frame_for_range(&self, range: NSRange) -> NSRect {
             self.resolve_with_context(|node, context| {
@@ -800,7 +782,6 @@ declare_class!(
                     || selector == sel!(accessibilityRangeForLine:)
                     || selector == sel!(accessibilityRangeForPosition:)
                     || selector == sel!(accessibilityStringForRange:)
-                    || selector == sel!(accessibilityAttributedStringForRange:)
                     || selector == sel!(accessibilityFrameForRange:)
                     || selector == sel!(accessibilityLineForIndex:)
                     || selector == sel!(accessibilityRangeForIndex:)

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -54,7 +54,13 @@ fn ns_role(node: &Node) -> &'static NSString {
             Role::Presentation => NSAccessibilityUnknownRole,
             Role::CheckBox => NSAccessibilityCheckBoxRole,
             Role::RadioButton => NSAccessibilityRadioButtonRole,
-            Role::TextField => NSAccessibilityTextFieldRole,
+            Role::TextField => {
+                if node.is_multiline() {
+                    NSAccessibilityTextAreaRole
+                } else {
+                    NSAccessibilityTextFieldRole
+                }
+            }
             Role::Button => NSAccessibilityButtonRole,
             Role::LabelText => NSAccessibilityGroupRole,
             Role::Pane => NSAccessibilityUnknownRole,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -804,13 +804,16 @@ declare_class!(
                     || selector == sel!(accessibilityFrameForRange:)
                     || selector == sel!(accessibilityLineForIndex:)
                     || selector == sel!(accessibilityRangeForIndex:)
-                    // This adapter doesn't yet actually support the SetValue
-                    // action, but we must claim to support it in order
-                    // to get the expected VoiceOver behavior in edits.
-                    || selector == sel!(setAccessibilityValue:)
                     || selector == sel!(setAccessibilitySelectedTextRange:)
                 {
                     return node.supports_text_ranges();
+                }
+                if selector == sel!(setAccessibilityValue:) {
+                    // We don't implement this selector, and it's not clear
+                    // if VoiceOver ever actually uses it, but it must be
+                    // allowed for editable text in order to get the expected
+                    // VoiceOver behavior.
+                    return node.supports_text_ranges() && !node.is_read_only();
                 }
                 selector == sel!(accessibilityParent)
                     || selector == sel!(accessibilityChildren)

--- a/platforms/macos/src/util.rs
+++ b/platforms/macos/src/util.rs
@@ -1,0 +1,79 @@
+// Copyright 2022 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::kurbo::{Point, Rect};
+use accesskit_consumer::{Node, TextPosition, TextRange};
+use objc2::foundation::{NSPoint, NSRange, NSRect, NSSize};
+
+use crate::appkit::*;
+
+pub(crate) fn from_ns_range<'a>(node: &'a Node<'a>, ns_range: NSRange) -> Option<TextRange<'a>> {
+    let pos = node.text_position_from_global_utf16_index(ns_range.location)?;
+    let mut range = pos.to_degenerate_range();
+    if ns_range.length > 0 {
+        let end =
+            node.text_position_from_global_utf16_index(ns_range.location + ns_range.length)?;
+        range.set_end(end);
+    }
+    Some(range)
+}
+
+pub(crate) fn to_ns_range(range: &TextRange) -> NSRange {
+    let start = range.start().to_global_utf16_index();
+    let end = range.end().to_global_utf16_index();
+    NSRange::from(start..end)
+}
+
+pub(crate) fn to_ns_range_for_character(pos: &TextPosition) -> NSRange {
+    let mut range = pos.to_degenerate_range();
+    if !pos.is_document_end() {
+        range.set_end(pos.forward_by_character());
+    }
+    to_ns_range(&range)
+}
+
+pub(crate) fn from_ns_point(view: &NSView, node: &Node, point: NSPoint) -> Point {
+    let window = view.window().unwrap();
+    let point = window.convert_point_from_screen(point);
+    let point = view.convert_point_from_view(point, None);
+    // AccessKit coordinates are in physical (DPI-dependent) pixels, but
+    // macOS provides logical (DPI-independent) coordinates here.
+    let factor = view.backing_scale_factor();
+    let point = Point::new(
+        point.x * factor,
+        if view.is_flipped() {
+            point.y * factor
+        } else {
+            let view_bounds = view.bounds();
+            (view_bounds.size.height - point.y) * factor
+        },
+    );
+    node.transform().inverse() * point
+}
+
+pub(crate) fn to_ns_rect(view: &NSView, rect: Rect) -> NSRect {
+    // AccessKit coordinates are in physical (DPI-dependent)
+    // pixels, but macOS expects logical (DPI-independent)
+    // coordinates here.
+    let factor = view.backing_scale_factor();
+    let rect = NSRect {
+        origin: NSPoint {
+            x: rect.x0 / factor,
+            y: if view.is_flipped() {
+                rect.y0 / factor
+            } else {
+                let view_bounds = view.bounds();
+                view_bounds.size.height - rect.y1 / factor
+            },
+        },
+        size: NSSize {
+            width: rect.width() / factor,
+            height: rect.height() / factor,
+        },
+    };
+    let rect = view.convert_rect_to_view(rect, None);
+    let window = view.window().unwrap();
+    window.convert_rect_to_screen(rect)
+}


### PR DESCRIPTION
This should be on par with the Windows adapter, meaning support for single-line and multi-line edit controls, but without exposing text formatting attributes or other rich text features. To test with a real toolkit implementation, use [this egui branch](https://github.com/mwcampbell/egui/tree/accesskit-macos-basic-text). egui itself required only one minor fix, which is already merged; the existing integration in egui that was tested with the Windows adapter was mostly fine already.