### PR TITLE
chore: Fix clippy lints and make CI more comprehensive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings --all-targets
+          args: --all-targets -- -D warnings
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -D warnings --all-targets
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -91,15 +91,8 @@ impl<'a> Node<'a> {
     }
 
     pub fn filtered_parent(&self, filter: &impl Fn(&Node) -> FilterResult) -> Option<Node<'a>> {
-        if let Some(parent) = self.parent() {
-            if filter(&parent) != FilterResult::Include {
-                parent.filtered_parent(filter)
-            } else {
-                Some(parent)
-            }
-        } else {
-            None
-        }
+        self.parent()
+            .filter(|parent| filter(parent) == FilterResult::Include)
     }
 
     pub fn parent_and_index(self) -> Option<(Node<'a>, usize)> {

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -121,7 +121,7 @@ impl WindowState {
             // window state.
             let mut initial_tree = get_initial_state();
             let inner_state = self.inner_state.borrow();
-            initial_tree.focus = inner_state.is_window_focused.then(|| inner_state.focus);
+            initial_tree.focus = inner_state.is_window_focused.then_some(inner_state.focus);
             let action_handler = Box::new(SimpleActionHandler { window });
             accesskit_windows::Adapter::new(
                 window,
@@ -168,7 +168,7 @@ impl WindowState {
         let update = TreeUpdate {
             nodes: vec![(PRESSED_TEXT_ID, node), (WINDOW_ID, root)],
             tree: None,
-            focus: is_window_focused.then(|| focus),
+            focus: is_window_focused.then_some(focus),
         };
         let events = adapter.update(update);
         events.raise();
@@ -189,7 +189,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
         let events = adapter.update(TreeUpdate {
             nodes: vec![],
             tree: None,
-            focus: is_window_focused.then(|| focus),
+            focus: is_window_focused.then_some(focus),
         });
         events.raise();
     }
@@ -230,7 +230,7 @@ impl ActionHandler for SimpleActionHandler {
 }
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    match message as u32 {
+    match message {
         WM_NCCREATE => {
             let create_struct: &CREATESTRUCTW = unsafe { &mut *(lparam.0 as *mut _) };
             let create_params: Box<WindowCreateParams> =

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -68,7 +68,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
         let events = adapter.update(TreeUpdate {
             nodes: vec![],
             tree: None,
-            focus: is_window_focused.then(|| focus),
+            focus: is_window_focused.then_some(focus),
         });
         events.raise();
     }
@@ -77,7 +77,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
 struct WindowCreateParams(TreeUpdate, NodeId, Box<dyn ActionHandler>);
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
-    match message as u32 {
+    match message {
         WM_NCCREATE => {
             let create_struct: &CREATESTRUCTW = unsafe { &mut *(lparam.0 as *mut _) };
             let create_params: Box<WindowCreateParams> =
@@ -93,7 +93,7 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
                 adapter: Lazy::new(Box::new(move || {
                     let mut initial_tree = initial_state;
                     let state = inner_state_for_tree_init.borrow();
-                    initial_tree.focus = state.is_window_focused.then(|| state.focus);
+                    initial_tree.focus = state.is_window_focused.then_some(state.focus);
                     Adapter::new(window, initial_tree, action_handler, uia_init_marker)
                 })),
                 inner_state,

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -23,7 +23,7 @@ impl From<VariantFactory> for VARIANT {
         Self {
             Anonymous: VARIANT_0 {
                 Anonymous: ManuallyDrop::new(VARIANT_0_0 {
-                    vt: VARENUM(vt.0 as u16),
+                    vt: VARENUM(vt.0),
                     wReserved1: 0,
                     wReserved2: 0,
                     wReserved3: 0,
@@ -135,8 +135,7 @@ impl<T: Into<VariantFactory>> From<Option<T>> for VariantFactory {
 }
 
 fn safe_array_from_primitive_slice<T>(vt: VARENUM, slice: &[T]) -> *mut SAFEARRAY {
-    let sa =
-        unsafe { SafeArrayCreateVector(VARENUM(vt.0 as u16), 0, slice.len().try_into().unwrap()) };
+    let sa = unsafe { SafeArrayCreateVector(VARENUM(vt.0), 0, slice.len().try_into().unwrap()) };
     if sa.is_null() {
         panic!("SAFEARRAY allocation failed");
     }


### PR DESCRIPTION
Rust 1.66 introduced a couple of new lints. There's also one from the Windows example that wasn't caught by the CI.