### PR TITLE
fix: Don't force winit's X11 and Wayland features to be enabled

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 accesskit = { version = "0.8.1", path = "../../common" }
 parking_lot = "0.12.1"
-winit = { version = "0.28", default-features = false, features = ["x11", "wayland", "wayland-dlopen"] }
+winit = { version = "0.28", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.11.0", path = "../windows" }


### PR DESCRIPTION
Bevy prefers to keep these features enabled by default and let the user choose which of them to enable. Since the Unix backend in `accesskit_winit` didn't actually need to use anything specific to X11 or Wayland, we can disable these features too.