### PR TITLE
fix: Provide fallback property implementations for the window root

### DIFF
--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -84,7 +84,6 @@ fn get_initial_state() -> TreeUpdate {
     let root = Arc::new(Node {
         role: Role::Window,
         children: vec![BUTTON_1_ID, BUTTON_2_ID],
-        name: Some(WINDOW_TITLE.into()),
         ..Default::default()
     });
     let button_1 = make_button(BUTTON_1_ID, "Button 1");
@@ -162,7 +161,6 @@ impl WindowState {
         let root = Arc::new(Node {
             role: Role::Window,
             children: vec![BUTTON_1_ID, BUTTON_2_ID, PRESSED_TEXT_ID],
-            name: Some(WINDOW_TITLE.into()),
             ..Node::default()
         });
         let update = TreeUpdate {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -608,8 +608,16 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
         self.resolve(|node| {
             let wrapper = NodeWrapper::Node(&node);
             let mut result = wrapper.get_property_value(property_id);
-            if property_id == UIA_NamePropertyId && result.is_empty() && node.is_root() {
-                result = window_title(self.hwnd).into();
+            if result.is_empty() && node.is_root() {
+                match property_id {
+                    UIA_NamePropertyId => {
+                        result = window_title(self.hwnd).into();
+                    }
+                    UIA_NativeWindowHandlePropertyId => {
+                        result = (self.hwnd.0 as i32).into();
+                    }
+                    _ => (),
+                }
             }
             Ok(result.into())
         })

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -607,7 +607,10 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
     fn GetPropertyValue(&self, property_id: UIA_PROPERTY_ID) -> Result<VARIANT> {
         self.resolve(|node| {
             let wrapper = NodeWrapper::Node(&node);
-            let result = wrapper.get_property_value(property_id);
+            let mut result = wrapper.get_property_value(property_id);
+            if property_id == UIA_NamePropertyId && result.is_empty() && node.is_root() {
+                result = window_title(self.hwnd).into();
+            }
             Ok(result.into())
         })
     }

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -29,7 +29,6 @@ fn get_initial_state() -> TreeUpdate {
     let root = Arc::new(Node {
         role: Role::Window,
         children: vec![BUTTON_1_ID, BUTTON_2_ID],
-        name: Some(WINDOW_TITLE.into()),
         ..Default::default()
     });
     let button_1 = make_button("Button 1");


### PR DESCRIPTION
UIA itself normally does this automatically. But for an AT that uses the UIA Remote Operations API introduced in Windows 11, such as the Windows 11 version of Narrator, this fallback isn't available for providers that don't use COM threading, such as ours. As a result, Windows 11 Narrator was unable to find the window context for the current focus if something other than the window is immediately focused. We don't want to switch to COM threading, since the ability to run UIA methods independently of the UI thread is a key benefit of the AccessKit architecture. We also don't want to require integrators to provide the window title as the name of the root node if we can avoid it. So, this PR implements our own fallback. It also modifies the Windows example and test code to clarify that the window title doesn't need to be explicitly provided in the AccessKit tree.