### PR TITLE
fix: Pin objc2 dependency to 0.3.0-beta.3

### DIFF
--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2021"
 [dependencies]
 accesskit = { version = "0.8.1", path = "../../common" }
 accesskit_consumer = { version = "0.11.0", path = "../../consumer" }
-objc2 = "0.3.0-beta.3"
+objc2 = "=0.3.0-beta.3"
 once_cell = "1.13.0"
 parking_lot = "0.12.1"


### PR DESCRIPTION
fixes #199

I'll merge this as soon as it passes CI, as it is the simplest, safest possible fix for the broken build reported in that issue.