### PR TITLE
fix: Correct broken UIA method implementation that was incompatible with Windows 11 ATs

### DIFF
--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -570,6 +570,6 @@ impl ITextRangeProvider_Impl for PlatformRange {
 
     fn GetChildren(&self) -> Result<*mut SAFEARRAY> {
         // We don't support embedded objects in text.
-        Ok(std::ptr::null_mut())
+        Ok(safe_array_from_com_slice(&[]))
     }
 }


### PR DESCRIPTION
This prevented Narrator on Windows 11 from reading characters, selection changes, and possibly other things. It might have also affected other assistive technologies that use the same newer UI Automation API that was introduced in Windows 11 and is now being used by Narrator.

fixes #189