### PR TITLE
refactor!: Move thread synchronization into platform adapters; drop parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,6 @@ name = "accesskit_consumer"
 version = "0.13.0"
 dependencies = [
  "accesskit",
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "accesskit_consumer",
  "objc2",
  "once_cell",
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,6 @@ dependencies = [
  "accesskit_consumer",
  "arrayvec",
  "once_cell",
- "parking_lot",
  "paste",
  "scopeguard",
  "windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "async-channel",
  "atspi",
  "futures-lite",
- "parking_lot",
  "serde",
  "zbus",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,6 @@ dependencies = [
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
- "parking_lot",
  "winit",
 ]
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2397,13 +2397,12 @@ pub struct ActionRequest {
 }
 
 /// Handles requests from assistive technologies or other clients.
-pub trait ActionHandler: Send + Sync {
+pub trait ActionHandler {
     /// Perform the requested action. If the requested action is not supported,
     /// this method must do nothing.
     ///
-    /// This method may be called on any thread. In particular, on platforms
-    /// with a designated UI thread, this method may or may not be called
-    /// on that thread. Implementations must correctly handle both cases.
+    /// The thread on which this method is called is platform-dependent.
+    /// Refer to the platform adapter documentation for more details.
     ///
     /// This method may queue the request and handle it asynchronously.
     /// This behavior is preferred over blocking, e.g. when dispatching

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -12,4 +12,3 @@ edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.9.0", path = "../common" }
-parking_lot = "0.12.1"

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -486,15 +486,15 @@ mod tests {
     #[test]
     fn following_siblings() {
         let tree = test_tree();
-        assert!(tree.read().root().following_siblings().next().is_none());
-        assert_eq!(0, tree.read().root().following_siblings().len());
+        assert!(tree.state().root().following_siblings().next().is_none());
+        assert_eq!(0, tree.state().root().following_siblings().len());
         assert_eq!(
             [
                 PARAGRAPH_1_IGNORED_ID,
                 PARAGRAPH_2_ID,
                 PARAGRAPH_3_IGNORED_ID
             ],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .following_siblings()
@@ -503,14 +503,14 @@ mod tests {
         );
         assert_eq!(
             3,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .following_siblings()
                 .len()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_3_IGNORED_ID)
             .unwrap()
             .following_siblings()
@@ -518,7 +518,7 @@ mod tests {
             .is_none());
         assert_eq!(
             0,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .following_siblings()
@@ -530,7 +530,7 @@ mod tests {
     fn following_siblings_reversed() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .following_siblings()
             .next_back()
@@ -541,7 +541,7 @@ mod tests {
                 PARAGRAPH_2_ID,
                 PARAGRAPH_1_IGNORED_ID
             ],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .following_siblings()
@@ -550,7 +550,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_3_IGNORED_ID)
             .unwrap()
             .following_siblings()
@@ -561,11 +561,11 @@ mod tests {
     #[test]
     fn preceding_siblings() {
         let tree = test_tree();
-        assert!(tree.read().root().preceding_siblings().next().is_none());
-        assert_eq!(0, tree.read().root().preceding_siblings().len());
+        assert!(tree.state().root().preceding_siblings().next().is_none());
+        assert_eq!(0, tree.state().root().preceding_siblings().len());
         assert_eq!(
             [PARAGRAPH_2_ID, PARAGRAPH_1_IGNORED_ID, PARAGRAPH_0_ID],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .preceding_siblings()
@@ -574,14 +574,14 @@ mod tests {
         );
         assert_eq!(
             3,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .preceding_siblings()
                 .len()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .preceding_siblings()
@@ -589,7 +589,7 @@ mod tests {
             .is_none());
         assert_eq!(
             0,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .preceding_siblings()
@@ -601,14 +601,14 @@ mod tests {
     fn preceding_siblings_reversed() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .preceding_siblings()
             .next_back()
             .is_none());
         assert_eq!(
             [PARAGRAPH_0_ID, PARAGRAPH_1_IGNORED_ID, PARAGRAPH_2_ID],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .preceding_siblings()
@@ -617,7 +617,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .preceding_siblings()
@@ -629,7 +629,7 @@ mod tests {
     fn following_filtered_siblings() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .following_filtered_siblings(test_tree_filter)
             .next()
@@ -641,7 +641,7 @@ mod tests {
                 STATIC_TEXT_3_1_0_ID,
                 BUTTON_3_2_ID
             ],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
@@ -649,7 +649,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_3_IGNORED_ID)
             .unwrap()
             .following_filtered_siblings(test_tree_filter)
@@ -661,7 +661,7 @@ mod tests {
     fn following_filtered_siblings_reversed() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .following_filtered_siblings(test_tree_filter)
             .next_back()
@@ -673,7 +673,7 @@ mod tests {
                 PARAGRAPH_2_ID,
                 STATIC_TEXT_1_0_ID
             ],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
@@ -682,7 +682,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_3_IGNORED_ID)
             .unwrap()
             .following_filtered_siblings(test_tree_filter)
@@ -694,14 +694,14 @@ mod tests {
     fn preceding_filtered_siblings() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .preceding_filtered_siblings(test_tree_filter)
             .next()
             .is_none());
         assert_eq!(
             [PARAGRAPH_2_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_0_ID],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
@@ -709,7 +709,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .preceding_filtered_siblings(test_tree_filter)
@@ -721,14 +721,14 @@ mod tests {
     fn preceding_filtered_siblings_reversed() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .preceding_filtered_siblings(test_tree_filter)
             .next_back()
             .is_none());
         assert_eq!(
             [PARAGRAPH_0_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_2_ID],
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
@@ -737,7 +737,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .preceding_filtered_siblings(test_tree_filter)
@@ -756,21 +756,21 @@ mod tests {
                 STATIC_TEXT_3_1_0_ID,
                 BUTTON_3_2_ID
             ],
-            tree.read()
+            tree.state()
                 .root()
                 .filtered_children(test_tree_filter)
                 .map(|node| node.id())
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .filtered_children(test_tree_filter)
             .next()
             .is_none());
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
             .filtered_children(test_tree_filter)
@@ -789,7 +789,7 @@ mod tests {
                 STATIC_TEXT_1_0_ID,
                 PARAGRAPH_0_ID
             ],
-            tree.read()
+            tree.state()
                 .root()
                 .filtered_children(test_tree_filter)
                 .rev()
@@ -797,14 +797,14 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .filtered_children(test_tree_filter)
             .next_back()
             .is_none());
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
             .filtered_children(test_tree_filter)

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -21,8 +21,7 @@ pub use text::{
 #[cfg(test)]
 mod tests {
     use accesskit::{
-        ActionHandler, ActionRequest, Affine, NodeBuilder, NodeClassSet, NodeId, Rect, Role, Tree,
-        TreeUpdate, Vec2,
+        Affine, NodeBuilder, NodeClassSet, NodeId, Rect, Role, Tree, TreeUpdate, Vec2,
     };
     use std::num::NonZeroU128;
 
@@ -43,12 +42,6 @@ mod tests {
     pub const BUTTON_3_2_ID: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(12) });
     pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId =
         NodeId(unsafe { NonZeroU128::new_unchecked(13) });
-
-    pub struct NullActionHandler;
-
-    impl ActionHandler for NullActionHandler {
-        fn do_action(&self, _request: ActionRequest) {}
-    }
 
     pub fn test_tree() -> crate::tree::Tree {
         let mut classes = NodeClassSet::new();
@@ -154,7 +147,7 @@ mod tests {
             tree: Some(Tree::new(ROOT_ID)),
             focus: None,
         };
-        crate::tree::Tree::new(initial_update, Box::new(NullActionHandler {}))
+        crate::tree::Tree::new(initial_update)
     }
 
     pub fn test_tree_filter(node: &crate::Node) -> FilterResult {

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -735,10 +735,10 @@ mod tests {
     #[test]
     fn parent_and_index() {
         let tree = test_tree();
-        assert!(tree.read().root().parent_and_index().is_none());
+        assert!(tree.state().root().parent_and_index().is_none());
         assert_eq!(
             Some((ROOT_ID, 0)),
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .parent_and_index()
@@ -746,7 +746,7 @@ mod tests {
         );
         assert_eq!(
             Some((PARAGRAPH_0_ID, 0)),
-            tree.read()
+            tree.state()
                 .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
                 .unwrap()
                 .parent_and_index()
@@ -754,7 +754,7 @@ mod tests {
         );
         assert_eq!(
             Some((ROOT_ID, 1)),
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_1_IGNORED_ID)
                 .unwrap()
                 .parent_and_index()
@@ -767,11 +767,11 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             STATIC_TEXT_0_0_IGNORED_ID,
-            tree.read().root().deepest_first_child().unwrap().id()
+            tree.state().root().deepest_first_child().unwrap().id()
         );
         assert_eq!(
             STATIC_TEXT_0_0_IGNORED_ID,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
                 .deepest_first_child()
@@ -779,7 +779,7 @@ mod tests {
                 .id()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
             .deepest_first_child()
@@ -791,7 +791,7 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             ROOT_ID,
-            tree.read()
+            tree.state()
                 .node_by_id(STATIC_TEXT_1_0_ID)
                 .unwrap()
                 .filtered_parent(&test_tree_filter)
@@ -799,7 +799,7 @@ mod tests {
                 .id()
         );
         assert!(tree
-            .read()
+            .state()
             .root()
             .filtered_parent(&test_tree_filter)
             .is_none());
@@ -810,20 +810,20 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             PARAGRAPH_0_ID,
-            tree.read()
+            tree.state()
                 .root()
                 .deepest_first_filtered_child(&test_tree_filter)
                 .unwrap()
                 .id()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .deepest_first_filtered_child(&test_tree_filter)
             .is_none());
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
             .deepest_first_filtered_child(&test_tree_filter)
@@ -835,11 +835,11 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             EMPTY_CONTAINER_3_3_IGNORED_ID,
-            tree.read().root().deepest_last_child().unwrap().id()
+            tree.state().root().deepest_last_child().unwrap().id()
         );
         assert_eq!(
             EMPTY_CONTAINER_3_3_IGNORED_ID,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .deepest_last_child()
@@ -847,7 +847,7 @@ mod tests {
                 .id()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(BUTTON_3_2_ID)
             .unwrap()
             .deepest_last_child()
@@ -859,7 +859,7 @@ mod tests {
         let tree = test_tree();
         assert_eq!(
             BUTTON_3_2_ID,
-            tree.read()
+            tree.state()
                 .root()
                 .deepest_last_filtered_child(&test_tree_filter)
                 .unwrap()
@@ -867,7 +867,7 @@ mod tests {
         );
         assert_eq!(
             BUTTON_3_2_ID,
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
                 .deepest_last_filtered_child(&test_tree_filter)
@@ -875,13 +875,13 @@ mod tests {
                 .id()
         );
         assert!(tree
-            .read()
+            .state()
             .node_by_id(BUTTON_3_2_ID)
             .unwrap()
             .deepest_last_filtered_child(&test_tree_filter)
             .is_none());
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
             .deepest_last_filtered_child(&test_tree_filter)
@@ -892,44 +892,44 @@ mod tests {
     fn is_descendant_of() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
-            .is_descendant_of(&tree.read().root()));
+            .is_descendant_of(&tree.state().root()));
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
-            .is_descendant_of(&tree.read().root()));
+            .is_descendant_of(&tree.state().root()));
         assert!(tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
-            .is_descendant_of(&tree.read().node_by_id(PARAGRAPH_0_ID).unwrap()));
+            .is_descendant_of(&tree.state().node_by_id(PARAGRAPH_0_ID).unwrap()));
         assert!(!tree
-            .read()
+            .state()
             .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
             .unwrap()
-            .is_descendant_of(&tree.read().node_by_id(PARAGRAPH_2_ID).unwrap()));
+            .is_descendant_of(&tree.state().node_by_id(PARAGRAPH_2_ID).unwrap()));
         assert!(!tree
-            .read()
+            .state()
             .node_by_id(PARAGRAPH_0_ID)
             .unwrap()
-            .is_descendant_of(&tree.read().node_by_id(PARAGRAPH_2_ID).unwrap()));
+            .is_descendant_of(&tree.state().node_by_id(PARAGRAPH_2_ID).unwrap()));
     }
 
     #[test]
     fn is_root() {
         let tree = test_tree();
-        assert!(tree.read().node_by_id(ROOT_ID).unwrap().is_root());
-        assert!(!tree.read().node_by_id(PARAGRAPH_0_ID).unwrap().is_root());
+        assert!(tree.state().node_by_id(ROOT_ID).unwrap().is_root());
+        assert!(!tree.state().node_by_id(PARAGRAPH_0_ID).unwrap().is_root());
     }
 
     #[test]
     fn bounding_box() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .node_by_id(ROOT_ID)
             .unwrap()
             .bounding_box()
@@ -941,7 +941,7 @@ mod tests {
                 x1: 810.0,
                 y1: 80.0,
             }),
-            tree.read()
+            tree.state()
                 .node_by_id(PARAGRAPH_1_IGNORED_ID)
                 .unwrap()
                 .bounding_box()
@@ -953,7 +953,7 @@ mod tests {
                 x1: 100.0,
                 y1: 70.0,
             }),
-            tree.read()
+            tree.state()
                 .node_by_id(STATIC_TEXT_1_0_ID)
                 .unwrap()
                 .bounding_box()
@@ -964,26 +964,26 @@ mod tests {
     fn node_at_point() {
         let tree = test_tree();
         assert!(tree
-            .read()
+            .state()
             .root()
             .node_at_point(Point::new(10.0, 40.0), &test_tree_filter)
             .is_none());
         assert_eq!(
             Some(STATIC_TEXT_1_0_ID),
-            tree.read()
+            tree.state()
                 .root()
                 .node_at_point(Point::new(20.0, 50.0), &test_tree_filter)
                 .map(|node| node.id())
         );
         assert_eq!(
             Some(STATIC_TEXT_1_0_ID),
-            tree.read()
+            tree.state()
                 .root()
                 .node_at_point(Point::new(50.0, 60.0), &test_tree_filter)
                 .map(|node| node.id())
         );
         assert!(tree
-            .read()
+            .state()
             .root()
             .node_at_point(Point::new(100.0, 70.0), &test_tree_filter)
             .is_none());
@@ -1008,7 +1008,7 @@ mod tests {
             focus: None,
         };
         let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
-        assert_eq!(None, tree.read().node_by_id(NODE_ID_2).unwrap().name());
+        assert_eq!(None, tree.state().node_by_id(NODE_ID_2).unwrap().name());
     }
 
     #[test]
@@ -1053,11 +1053,11 @@ mod tests {
         let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
         assert_eq!(
             Some([LABEL_1, LABEL_2].join(" ")),
-            tree.read().node_by_id(NODE_ID_2).unwrap().name()
+            tree.state().node_by_id(NODE_ID_2).unwrap().name()
         );
         assert_eq!(
             Some(LABEL_2.into()),
-            tree.read().node_by_id(NODE_ID_4).unwrap().name()
+            tree.state().node_by_id(NODE_ID_4).unwrap().name()
         );
     }
 
@@ -1106,11 +1106,11 @@ mod tests {
         let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
         assert_eq!(
             Some(BUTTON_LABEL.into()),
-            tree.read().node_by_id(NODE_ID_2).unwrap().name()
+            tree.state().node_by_id(NODE_ID_2).unwrap().name()
         );
         assert_eq!(
             Some(LINK_LABEL.into()),
-            tree.read().node_by_id(NODE_ID_4).unwrap().name()
+            tree.state().node_by_id(NODE_ID_4).unwrap().name()
         );
     }
 }

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -1007,7 +1007,7 @@ mod tests {
             tree: Some(Tree::new(NODE_ID_1)),
             focus: None,
         };
-        let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
+        let tree = crate::Tree::new(update);
         assert_eq!(None, tree.state().node_by_id(NODE_ID_2).unwrap().name());
     }
 
@@ -1050,7 +1050,7 @@ mod tests {
             tree: Some(Tree::new(NODE_ID_1)),
             focus: None,
         };
-        let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
+        let tree = crate::Tree::new(update);
         assert_eq!(
             Some([LABEL_1, LABEL_2].join(" ")),
             tree.state().node_by_id(NODE_ID_2).unwrap().name()
@@ -1103,7 +1103,7 @@ mod tests {
             tree: Some(Tree::new(NODE_ID_1)),
             focus: None,
         };
-        let tree = crate::Tree::new(update, Box::new(NullActionHandler {}));
+        let tree = crate::Tree::new(update);
         assert_eq!(
             Some(BUTTON_LABEL.into()),
             tree.state().node_by_id(NODE_ID_2).unwrap().name()

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -187,6 +187,10 @@ pub struct Position<'a> {
 }
 
 impl<'a> Position<'a> {
+    pub fn inner_node(&self) -> &Node {
+        &self.inner.node
+    }
+
     pub fn is_format_start(&self) -> bool {
         // TODO: support variable text formatting (part of rich text)
         self.is_document_start()

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -3,7 +3,9 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{NodeId, Point, Rect, Role, TextDirection, TextPosition as WeakPosition};
+use accesskit::{
+    NodeId, Point, Rect, Role, TextDirection, TextPosition as WeakPosition, TextSelection,
+};
 use std::{cmp::Ordering, iter::FusedIterator};
 
 use crate::{FilterResult, Node, TreeState};
@@ -693,6 +695,13 @@ impl<'a> Range<'a> {
             self.start = self.end;
         }
         self.fix_start_bias();
+    }
+
+    pub fn to_text_selection(&self) -> TextSelection {
+        TextSelection {
+            anchor: self.start.downgrade(),
+            focus: self.end.downgrade(),
+        }
     }
 
     pub fn downgrade(&self) -> WeakRange {

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -1276,7 +1276,7 @@ mod tests {
     #[test]
     fn supports_text_ranges() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         assert!(!state.node_by_id(NODE_ID_1).unwrap().supports_text_ranges());
         assert!(state.node_by_id(NODE_ID_2).unwrap().supports_text_ranges());
     }
@@ -1284,7 +1284,7 @@ mod tests {
     #[test]
     fn multiline_document_range() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let range = node.document_range();
         let start = range.start();
@@ -1343,7 +1343,7 @@ mod tests {
     #[test]
     fn multiline_end_degenerate_range() {
         let tree = main_multiline_tree(Some(multiline_end_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1369,7 +1369,7 @@ mod tests {
     #[test]
     fn multiline_wrapped_line_end_range() {
         let tree = main_multiline_tree(Some(multiline_wrapped_line_end_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1431,7 +1431,7 @@ mod tests {
     #[test]
     fn multiline_find_line_ends_from_middle() {
         let tree = main_multiline_tree(Some(multiline_second_line_middle_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let mut range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1463,7 +1463,7 @@ mod tests {
     #[test]
     fn multiline_find_wrapped_line_ends_from_middle() {
         let tree = main_multiline_tree(Some(multiline_first_line_middle_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let mut range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1495,7 +1495,7 @@ mod tests {
     #[test]
     fn multiline_find_paragraph_ends_from_middle() {
         let tree = main_multiline_tree(Some(multiline_second_line_middle_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let mut range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1539,7 +1539,7 @@ mod tests {
     #[test]
     fn multiline_find_word_ends_from_middle() {
         let tree = main_multiline_tree(Some(multiline_second_line_middle_selection()));
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
         let mut range = node.text_selection().unwrap();
         assert!(range.is_degenerate());
@@ -1567,7 +1567,7 @@ mod tests {
     #[test]
     fn text_position_at_point() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
 
         {
@@ -1659,7 +1659,7 @@ mod tests {
     #[test]
     fn to_global_utf16_index() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
 
         {
@@ -1684,7 +1684,7 @@ mod tests {
     #[test]
     fn to_line_index() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
 
         {
@@ -1710,7 +1710,7 @@ mod tests {
     #[test]
     fn line_range_from_index() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
 
         {
@@ -1749,7 +1749,7 @@ mod tests {
     #[test]
     fn text_position_from_global_utf16_index() {
         let tree = main_multiline_tree(None);
-        let state = tree.read();
+        let state = tree.state();
         let node = state.node_by_id(NODE_ID_2).unwrap();
 
         {

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -1015,8 +1015,6 @@ mod tests {
     use accesskit::{NodeId, Point, Rect, TextSelection};
     use std::num::NonZeroU128;
 
-    use crate::tests::NullActionHandler;
-
     const NODE_ID_1: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(1) });
     const NODE_ID_2: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(2) });
     const NODE_ID_3: NodeId = NodeId(unsafe { NonZeroU128::new_unchecked(3) });
@@ -1210,7 +1208,7 @@ mod tests {
             focus: Some(NODE_ID_2),
         };
 
-        crate::Tree::new(update, Box::new(NullActionHandler {}))
+        crate::Tree::new(update)
     }
 
     fn multiline_end_selection() -> TextSelection {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -247,7 +247,12 @@ impl State {
 pub trait ChangeHandler {
     fn node_added(&mut self, node: &Node);
     fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node);
-    fn focus_moved(&mut self, old_node: Option<&DetachedNode>, new_node: Option<&Node>);
+    fn focus_moved(
+        &mut self,
+        old_node: Option<&DetachedNode>,
+        new_node: Option<&Node>,
+        current_state: &State,
+    );
     /// The tree update process doesn't currently collect all possible information
     /// about removed nodes. The following methods don't accurately reflect
     /// the full state of the old node:
@@ -313,7 +318,11 @@ impl Tree {
                     }
                 }
             }
-            handler.focus_moved(focus_change.old_focus.as_ref(), new_node.as_ref());
+            handler.focus_moved(
+                focus_change.old_focus.as_ref(),
+                new_node.as_ref(),
+                &self.state,
+            );
         }
         for node in changes.removed_nodes.values() {
             handler.node_removed(node, &self.state);
@@ -441,6 +450,7 @@ mod tests {
                 &mut self,
                 _old_node: Option<&crate::DetachedNode>,
                 _new_node: Option<&crate::Node>,
+                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }
@@ -519,6 +529,7 @@ mod tests {
                 &mut self,
                 _old_node: Option<&crate::DetachedNode>,
                 _new_node: Option<&crate::Node>,
+                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }
@@ -609,6 +620,7 @@ mod tests {
                 &mut self,
                 old_node: Option<&crate::DetachedNode>,
                 new_node: Option<&crate::Node>,
+                _current_state: &crate::TreeState,
             ) {
                 if let (Some(old_node), Some(new_node)) = (old_node, new_node) {
                     if old_node.id() == NODE_ID_2 && new_node.id() == NODE_ID_3 {
@@ -697,6 +709,7 @@ mod tests {
                 &mut self,
                 _old_node: Option<&crate::DetachedNode>,
                 _new_node: Option<&crate::Node>,
+                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -15,4 +15,3 @@ accesskit = { version = "0.9.0", path = "../../common" }
 accesskit_consumer = { version = "0.13.0", path = "../../consumer" }
 objc2 = "=0.3.0-beta.3"
 once_cell = "1.13.0"
-parking_lot = "0.12.1"

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -27,20 +27,22 @@ impl Adapter {
     /// Create a new macOS adapter. This function must be called on
     /// the main thread.
     ///
+    /// The action handler will always be called on the main thread.
+    ///
     /// # Safety
     ///
     /// `view` must be a valid, unreleased pointer to an `NSView`.
     pub unsafe fn new(
         view: *mut c_void,
         initial_state: TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: impl 'static + ActionHandler,
     ) -> Self {
         let view = unsafe { Id::retain(view as *mut NSView) }.unwrap();
         let view = WeakId::new(&view);
-        let tree = Tree::new(initial_state, action_handler);
+        let tree = Tree::new(initial_state);
         let mtm = MainThreadMarker::new().unwrap();
         Self {
-            context: Context::new(view, tree, mtm),
+            context: Context::new(view, tree, action_handler, mtm),
         }
     }
 

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -35,7 +35,7 @@ impl Adapter {
     pub unsafe fn new(
         view: *mut c_void,
         initial_state: TreeUpdate,
-        action_handler: impl 'static + ActionHandler,
+        action_handler: Box<dyn ActionHandler>,
     ) -> Self {
         let view = unsafe { Id::retain(view as *mut NSView) }.unwrap();
         let view = WeakId::new(&view);

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -25,13 +25,13 @@ impl Context {
     pub(crate) fn new(
         view: WeakId<NSView>,
         tree: Tree,
-        action_handler: impl 'static + ActionHandler,
+        action_handler: Box<dyn ActionHandler>,
         mtm: MainThreadMarker,
     ) -> Rc<Self> {
         Rc::new(Self {
             view,
             tree: RefCell::new(tree),
-            action_handler: Box::new(action_handler),
+            action_handler,
             platform_nodes: RefCell::new(HashMap::new()),
             _mtm: mtm,
         })

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -15,7 +15,7 @@ use crate::{appkit::*, node::PlatformNode};
 
 pub(crate) struct Context {
     pub(crate) view: WeakId<NSView>,
-    pub(crate) tree: Tree,
+    pub(crate) tree: RefCell<Tree>,
     platform_nodes: RefCell<HashMap<NodeId, Id<PlatformNode, Shared>>>,
     _mtm: MainThreadMarker,
 }
@@ -24,7 +24,7 @@ impl Context {
     pub(crate) fn new(view: WeakId<NSView>, tree: Tree, mtm: MainThreadMarker) -> Rc<Self> {
         Rc::new(Self {
             view,
-            tree,
+            tree: RefCell::new(tree),
             platform_nodes: RefCell::new(HashMap::new()),
             _mtm: mtm,
         })

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::NodeId;
+use accesskit::{ActionHandler, NodeId};
 use accesskit_consumer::Tree;
 use objc2::{
     foundation::MainThreadMarker,
@@ -16,15 +16,22 @@ use crate::{appkit::*, node::PlatformNode};
 pub(crate) struct Context {
     pub(crate) view: WeakId<NSView>,
     pub(crate) tree: RefCell<Tree>,
+    pub(crate) action_handler: Box<dyn ActionHandler>,
     platform_nodes: RefCell<HashMap<NodeId, Id<PlatformNode, Shared>>>,
     _mtm: MainThreadMarker,
 }
 
 impl Context {
-    pub(crate) fn new(view: WeakId<NSView>, tree: Tree, mtm: MainThreadMarker) -> Rc<Self> {
+    pub(crate) fn new(
+        view: WeakId<NSView>,
+        tree: Tree,
+        action_handler: impl 'static + ActionHandler,
+        mtm: MainThreadMarker,
+    ) -> Rc<Self> {
         Rc::new(Self {
             view,
             tree: RefCell::new(tree),
+            action_handler: Box::new(action_handler),
             platform_nodes: RefCell::new(HashMap::new()),
             _mtm: mtm,
         })

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -201,7 +201,12 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&DetachedNode>, new_node: Option<&Node>) {
+    fn focus_moved(
+        &mut self,
+        _old_node: Option<&DetachedNode>,
+        new_node: Option<&Node>,
+        _current_state: &TreeState,
+    ) {
         if let Some(new_node) = new_node {
             if filter(new_node) != FilterResult::Include {
                 return;

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -776,7 +776,8 @@ impl PlatformNode {
         F: FnOnce(&Node, &Rc<Context>) -> T,
     {
         let context = self.boxed.context.upgrade()?;
-        let state = context.tree.read();
+        let tree = context.tree.borrow();
+        let state = tree.state();
         let node = state.node_by_id(self.boxed.node_id)?;
         Some(f(&node, &context))
     }
@@ -792,7 +793,11 @@ impl PlatformNode {
     where
         F: FnOnce(&Node, &Tree) -> T,
     {
-        self.resolve_with_context(|node, context| f(node, &context.tree))
+        let context = self.boxed.context.upgrade()?;
+        let tree = context.tree.borrow();
+        let state = tree.state();
+        let node = state.node_by_id(self.boxed.node_id)?;
+        Some(f(&node, &tree))
     }
 
     fn children_internal(&self) -> *mut NSArray<PlatformNode> {

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -10,8 +10,8 @@
 
 #![allow(non_upper_case_globals)]
 
-use accesskit::{CheckedState, NodeId, Role, TextSelection};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, Tree};
+use accesskit::{Action, ActionData, ActionRequest, CheckedState, NodeId, Role, TextSelection};
+use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState};
 use objc2::{
     declare::{Ivar, IvarDrop},
     declare_class,
@@ -489,15 +489,23 @@ declare_class!(
 
         #[sel(setAccessibilityFocused:)]
         fn set_focused(&self, focused: bool) {
-            self.resolve_with_tree(|node, tree| {
+            self.resolve_with_context(|node, context| {
                 if focused {
                     if node.is_focusable() {
-                        tree.set_focus(node.id());
+                        context.action_handler.do_action(ActionRequest {
+                            action: Action::Focus,
+                            target: node.id(),
+                            data: None,
+                        });
                     }
                 } else {
                     let root = node.tree_state.root();
                     if root.is_focusable() {
-                        tree.set_focus(root.id());
+                        context.action_handler.do_action(ActionRequest {
+                            action: Action::Focus,
+                            target: root.id(),
+                            data: None,
+                        });
                     }
                 }
             });
@@ -505,10 +513,14 @@ declare_class!(
 
         #[sel(accessibilityPerformPress)]
         fn press(&self) -> bool {
-            self.resolve_with_tree(|node, tree| {
+            self.resolve_with_context(|node, context| {
                 let clickable = node.is_clickable();
                 if clickable {
-                    tree.do_default_action(node.id());
+                    context.action_handler.do_action(ActionRequest {
+                        action: Action::Default,
+                        target: node.id(),
+                        data: None,
+                    });
                 }
                 clickable
             })
@@ -517,10 +529,14 @@ declare_class!(
 
         #[sel(accessibilityPerformIncrement)]
         fn increment(&self) -> bool {
-            self.resolve_with_tree(|node, tree| {
+            self.resolve_with_context(|node, context| {
                 let supports_increment = node.supports_increment();
                 if supports_increment {
-                    tree.increment(node.id());
+                    context.action_handler.do_action(ActionRequest {
+                        action: Action::Increment,
+                        target: node.id(),
+                        data: None,
+                    });
                 }
                 supports_increment
             })
@@ -529,10 +545,14 @@ declare_class!(
 
         #[sel(accessibilityPerformDecrement)]
         fn decrement(&self) -> bool {
-            self.resolve_with_tree(|node, tree| {
+            self.resolve_with_context(|node, context| {
                 let supports_decrement = node.supports_decrement();
                 if supports_decrement {
-                    tree.decrement(node.id());
+                    context.action_handler.do_action(ActionRequest {
+                        action: Action::Decrement,
+                        target: node.id(),
+                        data: None,
+                    });
                 }
                 supports_decrement
             })
@@ -696,10 +716,14 @@ declare_class!(
 
         #[sel(setAccessibilitySelectedTextRange:)]
         fn set_selected_text_range(&self, range: NSRange) {
-            self.resolve_with_tree(|node, tree| {
+            self.resolve_with_context(|node, context| {
                 if node.supports_text_ranges() {
                     if let Some(range) = from_ns_range(node, range) {
-                        tree.select_text_range(&range);
+                        context.action_handler.do_action(ActionRequest {
+                            action: Action::SetTextSelection,
+                            target: node.id(),
+                            data: Some(ActionData::SetTextSelection(range.to_text_selection())),
+                        });
                     }
                 }
             });
@@ -787,17 +811,6 @@ impl PlatformNode {
         F: FnOnce(&Node) -> T,
     {
         self.resolve_with_context(|node, _| f(node))
-    }
-
-    fn resolve_with_tree<F, T>(&self, f: F) -> Option<T>
-    where
-        F: FnOnce(&Node, &Tree) -> T,
-    {
-        let context = self.boxed.context.upgrade()?;
-        let tree = context.tree.borrow();
-        let state = tree.state();
-        let node = state.node_by_id(self.boxed.node_id)?;
-        Some(f(&node, &tree))
     }
 
     fn children_internal(&self) -> *mut NSArray<PlatformNode> {

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -112,7 +112,7 @@ impl SubclassingAdapter {
     pub unsafe fn new(
         view: *mut c_void,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: impl 'static + ActionHandler,
+        action_handler: Box<dyn ActionHandler>,
     ) -> Self {
         let view = view as *mut NSView;
         let retained_view = unsafe { Id::retain(view) }.unwrap();

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -104,13 +104,15 @@ pub struct SubclassingAdapter {
 impl SubclassingAdapter {
     /// Create an adapter that dynamically subclasses the specified view.
     ///
+    /// The action handler will always be called on the main thread.
+    ///
     /// # Safety
     ///
     /// `view` must be a valid, unreleased pointer to an `NSView`.
     pub unsafe fn new(
         view: *mut c_void,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: impl 'static + ActionHandler,
     ) -> Self {
         let view = view as *mut NSView;
         let retained_view = unsafe { Id::retain(view) }.unwrap();

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -18,8 +18,7 @@ use objc2::{
     sel, ClassType,
 };
 use once_cell::{sync::Lazy as SyncLazy, unsync::Lazy};
-use parking_lot::Mutex;
-use std::{collections::HashMap, ffi::c_void};
+use std::{collections::HashMap, ffi::c_void, sync::Mutex};
 
 use crate::{appkit::NSView, event::QueuedEvents, Adapter};
 
@@ -135,7 +134,7 @@ impl SubclassingAdapter {
                 OBJC_ASSOCIATION_RETAIN_NONATOMIC,
             )
         };
-        let mut subclasses = SUBCLASSES.lock();
+        let mut subclasses = SUBCLASSES.lock().unwrap();
         let entry = subclasses.entry(prev_class);
         let subclass = entry.or_insert_with(|| {
             let name = format!("AccessKitSubclassOf{}", prev_class.name());

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -16,6 +16,5 @@ accesskit_consumer = { version = "0.13.0", path = "../../consumer" }
 async-channel = "1.8.0"
 atspi = "0.8.7"
 futures-lite = "1.12.0"
-parking_lot = "0.12.1"
 serde = "1.0"
 zbus = "3.6"

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -11,24 +11,23 @@ use crate::{
         },
         Bus, ObjectId, ACCESSIBLE_PATH_PREFIX,
     },
-    node::{filter, filter_detached, NodeWrapper, PlatformNode, PlatformRootNode},
-    util::{AppContext, WindowBounds},
+    context::Context,
+    node::{filter, filter_detached, NodeWrapper, PlatformNode},
+    util::AppContext,
 };
 use accesskit::{ActionHandler, NodeId, Rect, Role, TreeUpdate};
 use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
 use async_channel::{Receiver, Sender};
 use atspi::{Interface, InterfaceSet, State};
 use futures_lite::StreamExt;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use zbus::Task;
 
 pub struct Adapter {
     atspi_bus: Bus,
     _event_task: Task<()>,
     events: Sender<Event>,
-    _app_context: Arc<RwLock<AppContext>>,
-    root_window_bounds: Arc<RwLock<WindowBounds>>,
-    tree: Arc<RwLock<Tree>>,
+    context: Arc<Context>,
 }
 
 impl Adapter {
@@ -38,7 +37,7 @@ impl Adapter {
         toolkit_name: String,
         toolkit_version: String,
         initial_state: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Option<Self> {
         let mut atspi_bus = Bus::a11y_bus()?;
         let (event_sender, event_receiver) = async_channel::unbounded();
@@ -49,29 +48,22 @@ impl Adapter {
             },
             "accesskit_event_task",
         );
-        let tree = Arc::new(RwLock::new(Tree::new(initial_state(), action_handler)));
-        let app_context = Arc::new(RwLock::new(AppContext::new(
-            app_name,
-            toolkit_name,
-            toolkit_version,
-        )));
-        atspi_bus
-            .register_root_node(PlatformRootNode::new(&app_context, &tree))
-            .ok()?;
+        let tree = Tree::new(initial_state());
+        let app_context = AppContext::new(app_name, toolkit_name, toolkit_version);
+        let context = Context::new(tree, action_handler, app_context);
+        atspi_bus.register_root_node(&context).ok()?;
         let adapter = Adapter {
             atspi_bus,
             _event_task: event_task,
             events: event_sender,
-            _app_context: app_context,
-            root_window_bounds: Arc::new(RwLock::new(WindowBounds::default())),
-            tree,
+            context,
         };
         adapter.register_tree();
         Some(adapter)
     }
 
     fn register_tree(&self) {
-        let tree = self.tree.read().unwrap();
+        let tree = self.context.read_tree();
         let tree_state = tree.state();
         let mut objects_to_add = Vec::new();
 
@@ -86,40 +78,38 @@ impl Adapter {
         add_children(tree_state.root(), &mut objects_to_add);
         for id in objects_to_add {
             let interfaces = NodeWrapper::Node(&tree_state.node_by_id(id).unwrap()).interfaces();
-            self.register_interfaces(&self.tree, id, interfaces)
-                .unwrap();
+            self.register_interfaces(id, interfaces).unwrap();
         }
     }
 
-    fn register_interfaces(
-        &self,
-        tree: &Arc<RwLock<Tree>>,
-        id: NodeId,
-        new_interfaces: InterfaceSet,
-    ) -> zbus::Result<bool> {
+    fn register_interfaces(&self, id: NodeId, new_interfaces: InterfaceSet) -> zbus::Result<bool> {
         let path = format!("{}{}", ACCESSIBLE_PATH_PREFIX, ObjectId::from(id).as_str());
         if new_interfaces.contains(Interface::Accessible) {
             self.atspi_bus.register_interface(
                 &path,
                 AccessibleInterface::new(
                     self.atspi_bus.unique_name().to_owned(),
-                    PlatformNode::new(tree, id),
+                    PlatformNode::new(&self.context, id),
                 ),
             )?;
         }
         if new_interfaces.contains(Interface::Action) {
-            self.atspi_bus
-                .register_interface(&path, ActionInterface::new(PlatformNode::new(tree, id)))?;
+            self.atspi_bus.register_interface(
+                &path,
+                ActionInterface::new(PlatformNode::new(&self.context, id)),
+            )?;
         }
         if new_interfaces.contains(Interface::Component) {
             self.atspi_bus.register_interface(
                 &path,
-                ComponentInterface::new(PlatformNode::new(tree, id), &self.root_window_bounds),
+                ComponentInterface::new(PlatformNode::new(&self.context, id)),
             )?;
         }
         if new_interfaces.contains(Interface::Value) {
-            self.atspi_bus
-                .register_interface(&path, ValueInterface::new(PlatformNode::new(tree, id)))?;
+            self.atspi_bus.register_interface(
+                &path,
+                ValueInterface::new(PlatformNode::new(&self.context, id)),
+            )?;
         }
         Ok(true)
     }
@@ -150,7 +140,7 @@ impl Adapter {
     }
 
     pub fn set_root_window_bounds(&self, outer: Rect, inner: Rect) {
-        let mut bounds = self.root_window_bounds.write().unwrap();
+        let mut bounds = self.context.root_window_bounds.write().unwrap();
         bounds.outer = outer;
         bounds.inner = inner;
     }
@@ -159,13 +149,12 @@ impl Adapter {
     pub fn update(&self, update: TreeUpdate) {
         struct Handler<'a> {
             adapter: &'a Adapter,
-            tree: &'a Arc<RwLock<Tree>>,
         }
         impl Handler<'_> {
             fn add_node(&mut self, node: &Node) {
                 let interfaces = NodeWrapper::Node(node).interfaces();
                 self.adapter
-                    .register_interfaces(self.tree, node.id(), interfaces)
+                    .register_interfaces(node.id(), interfaces)
                     .unwrap();
             }
             fn remove_node(&mut self, node: &DetachedNode) {
@@ -207,14 +196,10 @@ impl Adapter {
                         .unregister_interfaces(&new_wrapper.id(), old_interfaces ^ kept_interfaces)
                         .unwrap();
                     self.adapter
-                        .register_interfaces(
-                            self.tree,
-                            new_node.id(),
-                            new_interfaces ^ kept_interfaces,
-                        )
+                        .register_interfaces(new_node.id(), new_interfaces ^ kept_interfaces)
                         .unwrap();
                     new_wrapper.notify_changes(
-                        &self.adapter.root_window_bounds.read().unwrap(),
+                        &self.adapter.context.read_root_window_bounds(),
                         &self.adapter.events,
                         &old_wrapper,
                     );
@@ -226,8 +211,7 @@ impl Adapter {
                 new_node: Option<&Node>,
                 current_state: &TreeState,
             ) {
-                let tree = self.tree.read().unwrap();
-                if let Some(root_window) = root_window(tree.state()) {
+                if let Some(root_window) = root_window(current_state) {
                     if old_node.is_none() && new_node.is_some() {
                         self.adapter.window_activated(
                             &NodeWrapper::Node(&root_window),
@@ -265,11 +249,8 @@ impl Adapter {
                 }
             }
         }
-        let mut handler = Handler {
-            adapter: self,
-            tree: &self.tree,
-        };
-        let mut tree = self.tree.write().unwrap();
+        let mut handler = Handler { adapter: self };
+        let mut tree = self.context.tree.write().unwrap();
         tree.update_and_process_changes(update, &mut handler);
     }
 

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -37,7 +37,7 @@ impl Adapter {
         toolkit_name: String,
         toolkit_version: String,
         initial_state: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: Box<dyn ActionHandler + Send + Sync>,
     ) -> Option<Self> {
         let mut atspi_bus = Bus::a11y_bus()?;
         let (event_sender, event_receiver) = async_channel::unbounded();

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -220,7 +220,12 @@ impl Adapter {
                     );
                 }
             }
-            fn focus_moved(&mut self, old_node: Option<&DetachedNode>, new_node: Option<&Node>) {
+            fn focus_moved(
+                &mut self,
+                old_node: Option<&DetachedNode>,
+                new_node: Option<&Node>,
+                current_state: &TreeState,
+            ) {
                 let tree = self.tree.read().unwrap();
                 if let Some(root_window) = root_window(tree.state()) {
                     if old_node.is_none() && new_node.is_some() {

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -68,7 +68,7 @@ impl Bus {
                 ObjectPath::from_str_unchecked(ROOT_PATH),
             ))?;
             if let Some(context) = node.context.upgrade() {
-                context.write().desktop_address = Some(desktop.into());
+                context.write().unwrap().desktop_address = Some(desktop.into());
             }
             Ok(true)
         } else {

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -115,7 +115,7 @@ impl AccessibleInterface<PlatformRootNode> {
         self.node
             .context
             .upgrade()
-            .map(|context| context.read().name.clone())
+            .map(|context| context.read().unwrap().name.clone())
             .unwrap_or_default()
     }
 
@@ -129,7 +129,7 @@ impl AccessibleInterface<PlatformRootNode> {
         self.node
             .context
             .upgrade()
-            .and_then(|context| context.read().desktop_address.clone())
+            .and_then(|context| context.read().unwrap().desktop_address.clone())
             .unwrap_or_else(|| OwnedObjectAddress::null(self.bus_name.clone()))
     }
 
@@ -162,7 +162,7 @@ impl AccessibleInterface<PlatformRootNode> {
             .node
             .tree
             .upgrade()
-            .map(|tree| ObjectRef::Managed(tree.read().root().id().into()));
+            .map(|tree| ObjectRef::Managed(tree.read().unwrap().state().root().id().into()));
         super::object_address(hdr.destination()?, child)
     }
 
@@ -174,7 +174,7 @@ impl AccessibleInterface<PlatformRootNode> {
             .map(|tree| {
                 vec![OwnedObjectAddress::accessible(
                     self.bus_name.clone(),
-                    tree.read().root().id().into(),
+                    tree.read().unwrap().state().root().id().into(),
                 )]
             })
             .ok_or_else(|| unknown_object(&ObjectId::root()))

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -115,7 +115,7 @@ impl AccessibleInterface<PlatformRootNode> {
         self.node
             .context
             .upgrade()
-            .map(|context| context.read().unwrap().name.clone())
+            .map(|context| context.read_app_context().name.clone())
             .unwrap_or_default()
     }
 
@@ -129,7 +129,7 @@ impl AccessibleInterface<PlatformRootNode> {
         self.node
             .context
             .upgrade()
-            .and_then(|context| context.read().unwrap().desktop_address.clone())
+            .and_then(|context| context.read_app_context().desktop_address.clone())
             .unwrap_or_else(|| OwnedObjectAddress::null(self.bus_name.clone()))
     }
 
@@ -160,21 +160,21 @@ impl AccessibleInterface<PlatformRootNode> {
         }
         let child = self
             .node
-            .tree
+            .context
             .upgrade()
-            .map(|tree| ObjectRef::Managed(tree.read().unwrap().state().root().id().into()));
+            .map(|context| ObjectRef::Managed(context.read_tree().state().root().id().into()));
         super::object_address(hdr.destination()?, child)
     }
 
     fn get_children(&self) -> fdo::Result<Vec<OwnedObjectAddress>> {
         // TODO: Handle multiple top-level windows.
         self.node
-            .tree
+            .context
             .upgrade()
-            .map(|tree| {
+            .map(|context| {
                 vec![OwnedObjectAddress::accessible(
                     self.bus_name.clone(),
-                    tree.read().unwrap().state().root().id().into(),
+                    context.read_tree().state().root().id().into(),
                 )]
             })
             .ok_or_else(|| unknown_object(&ObjectId::root()))

--- a/platforms/unix/src/atspi/interfaces/application.rs
+++ b/platforms/unix/src/atspi/interfaces/application.rs
@@ -15,7 +15,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.read().unwrap().toolkit_name.clone())
+            .map(|context| context.read_app_context().toolkit_name.clone())
             .unwrap_or_default()
     }
 
@@ -24,7 +24,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.read().unwrap().toolkit_version.clone())
+            .map(|context| context.read_app_context().toolkit_version.clone())
             .unwrap_or_default()
     }
 
@@ -38,7 +38,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .and_then(|context| context.read().unwrap().id)
+            .and_then(|context| context.read_app_context().id)
             .unwrap_or(-1)
     }
 
@@ -47,7 +47,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.write().unwrap().id = Some(id))
+            .map(|context| context.app_context.write().unwrap().id = Some(id))
             .ok_or_else(|| unknown_object(&ObjectId::root()))
     }
 }

--- a/platforms/unix/src/atspi/interfaces/application.rs
+++ b/platforms/unix/src/atspi/interfaces/application.rs
@@ -15,7 +15,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.read().toolkit_name.clone())
+            .map(|context| context.read().unwrap().toolkit_name.clone())
             .unwrap_or_default()
     }
 
@@ -24,7 +24,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.read().toolkit_version.clone())
+            .map(|context| context.read().unwrap().toolkit_version.clone())
             .unwrap_or_default()
     }
 
@@ -38,7 +38,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .and_then(|context| context.read().id)
+            .and_then(|context| context.read().unwrap().id)
             .unwrap_or(-1)
     }
 
@@ -47,7 +47,7 @@ impl ApplicationInterface {
         self.0
             .context
             .upgrade()
-            .map(|context| context.write().id = Some(id))
+            .map(|context| context.write().unwrap().id = Some(id))
             .ok_or_else(|| unknown_object(&ObjectId::root()))
     }
 }

--- a/platforms/unix/src/atspi/interfaces/component.rs
+++ b/platforms/unix/src/atspi/interfaces/component.rs
@@ -5,44 +5,25 @@
 
 use crate::{
     atspi::{OwnedObjectAddress, Rect},
-    unknown_object,
-    util::WindowBounds,
     PlatformNode,
 };
 use atspi::{component::Layer, CoordType};
-use std::sync::{Arc, RwLock, Weak};
 use zbus::{fdo, MessageHeader};
 
 pub(crate) struct ComponentInterface {
     node: PlatformNode,
-    root_window_bounds: Weak<RwLock<WindowBounds>>,
 }
 
 impl ComponentInterface {
-    pub(crate) fn new(node: PlatformNode, root_window_bounds: &Arc<RwLock<WindowBounds>>) -> Self {
-        Self {
-            node,
-            root_window_bounds: Arc::downgrade(root_window_bounds),
-        }
-    }
-
-    fn upgrade_bounds(&self) -> fdo::Result<Arc<RwLock<WindowBounds>>> {
-        if let Some(bounds) = self.root_window_bounds.upgrade() {
-            Ok(bounds)
-        } else {
-            Err(unknown_object(&self.node.accessible_id()))
-        }
+    pub(crate) fn new(node: PlatformNode) -> Self {
+        Self { node }
     }
 }
 
 #[dbus_interface(name = "org.a11y.atspi.Component")]
 impl ComponentInterface {
     fn contains(&self, x: i32, y: i32, coord_type: CoordType) -> fdo::Result<bool> {
-        let window_bounds = self.upgrade_bounds()?;
-        let contains = self
-            .node
-            .contains(&window_bounds.read().unwrap(), x, y, coord_type);
-        contains
+        self.node.contains(x, y, coord_type)
     }
 
     fn get_accessible_at_point(
@@ -52,19 +33,12 @@ impl ComponentInterface {
         y: i32,
         coord_type: CoordType,
     ) -> fdo::Result<(OwnedObjectAddress,)> {
-        let window_bounds = self.upgrade_bounds()?;
-        let accessible =
-            self.node
-                .get_accessible_at_point(&window_bounds.read().unwrap(), x, y, coord_type)?;
+        let accessible = self.node.get_accessible_at_point(x, y, coord_type)?;
         super::object_address(hdr.destination()?, accessible)
     }
 
     fn get_extents(&self, coord_type: CoordType) -> fdo::Result<(Rect,)> {
-        let window_bounds = self.upgrade_bounds()?;
-        let extents = self
-            .node
-            .get_extents(&window_bounds.read().unwrap(), coord_type);
-        extents
+        self.node.get_extents(coord_type)
     }
 
     fn get_layer(&self) -> fdo::Result<Layer> {
@@ -76,10 +50,6 @@ impl ComponentInterface {
     }
 
     fn scroll_to_point(&self, coord_type: CoordType, x: i32, y: i32) -> fdo::Result<bool> {
-        let window_bounds = self.upgrade_bounds()?;
-        let scrolled = self
-            .node
-            .scroll_to_point(&window_bounds.read().unwrap(), coord_type, x, y);
-        scrolled
+        self.node.scroll_to_point(coord_type, x, y)
     }
 }

--- a/platforms/unix/src/atspi/interfaces/component.rs
+++ b/platforms/unix/src/atspi/interfaces/component.rs
@@ -10,8 +10,7 @@ use crate::{
     PlatformNode,
 };
 use atspi::{component::Layer, CoordType};
-use parking_lot::RwLock;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, RwLock, Weak};
 use zbus::{fdo, MessageHeader};
 
 pub(crate) struct ComponentInterface {
@@ -40,7 +39,9 @@ impl ComponentInterface {
 impl ComponentInterface {
     fn contains(&self, x: i32, y: i32, coord_type: CoordType) -> fdo::Result<bool> {
         let window_bounds = self.upgrade_bounds()?;
-        let contains = self.node.contains(&window_bounds.read(), x, y, coord_type);
+        let contains = self
+            .node
+            .contains(&window_bounds.read().unwrap(), x, y, coord_type);
         contains
     }
 
@@ -54,13 +55,15 @@ impl ComponentInterface {
         let window_bounds = self.upgrade_bounds()?;
         let accessible =
             self.node
-                .get_accessible_at_point(&window_bounds.read(), x, y, coord_type)?;
+                .get_accessible_at_point(&window_bounds.read().unwrap(), x, y, coord_type)?;
         super::object_address(hdr.destination()?, accessible)
     }
 
     fn get_extents(&self, coord_type: CoordType) -> fdo::Result<(Rect,)> {
         let window_bounds = self.upgrade_bounds()?;
-        let extents = self.node.get_extents(&window_bounds.read(), coord_type);
+        let extents = self
+            .node
+            .get_extents(&window_bounds.read().unwrap(), coord_type);
         extents
     }
 
@@ -76,7 +79,7 @@ impl ComponentInterface {
         let window_bounds = self.upgrade_bounds()?;
         let scrolled = self
             .node
-            .scroll_to_point(&window_bounds.read(), coord_type, x, y);
+            .scroll_to_point(&window_bounds.read().unwrap(), coord_type, x, y);
         scrolled
     }
 }

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -5,13 +5,13 @@
 
 use accesskit::{ActionHandler, ActionRequest};
 use accesskit_consumer::Tree;
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 use crate::util::{AppContext, WindowBounds};
 
 pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
-    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
+    action_handler: Box<dyn ActionHandler + Send + Sync>,
     pub(crate) app_context: RwLock<AppContext>,
     pub(crate) root_window_bounds: RwLock<WindowBounds>,
 }
@@ -19,12 +19,12 @@ pub(crate) struct Context {
 impl Context {
     pub(crate) fn new(
         tree: Tree,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: Box<dyn ActionHandler + Send + Sync>,
         app_context: AppContext,
     ) -> Arc<Self> {
         Arc::new(Self {
             tree: RwLock::new(tree),
-            action_handler: Mutex::new(action_handler),
+            action_handler,
             app_context: RwLock::new(app_context),
             root_window_bounds: RwLock::new(Default::default()),
         })
@@ -43,6 +43,6 @@ impl Context {
     }
 
     pub(crate) fn do_action(&self, request: ActionRequest) {
-        self.action_handler.lock().unwrap().do_action(request);
+        self.action_handler.do_action(request);
     }
 }

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::{ActionHandler, ActionRequest};
+use accesskit_consumer::Tree;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+
+use crate::util::{AppContext, WindowBounds};
+
+pub(crate) struct Context {
+    pub(crate) tree: RwLock<Tree>,
+    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
+    pub(crate) app_context: RwLock<AppContext>,
+    pub(crate) root_window_bounds: RwLock<WindowBounds>,
+}
+
+impl Context {
+    pub(crate) fn new(
+        tree: Tree,
+        action_handler: Box<dyn ActionHandler + Send>,
+        app_context: AppContext,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            tree: RwLock::new(tree),
+            action_handler: Mutex::new(action_handler),
+            app_context: RwLock::new(app_context),
+            root_window_bounds: RwLock::new(Default::default()),
+        })
+    }
+
+    pub(crate) fn read_tree(&self) -> RwLockReadGuard<'_, Tree> {
+        self.tree.read().unwrap()
+    }
+
+    pub(crate) fn read_app_context(&self) -> RwLockReadGuard<'_, AppContext> {
+        self.app_context.read().unwrap()
+    }
+
+    pub(crate) fn read_root_window_bounds(&self) -> RwLockReadGuard<'_, WindowBounds> {
+        self.root_window_bounds.read().unwrap()
+    }
+
+    pub(crate) fn do_action(&self, request: ActionRequest) {
+        self.action_handler.lock().unwrap().do_action(request);
+    }
+}

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, ActionRequest};
+use accesskit::ActionHandler;
 use accesskit_consumer::Tree;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 
@@ -11,7 +11,7 @@ use crate::util::{AppContext, WindowBounds};
 
 pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
-    action_handler: Box<dyn ActionHandler + Send + Sync>,
+    pub(crate) action_handler: Box<dyn ActionHandler + Send + Sync>,
     pub(crate) app_context: RwLock<AppContext>,
     pub(crate) root_window_bounds: RwLock<WindowBounds>,
 }
@@ -40,9 +40,5 @@ impl Context {
 
     pub(crate) fn read_root_window_bounds(&self) -> RwLockReadGuard<'_, WindowBounds> {
         self.root_window_bounds.read().unwrap()
-    }
-
-    pub(crate) fn do_action(&self, request: ActionRequest) {
-        self.action_handler.do_action(request);
     }
 }

--- a/platforms/unix/src/lib.rs
+++ b/platforms/unix/src/lib.rs
@@ -8,6 +8,7 @@ extern crate zbus;
 
 mod adapter;
 mod atspi;
+mod context;
 mod node;
 mod util;
 

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -10,13 +10,17 @@
 
 use crate::{
     atspi::{
-        interfaces::{Action, Event, ObjectEvent, Property},
+        interfaces::{Action as AtspiAction, Event, ObjectEvent, Property},
         ObjectId, ObjectRef, Rect as AtspiRect, ACCESSIBLE_PATH_PREFIX,
     },
-    util::{AppContext, WindowBounds},
+    context::Context,
+    util::WindowBounds,
 };
-use accesskit::{Affine, CheckedState, DefaultActionVerb, NodeId, Point, Rect, Role};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, Tree, TreeState};
+use accesskit::{
+    Action, ActionData, ActionRequest, Affine, CheckedState, DefaultActionVerb, NodeId, Point,
+    Rect, Role,
+};
+use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
 use async_channel::Sender;
 use atspi::{
     accessible::Role as AtspiRole, component::Layer, CoordType, Interface, InterfaceSet, State,
@@ -24,7 +28,7 @@ use atspi::{
 };
 use std::{
     iter::FusedIterator,
-    sync::{Arc, RwLock, Weak},
+    sync::{Arc, Weak},
 };
 use zbus::fdo;
 
@@ -597,61 +601,69 @@ pub(crate) fn unknown_object(id: &ObjectId) -> fdo::Error {
 
 #[derive(Clone)]
 pub(crate) struct PlatformNode {
-    tree: Weak<RwLock<Tree>>,
+    context: Weak<Context>,
     node_id: NodeId,
 }
 
 impl PlatformNode {
-    pub(crate) fn new(tree: &Arc<RwLock<Tree>>, node_id: NodeId) -> Self {
+    pub(crate) fn new(context: &Arc<Context>, node_id: NodeId) -> Self {
         Self {
-            tree: Arc::downgrade(tree),
+            context: Arc::downgrade(context),
             node_id,
         }
     }
 
-    fn with_tree<F, T>(&self, f: F) -> fdo::Result<T>
-    where
-        F: FnOnce(&Tree) -> fdo::Result<T>,
-    {
-        if let Some(tree) = self.tree.upgrade() {
-            let tree = tree.read().unwrap();
-            f(&tree)
+    fn upgrade_context(&self) -> fdo::Result<Arc<Context>> {
+        if let Some(context) = self.context.upgrade() {
+            Ok(context)
         } else {
             Err(unknown_object(&self.accessible_id()))
         }
     }
 
-    fn with_tree_state<F, T>(&self, f: F) -> fdo::Result<T>
+    fn with_tree_state_and_context<F, T>(&self, f: F) -> fdo::Result<T>
     where
-        F: FnOnce(&TreeState) -> fdo::Result<T>,
+        F: FnOnce(&TreeState, &Context) -> fdo::Result<T>,
     {
-        self.with_tree(|tree| f(tree.state()))
+        let context = self.upgrade_context()?;
+        let tree = context.read_tree();
+        f(tree.state(), &context)
+    }
+
+    fn resolve_with_context<F, T>(&self, f: F) -> fdo::Result<T>
+    where
+        for<'a> F: FnOnce(Node<'a>, &Context) -> fdo::Result<T>,
+    {
+        self.with_tree_state_and_context(|state, context| {
+            if let Some(node) = state.node_by_id(self.node_id) {
+                f(node, context)
+            } else {
+                Err(unknown_object(&self.accessible_id()))
+            }
+        })
     }
 
     fn resolve<F, T>(&self, f: F) -> fdo::Result<T>
     where
         for<'a> F: FnOnce(Node<'a>) -> fdo::Result<T>,
     {
-        self.with_tree_state(|state| {
-            if let Some(node) = state.node_by_id(self.node_id) {
-                f(node)
-            } else {
-                Err(unknown_object(&self.accessible_id()))
-            }
-        })
+        self.resolve_with_context(|node, _| f(node))
     }
 
-    fn validate_for_action<F, T>(&self, f: F) -> fdo::Result<T>
+    fn do_action_internal<F>(&self, f: F) -> fdo::Result<()>
     where
-        F: FnOnce(&Tree) -> fdo::Result<T>,
+        F: FnOnce(&TreeState, &Context) -> ActionRequest,
     {
-        self.with_tree(|tree| {
-            if tree.state().has_node(self.node_id) {
-                f(tree)
-            } else {
-                Err(unknown_object(&self.accessible_id()))
-            }
-        })
+        let context = self.upgrade_context()?;
+        let tree = context.read_tree();
+        if tree.state().has_node(self.node_id) {
+            let request = f(tree.state(), &context);
+            drop(tree);
+            context.do_action(request);
+            Ok(())
+        } else {
+            Err(unknown_object(&self.accessible_id()))
+        }
     }
 
     pub fn name(&self) -> fdo::Result<String> {
@@ -750,13 +762,13 @@ impl PlatformNode {
         })
     }
 
-    pub fn get_actions(&self) -> fdo::Result<Vec<Action>> {
+    pub fn get_actions(&self) -> fdo::Result<Vec<AtspiAction>> {
         self.resolve(|node| {
             let wrapper = NodeWrapper::Node(&node);
             let n_actions = wrapper.n_actions() as usize;
             let mut actions = Vec::with_capacity(n_actions);
             for i in 0..n_actions {
-                actions.push(Action {
+                actions.push(AtspiAction {
                     localized_name: wrapper.get_action_name(i as i32),
                     description: "".into(),
                     key_binding: "".into(),
@@ -770,20 +782,17 @@ impl PlatformNode {
         if index != 0 {
             return Ok(false);
         }
-        self.validate_for_action(|tree| {
-            tree.do_default_action(self.node_id);
-            Ok(true)
-        })
+        self.do_action_internal(|_, _| ActionRequest {
+            action: Action::Default,
+            target: self.node_id,
+            data: None,
+        })?;
+        Ok(true)
     }
 
-    pub fn contains(
-        &self,
-        window_bounds: &WindowBounds,
-        x: i32,
-        y: i32,
-        coord_type: CoordType,
-    ) -> fdo::Result<bool> {
-        self.resolve(|node| {
+    pub fn contains(&self, x: i32, y: i32, coord_type: CoordType) -> fdo::Result<bool> {
+        self.resolve_with_context(|node, context| {
+            let window_bounds = context.read_root_window_bounds();
             let bounds = match node.bounding_box() {
                 Some(node_bounds) => {
                     let top_left = window_bounds.top_left(coord_type, node.is_root());
@@ -807,12 +816,12 @@ impl PlatformNode {
 
     pub fn get_accessible_at_point(
         &self,
-        window_bounds: &WindowBounds,
         x: i32,
         y: i32,
         coord_type: CoordType,
     ) -> fdo::Result<Option<ObjectRef>> {
-        self.resolve(|node| {
+        self.resolve_with_context(|node, context| {
+            let window_bounds = context.read_root_window_bounds();
             let top_left = window_bounds.top_left(coord_type, node.is_root());
             let point = Point::new(f64::from(x) - top_left.x, f64::from(y) - top_left.y);
             let point = node.transform().inverse() * point;
@@ -822,27 +831,26 @@ impl PlatformNode {
         })
     }
 
-    pub fn get_extents(
-        &self,
-        window_bounds: &WindowBounds,
-        coord_type: CoordType,
-    ) -> fdo::Result<(AtspiRect,)> {
-        self.resolve(|node| match node.bounding_box() {
-            Some(node_bounds) => {
-                let top_left = window_bounds.top_left(coord_type, node.is_root());
-                let new_origin =
-                    Point::new(top_left.x + node_bounds.x0, top_left.y + node_bounds.y0);
-                Ok((node_bounds.with_origin(new_origin).into(),))
+    pub fn get_extents(&self, coord_type: CoordType) -> fdo::Result<(AtspiRect,)> {
+        self.resolve_with_context(|node, context| {
+            let window_bounds = context.read_root_window_bounds();
+            match node.bounding_box() {
+                Some(node_bounds) => {
+                    let top_left = window_bounds.top_left(coord_type, node.is_root());
+                    let new_origin =
+                        Point::new(top_left.x + node_bounds.x0, top_left.y + node_bounds.y0);
+                    Ok((node_bounds.with_origin(new_origin).into(),))
+                }
+                None if node.is_root() => {
+                    let bounds = window_bounds.outer;
+                    Ok((match coord_type {
+                        CoordType::Screen => bounds.into(),
+                        CoordType::Window => bounds.with_origin(Point::ZERO).into(),
+                        _ => unimplemented!(),
+                    },))
+                }
+                _ => Err(unknown_object(&self.accessible_id())),
             }
-            None if node.is_root() => {
-                let bounds = window_bounds.outer;
-                Ok((match coord_type {
-                    CoordType::Screen => bounds.into(),
-                    CoordType::Window => bounds.with_origin(Point::ZERO).into(),
-                    _ => unimplemented!(),
-                },))
-            }
-            _ => Err(unknown_object(&self.accessible_id())),
         })
     }
 
@@ -858,26 +866,27 @@ impl PlatformNode {
     }
 
     pub fn grab_focus(&self) -> fdo::Result<bool> {
-        self.validate_for_action(|tree| {
-            tree.set_focus(self.node_id);
-            Ok(true)
-        })
+        self.do_action_internal(|_, _| ActionRequest {
+            action: Action::Focus,
+            target: self.node_id,
+            data: None,
+        })?;
+        Ok(true)
     }
 
-    pub fn scroll_to_point(
-        &self,
-        window_bounds: &WindowBounds,
-        coord_type: CoordType,
-        x: i32,
-        y: i32,
-    ) -> fdo::Result<bool> {
-        self.validate_for_action(|tree| {
-            let is_root = self.node_id == tree.state().root_id();
+    pub fn scroll_to_point(&self, coord_type: CoordType, x: i32, y: i32) -> fdo::Result<bool> {
+        self.do_action_internal(|tree_state, context| {
+            let window_bounds = context.read_root_window_bounds();
+            let is_root = self.node_id == tree_state.root_id();
             let top_left = window_bounds.top_left(coord_type, is_root);
             let point = Point::new(f64::from(x) - top_left.x, f64::from(y) - top_left.y);
-            tree.scroll_to_point(self.node_id, point);
-            Ok(true)
-        })
+            ActionRequest {
+                action: Action::ScrollToPoint,
+                target: self.node_id,
+                data: Some(ActionData::ScrollToPoint(point)),
+            }
+        })?;
+        Ok(true)
     }
 
     pub fn minimum_value(&self) -> fdo::Result<f64> {
@@ -900,24 +909,23 @@ impl PlatformNode {
     }
 
     pub fn set_current_value(&self, value: f64) -> fdo::Result<()> {
-        self.validate_for_action(|tree| {
-            tree.set_numeric_value(self.node_id, value);
-            Ok(())
+        self.do_action_internal(|_, _| ActionRequest {
+            action: Action::SetValue,
+            target: self.node_id,
+            data: Some(ActionData::NumericValue(value)),
         })
     }
 }
 
 #[derive(Clone)]
 pub(crate) struct PlatformRootNode {
-    pub(crate) context: Weak<RwLock<AppContext>>,
-    pub(crate) tree: Weak<RwLock<Tree>>,
+    pub(crate) context: Weak<Context>,
 }
 
 impl PlatformRootNode {
-    pub fn new(context: &Arc<RwLock<AppContext>>, tree: &Arc<RwLock<Tree>>) -> Self {
+    pub fn new(context: &Arc<Context>) -> Self {
         Self {
             context: Arc::downgrade(context),
-            tree: Arc::downgrade(tree),
         }
     }
 }

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -659,7 +659,7 @@ impl PlatformNode {
         if tree.state().has_node(self.node_id) {
             let request = f(tree.state(), &context);
             drop(tree);
-            context.do_action(request);
+            context.action_handler.do_action(request);
             Ok(())
         } else {
             Err(unknown_object(&self.accessible_id()))

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -15,7 +15,6 @@ accesskit = { version = "0.9.0", path = "../../common" }
 accesskit_consumer = { version = "0.13.0", path = "../../consumer" }
 arrayvec = "0.7.1"
 once_cell = "1.13.0"
-parking_lot = "0.12.1"
 paste = "1.0"
 
 [dependencies.windows]

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -30,7 +30,7 @@ impl Adapter {
     pub fn new(
         hwnd: HWND,
         initial_state: TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: Box<dyn ActionHandler + Send + Sync>,
         _uia_init_marker: UiaInitMarker,
     ) -> Self {
         let context = Context::new(hwnd, Tree::new(initial_state), action_handler);

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -135,7 +135,12 @@ impl Adapter {
                     });
                 }
             }
-            fn focus_moved(&mut self, _old_node: Option<&DetachedNode>, new_node: Option<&Node>) {
+            fn focus_moved(
+                &mut self,
+                _old_node: Option<&DetachedNode>,
+                new_node: Option<&Node>,
+                _current_state: &TreeState,
+            ) {
                 if let Some(new_node) = new_node {
                     let platform_node = PlatformNode::new(self.context, new_node.id());
                     let element: IRawElementProviderSimple = platform_node.into();

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -3,11 +3,12 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use std::{collections::HashSet, sync::Arc};
-
 use accesskit::{ActionHandler, Live, NodeId, Role, TreeUpdate};
 use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
-use parking_lot::RwLock;
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+};
 use windows::Win32::{
     Foundation::*,
     UI::{Accessibility::*, WindowsAndMessaging::*},
@@ -157,13 +158,13 @@ impl Adapter {
             queue: Vec::new(),
             text_changed: HashSet::new(),
         };
-        let mut tree = self.tree.write();
+        let mut tree = self.tree.write().unwrap();
         tree.update_and_process_changes(update, &mut handler);
         QueuedEvents(handler.queue)
     }
 
     fn root_platform_node(&self) -> PlatformNode {
-        let tree = self.tree.read();
+        let tree = self.tree.read().unwrap();
         let node_id = tree.state().root_id();
         PlatformNode::new(&self.tree, node_id, self.hwnd)
     }

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::{ActionHandler, ActionRequest, Point};
+use accesskit_consumer::Tree;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+use windows::Win32::Foundation::*;
+
+use crate::util::*;
+
+pub(crate) struct Context {
+    pub(crate) hwnd: HWND,
+    pub(crate) tree: RwLock<Tree>,
+    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
+}
+
+impl Context {
+    pub(crate) fn new(
+        hwnd: HWND,
+        tree: Tree,
+        action_handler: Box<dyn ActionHandler + Send>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            hwnd,
+            tree: RwLock::new(tree),
+            action_handler: Mutex::new(action_handler),
+        })
+    }
+
+    pub(crate) fn read_tree(&self) -> RwLockReadGuard<'_, Tree> {
+        self.tree.read().unwrap()
+    }
+
+    pub(crate) fn do_action(&self, request: ActionRequest) {
+        self.action_handler.lock().unwrap().do_action(request);
+    }
+
+    pub(crate) fn client_top_left(&self) -> Point {
+        client_top_left(self.hwnd)
+    }
+}

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -3,9 +3,9 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, ActionRequest, Point};
+use accesskit::{ActionHandler, Point};
 use accesskit_consumer::Tree;
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 use windows::Win32::Foundation::*;
 
 use crate::util::*;
@@ -13,28 +13,24 @@ use crate::util::*;
 pub(crate) struct Context {
     pub(crate) hwnd: HWND,
     pub(crate) tree: RwLock<Tree>,
-    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
+    pub(crate) action_handler: Box<dyn ActionHandler + Send + Sync>,
 }
 
 impl Context {
     pub(crate) fn new(
         hwnd: HWND,
         tree: Tree,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: Box<dyn ActionHandler + Send + Sync>,
     ) -> Arc<Self> {
         Arc::new(Self {
             hwnd,
             tree: RwLock::new(tree),
-            action_handler: Mutex::new(action_handler),
+            action_handler,
         })
     }
 
     pub(crate) fn read_tree(&self) -> RwLockReadGuard<'_, Tree> {
         self.tree.read().unwrap()
-    }
-
-    pub(crate) fn do_action(&self, request: ActionRequest) {
-        self.action_handler.lock().unwrap().do_action(request);
     }
 
     pub(crate) fn client_top_left(&self) -> Point {

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -3,6 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
+mod context;
 mod node;
 mod text;
 mod util;

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -10,17 +10,19 @@
 
 #![allow(non_upper_case_globals)]
 
-use accesskit::{CheckedState, Live, NodeId, NodeIdContent, Point, Role};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, Tree, TreeState};
+use accesskit::{
+    Action, ActionData, ActionRequest, CheckedState, Live, NodeId, NodeIdContent, Point, Role,
+};
+use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
 use arrayvec::ArrayVec;
 use paste::paste;
-use std::sync::{Arc, RwLock, Weak};
+use std::sync::{Arc, Weak};
 use windows::{
     core::*,
     Win32::{Foundation::*, System::Com::*, UI::Accessibility::*},
 };
 
-use crate::{text::PlatformRange as PlatformTextRange, util::*};
+use crate::{context::Context, text::PlatformRange as PlatformTextRange, util::*};
 
 fn runtime_id_from_node_id(id: NodeId) -> impl std::ops::Deref<Target = [i32]> {
     let mut result = ArrayVec::<i32, { std::mem::size_of::<NodeIdContent>() + 1 }>::new();
@@ -504,43 +506,68 @@ impl<'a> NodeWrapper<'a> {
     ITextProvider
 )]
 pub(crate) struct PlatformNode {
-    pub(crate) tree: Weak<RwLock<Tree>>,
+    pub(crate) context: Weak<Context>,
     pub(crate) node_id: NodeId,
-    pub(crate) hwnd: HWND,
 }
 
 impl PlatformNode {
-    pub(crate) fn new(tree: &Arc<RwLock<Tree>>, node_id: NodeId, hwnd: HWND) -> Self {
+    pub(crate) fn new(context: &Arc<Context>, node_id: NodeId) -> Self {
         Self {
-            tree: Arc::downgrade(tree),
+            context: Arc::downgrade(context),
             node_id,
-            hwnd,
         }
     }
 
-    fn with_tree<F, T>(&self, f: F) -> Result<T>
+    fn upgrade_context(&self) -> Result<Arc<Context>> {
+        upgrade(&self.context)
+    }
+
+    fn with_tree_state_and_context<F, T>(&self, f: F) -> Result<T>
     where
-        F: FnOnce(&Tree) -> Result<T>,
+        F: FnOnce(&TreeState, &Context) -> Result<T>,
     {
-        let tree = upgrade(&self.tree)?;
-        let tree = tree.read().unwrap();
-        f(&tree)
+        let context = self.upgrade_context()?;
+        let tree = context.read_tree();
+        f(tree.state(), &context)
     }
 
     fn with_tree_state<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&TreeState) -> Result<T>,
     {
-        self.with_tree(|tree| f(tree.state()))
+        self.with_tree_state_and_context(|state, _| f(state))
+    }
+
+    fn resolve_with_context<F, T>(&self, f: F) -> Result<T>
+    where
+        for<'a> F: FnOnce(Node<'a>, &Context) -> Result<T>,
+    {
+        self.with_tree_state_and_context(|state, context| {
+            if let Some(node) = state.node_by_id(self.node_id) {
+                f(node, context)
+            } else {
+                Err(element_not_available())
+            }
+        })
     }
 
     fn resolve<F, T>(&self, f: F) -> Result<T>
     where
         for<'a> F: FnOnce(Node<'a>) -> Result<T>,
     {
-        self.with_tree_state(|state| {
-            if let Some(node) = state.node_by_id(self.node_id) {
-                f(node)
+        self.resolve_with_context(|node, _| f(node))
+    }
+
+    fn resolve_with_context_for_text_pattern<F, T>(&self, f: F) -> Result<T>
+    where
+        for<'a> F: FnOnce(Node<'a>, &Context) -> Result<T>,
+    {
+        self.with_tree_state_and_context(|state, context| {
+            if let Some(node) = state
+                .node_by_id(self.node_id)
+                .filter(Node::supports_text_ranges)
+            {
+                f(node, context)
             } else {
                 Err(element_not_available())
             }
@@ -551,48 +578,38 @@ impl PlatformNode {
     where
         for<'a> F: FnOnce(Node<'a>) -> Result<T>,
     {
-        self.with_tree_state(|state| {
-            if let Some(node) = state
-                .node_by_id(self.node_id)
-                .filter(Node::supports_text_ranges)
-            {
-                f(node)
-            } else {
-                Err(element_not_available())
-            }
-        })
+        self.resolve_with_context_for_text_pattern(|node, _| f(node))
     }
 
-    fn validate_for_action<F, T>(&self, f: F) -> Result<T>
+    fn do_action<F>(&self, f: F) -> Result<()>
     where
-        F: FnOnce(&Tree) -> Result<T>,
+        F: FnOnce() -> ActionRequest,
     {
-        self.with_tree(|tree| {
-            if tree.state().has_node(self.node_id) {
-                f(tree)
-            } else {
-                Err(element_not_available())
-            }
-        })
+        let context = self.upgrade_context()?;
+        let tree = context.read_tree();
+        if tree.state().has_node(self.node_id) {
+            drop(tree);
+            let request = f();
+            context.do_action(request);
+            Ok(())
+        } else {
+            Err(element_not_available())
+        }
     }
 
     fn do_default_action(&self) -> Result<()> {
-        self.validate_for_action(|tree| {
-            tree.do_default_action(self.node_id);
-            Ok(())
+        self.do_action(|| ActionRequest {
+            action: Action::Default,
+            target: self.node_id,
+            data: None,
         })
     }
 
     fn relative(&self, node_id: NodeId) -> Self {
         Self {
-            tree: self.tree.clone(),
+            context: self.context.clone(),
             node_id,
-            hwnd: self.hwnd,
         }
-    }
-
-    fn client_top_left(&self) -> Point {
-        client_top_left(self.hwnd)
     }
 }
 
@@ -606,16 +623,16 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
     }
 
     fn GetPropertyValue(&self, property_id: UIA_PROPERTY_ID) -> Result<VARIANT> {
-        self.resolve(|node| {
+        self.resolve_with_context(|node, context| {
             let wrapper = NodeWrapper::Node(&node);
             let mut result = wrapper.get_property_value(property_id);
             if result.is_empty() && node.is_root() {
                 match property_id {
                     UIA_NamePropertyId => {
-                        result = window_title(self.hwnd).into();
+                        result = window_title(context.hwnd).into();
                     }
                     UIA_NativeWindowHandlePropertyId => {
-                        result = (self.hwnd.0 as i32).into();
+                        result = (context.hwnd.0 as i32).into();
                     }
                     _ => (),
                 }
@@ -625,9 +642,9 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
     }
 
     fn HostRawElementProvider(&self) -> Result<IRawElementProviderSimple> {
-        self.with_tree_state(|state| {
+        self.with_tree_state_and_context(|state, context| {
             if self.node_id == state.root_id() {
-                unsafe { UiaHostProviderFromHwnd(self.hwnd) }
+                unsafe { UiaHostProviderFromHwnd(context.hwnd) }
             } else {
                 Err(Error::OK)
             }
@@ -661,9 +678,9 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
     }
 
     fn BoundingRectangle(&self) -> Result<UiaRect> {
-        self.resolve(|node| {
+        self.resolve_with_context(|node, context| {
             let rect = node.bounding_box().map_or(UiaRect::default(), |rect| {
-                let client_top_left = self.client_top_left();
+                let client_top_left = context.client_top_left();
                 UiaRect {
                     left: rect.x0 + client_top_left.x,
                     top: rect.y0 + client_top_left.y,
@@ -680,9 +697,10 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
     }
 
     fn SetFocus(&self) -> Result<()> {
-        self.validate_for_action(|tree| {
-            tree.set_focus(self.node_id);
-            Ok(())
+        self.do_action(|| ActionRequest {
+            action: Action::Focus,
+            target: self.node_id,
+            data: None,
         })
     }
 
@@ -701,8 +719,8 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
 
 impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
     fn ElementProviderFromPoint(&self, x: f64, y: f64) -> Result<IRawElementProviderFragment> {
-        self.resolve(|node| {
-            let client_top_left = self.client_top_left();
+        self.resolve_with_context(|node, context| {
+            let client_top_left = context.client_top_left();
             let point = Point::new(x - client_top_left.x, y - client_top_left.y);
             let point = node.transform().inverse() * point;
             node.node_at_point(point, &filter).map_or_else(
@@ -851,10 +869,13 @@ patterns! {
         (IsReadOnly, is_read_only, BOOL)
     ), (
         fn SetValue(&self, value: &PCWSTR) -> Result<()> {
-            self.validate_for_action(|tree| {
+            self.do_action(|| {
                 let value = unsafe { value.to_string() }.unwrap();
-                tree.set_value(self.node_id, value);
-                Ok(())
+                ActionRequest {
+                    action: Action::SetValue,
+                    target: self.node_id,
+                    data: Some(ActionData::Value(value.into())),
+                }
             })
         }
     )),
@@ -867,9 +888,12 @@ patterns! {
         (LargeChange, numeric_value_jump, f64)
     ), (
         fn SetValue(&self, value: f64) -> Result<()> {
-            self.validate_for_action(|tree| {
-                tree.set_numeric_value(self.node_id, value);
-                Ok(())
+            self.do_action(|| {
+                ActionRequest {
+                    action: Action::SetValue,
+                    target: self.node_id,
+                    data: Some(ActionData::NumericValue(value)),
+                }
             })
         }
     )),
@@ -901,7 +925,7 @@ patterns! {
         fn GetSelection(&self) -> Result<*mut SAFEARRAY> {
             self.resolve_for_text_pattern(|node| {
                 if let Some(range) = node.text_selection() {
-                    let platform_range: ITextRangeProvider = PlatformTextRange::new(&self.tree, range, self.hwnd).into();
+                    let platform_range: ITextRangeProvider = PlatformTextRange::new(&self.context, range).into();
                     let iunknown: IUnknown = platform_range.into();
                     Ok(safe_array_from_com_slice(&[iunknown]))
                 } else {
@@ -923,20 +947,20 @@ patterns! {
         },
 
         fn RangeFromPoint(&self, point: &UiaPoint) -> Result<ITextRangeProvider> {
-            self.resolve_for_text_pattern(|node| {
-                let client_top_left = self.client_top_left();
+            self.resolve_with_context_for_text_pattern(|node, context| {
+                let client_top_left = context.client_top_left();
                 let point = Point::new(point.x - client_top_left.x, point.y - client_top_left.y);
                 let point = node.transform().inverse() * point;
                 let pos = node.text_position_at_point(point);
                 let range = pos.to_degenerate_range();
-                Ok(PlatformTextRange::new(&self.tree, range, self.hwnd).into())
+                Ok(PlatformTextRange::new(&self.context, range).into())
             })
         },
 
         fn DocumentRange(&self) -> Result<ITextRangeProvider> {
             self.resolve_for_text_pattern(|node| {
                 let range = node.document_range();
-                Ok(PlatformTextRange::new(&self.tree, range, self.hwnd).into())
+                Ok(PlatformTextRange::new(&self.context, range).into())
             })
         },
 

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -522,12 +522,9 @@ impl PlatformNode {
     where
         F: FnOnce(&Tree) -> Result<T>,
     {
-        if let Some(tree) = self.tree.upgrade() {
-            let tree = tree.read().unwrap();
-            f(&tree)
-        } else {
-            Err(element_not_available())
-        }
+        let tree = upgrade(&self.tree)?;
+        let tree = tree.read().unwrap();
+        f(&tree)
     }
 
     fn with_tree_state<F, T>(&self, f: F) -> Result<T>

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -590,7 +590,7 @@ impl PlatformNode {
         if tree.state().has_node(self.node_id) {
             drop(tree);
             let request = f();
-            context.do_action(request);
+            context.action_handler.do_action(request);
             Ok(())
         } else {
             Err(element_not_available())

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -13,9 +13,8 @@
 use accesskit::{CheckedState, Live, NodeId, NodeIdContent, Point, Role};
 use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, Tree, TreeState};
 use arrayvec::ArrayVec;
-use parking_lot::RwLock;
 use paste::paste;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, RwLock, Weak};
 use windows::{
     core::*,
     Win32::{Foundation::*, System::Com::*, UI::Accessibility::*},
@@ -524,7 +523,7 @@ impl PlatformNode {
         F: FnOnce(&Tree) -> Result<T>,
     {
         if let Some(tree) = self.tree.upgrade() {
-            let tree = tree.read();
+            let tree = tree.read().unwrap();
             f(&tree)
         } else {
             Err(element_not_available())

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -42,6 +42,10 @@ extern "system" fn wnd_proc(window: HWND, message: u32, wparam: WPARAM, lparam: 
 }
 
 impl SubclassImpl {
+    /// Creates a new Windows platform adapter using window subclassing.
+    ///
+    /// The action handler may or may not be called on the thread that owns
+    /// the window.
     fn new(hwnd: HWND, adapter: LazyAdapter) -> Box<Self> {
         Box::new(Self {
             hwnd,
@@ -98,7 +102,7 @@ impl SubclassingAdapter {
     pub fn new(
         hwnd: HWND,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Self {
         let uia_init_marker = UiaInitMarker::new();
         let adapter: LazyAdapter = Lazy::new(Box::new(move || {

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -102,7 +102,7 @@ impl SubclassingAdapter {
     pub fn new(
         hwnd: HWND,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: Box<dyn ActionHandler + Send + Sync>,
     ) -> Self {
         let uia_init_marker = UiaInitMarker::new();
         let adapter: LazyAdapter = Lazy::new(Box::new(move || {

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -79,7 +79,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
     }
 }
 
-struct WindowCreateParams(TreeUpdate, NodeId, Box<dyn ActionHandler>);
+struct WindowCreateParams(TreeUpdate, NodeId, Box<dyn ActionHandler + Send>);
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     match message {
@@ -150,7 +150,7 @@ fn create_window(
     title: &str,
     initial_state: TreeUpdate,
     initial_focus: NodeId,
-    action_handler: Box<dyn ActionHandler>,
+    action_handler: Box<dyn ActionHandler + Send>,
 ) -> Result<HWND> {
     let create_params = Box::new(WindowCreateParams(
         initial_state,
@@ -200,7 +200,7 @@ pub(crate) fn scope<F>(
     window_title: &str,
     initial_state: TreeUpdate,
     initial_focus: NodeId,
-    action_handler: Box<dyn ActionHandler>,
+    action_handler: Box<dyn ActionHandler + Send>,
     f: F,
 ) -> Result<()>
 where

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -79,7 +79,7 @@ fn update_focus(window: HWND, is_window_focused: bool) {
     }
 }
 
-struct WindowCreateParams(TreeUpdate, NodeId, Box<dyn ActionHandler + Send>);
+struct WindowCreateParams(TreeUpdate, NodeId, Box<dyn ActionHandler + Send + Sync>);
 
 extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
     match message {
@@ -150,7 +150,7 @@ fn create_window(
     title: &str,
     initial_state: TreeUpdate,
     initial_focus: NodeId,
-    action_handler: Box<dyn ActionHandler + Send>,
+    action_handler: Box<dyn ActionHandler + Send + Sync>,
 ) -> Result<HWND> {
     let create_params = Box::new(WindowCreateParams(
         initial_state,
@@ -200,7 +200,7 @@ pub(crate) fn scope<F>(
     window_title: &str,
     initial_state: TreeUpdate,
     initial_focus: NodeId,
-    action_handler: Box<dyn ActionHandler + Send>,
+    action_handler: Box<dyn ActionHandler + Send + Sync>,
     f: F,
 ) -> Result<()>
 where

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -221,12 +221,9 @@ impl PlatformRange {
     where
         F: FnOnce(&Tree) -> Result<T>,
     {
-        if let Some(tree) = self.tree.upgrade() {
-            let tree = tree.read().unwrap();
-            f(&tree)
-        } else {
-            Err(element_not_available())
-        }
+        let tree = upgrade(&self.tree)?;
+        let tree = tree.read().unwrap();
+        f(&tree)
     }
 
     fn with_tree_state<F, T>(&self, f: F) -> Result<T>

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -295,7 +295,7 @@ impl PlatformRange {
         let range = self.upgrade_for_read(tree.state())?;
         let request = f(range);
         drop(tree);
-        context.do_action(request);
+        context.action_handler.do_action(request);
         Ok(())
     }
 

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -4,7 +4,11 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::Point;
-use std::{convert::TryInto, mem::ManuallyDrop};
+use std::{
+    convert::TryInto,
+    mem::ManuallyDrop,
+    sync::{Arc, Weak},
+};
 use windows::{
     core::*,
     Win32::{
@@ -237,4 +241,12 @@ pub(crate) fn window_title(hwnd: HWND) -> Option<BSTR> {
     let len = result.0 as usize;
     unsafe { buffer.set_len(len) };
     Some(BSTR::from_wide(&buffer))
+}
+
+pub(crate) fn upgrade<T>(weak: &Weak<T>) -> Result<Arc<T>> {
+    if let Some(strong) = weak.upgrade() {
+        Ok(strong)
+    } else {
+        Err(element_not_available())
+    }
 }

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.9.0", path = "../../common" }
-parking_lot = "0.12.1"
 winit = { version = "0.28", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -46,7 +46,7 @@ impl Adapter {
             window_id: window.id(),
             proxy: event_loop_proxy,
         };
-        Self::with_action_handler(window, source, action_handler)
+        Self::with_action_handler(window, source, Box::new(action_handler))
     }
 
     /// Use this if you need to provide your own AccessKit action handler
@@ -56,7 +56,7 @@ impl Adapter {
     pub fn with_action_handler(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate + Send,
-        action_handler: impl 'static + ActionHandler + Send,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Self {
         let adapter = platform_impl::Adapter::new(window, source, action_handler);
         Self { adapter }

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -3,6 +3,14 @@
 // the LICENSE-APACHE file).
 
 use accesskit::{ActionHandler, ActionRequest, TreeUpdate};
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+use std::sync::{Mutex, MutexGuard};
 use winit::{
     event::WindowEvent,
     event_loop::EventLoopProxy,
@@ -19,7 +27,69 @@ pub struct ActionRequestEvent {
 
 struct WinitActionHandler<T: From<ActionRequestEvent> + Send + 'static> {
     window_id: WindowId,
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    proxy: Mutex<EventLoopProxy<T>>,
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     proxy: EventLoopProxy<T>,
+}
+
+impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
+        Self {
+            window_id,
+            proxy: Mutex::new(proxy),
+        }
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
+        Self { window_id, proxy }
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    fn proxy(&self) -> MutexGuard<'_, EventLoopProxy<T>> {
+        self.proxy.lock().unwrap()
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    fn proxy(&self) -> &EventLoopProxy<T> {
+        &self.proxy
+    }
 }
 
 impl<T: From<ActionRequestEvent> + Send + 'static> ActionHandler for WinitActionHandler<T> {
@@ -28,7 +98,7 @@ impl<T: From<ActionRequestEvent> + Send + 'static> ActionHandler for WinitAction
             window_id: self.window_id,
             request,
         };
-        self.proxy.send_event(event.into()).ok();
+        self.proxy().send_event(event.into()).ok();
     }
 }
 
@@ -42,10 +112,7 @@ impl Adapter {
         source: impl 'static + FnOnce() -> TreeUpdate + Send,
         event_loop_proxy: EventLoopProxy<T>,
     ) -> Self {
-        let action_handler = WinitActionHandler {
-            window_id: window.id(),
-            proxy: event_loop_proxy,
-        };
+        let action_handler = WinitActionHandler::new(window.id(), event_loop_proxy);
         Self::with_action_handler(window, source, Box::new(action_handler))
     }
 
@@ -56,7 +123,7 @@ impl Adapter {
     pub fn with_action_handler(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate + Send,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: platform_impl::ActionHandlerBox,
     ) -> Self {
         let adapter = platform_impl::Adapter::new(window, source, action_handler);
         Self { adapter }

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -8,7 +8,8 @@ use accesskit::{ActionHandler, ActionRequest, TreeUpdate};
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "windows"
 ))]
 use std::sync::{Mutex, MutexGuard};
 use winit::{
@@ -32,7 +33,8 @@ struct WinitActionHandler<T: From<ActionRequestEvent> + Send + 'static> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     ))]
     proxy: Mutex<EventLoopProxy<T>>,
     #[cfg(not(any(
@@ -40,7 +42,8 @@ struct WinitActionHandler<T: From<ActionRequestEvent> + Send + 'static> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     )))]
     proxy: EventLoopProxy<T>,
 }
@@ -51,7 +54,8 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     ))]
     fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
         Self {
@@ -64,7 +68,8 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     )))]
     fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
         Self { window_id, proxy }
@@ -75,7 +80,8 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     ))]
     fn proxy(&self) -> MutexGuard<'_, EventLoopProxy<T>> {
         self.proxy.lock().unwrap()
@@ -85,7 +91,8 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "windows"
     )))]
     fn proxy(&self) -> &EventLoopProxy<T> {
         &self.proxy

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -14,7 +14,7 @@ impl Adapter {
     pub fn new(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: impl 'static + ActionHandler,
+        action_handler: Box<dyn ActionHandler>,
     ) -> Self {
         let view = window.ns_view();
         let adapter = unsafe { SubclassingAdapter::new(view, source, action_handler) };

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -6,6 +6,8 @@ use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_macos::SubclassingAdapter;
 use winit::{platform::macos::WindowExtMacOS, window::Window};
 
+pub type ActionHandlerBox = Box<dyn ActionHandler>;
+
 pub struct Adapter {
     adapter: SubclassingAdapter,
 }
@@ -14,7 +16,7 @@ impl Adapter {
     pub fn new(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: ActionHandlerBox,
     ) -> Self {
         let view = window.ns_view();
         let adapter = unsafe { SubclassingAdapter::new(view, source, action_handler) };

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -14,7 +14,7 @@ impl Adapter {
     pub fn new(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: impl 'static + ActionHandler,
     ) -> Self {
         let view = window.ns_view();
         let adapter = unsafe { SubclassingAdapter::new(view, source, action_handler) };

--- a/platforms/winit/src/platform_impl/null.rs
+++ b/platforms/winit/src/platform_impl/null.rs
@@ -5,13 +5,15 @@
 use accesskit::{ActionHandler, TreeUpdate};
 use winit::window::Window;
 
+pub type ActionHandlerBox = Box<dyn ActionHandler>;
+
 pub struct Adapter;
 
 impl Adapter {
     pub fn new(
         _window: &Window,
         _source: impl 'static + FnOnce() -> TreeUpdate,
-        _action_handler: Box<dyn ActionHandler>,
+        _action_handler: ActionHandlerBox,
     ) -> Self {
         Self {}
     }

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -14,7 +14,7 @@ impl Adapter {
     pub fn new(
         _: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Self {
         let adapter = UnixAdapter::new(
             String::new(),

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -6,6 +6,8 @@ use accesskit::{ActionHandler, Rect, TreeUpdate};
 use accesskit_unix::Adapter as UnixAdapter;
 use winit::window::Window;
 
+pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
+
 pub struct Adapter {
     adapter: Option<UnixAdapter>,
 }
@@ -14,7 +16,7 @@ impl Adapter {
     pub fn new(
         _: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: ActionHandlerBox,
     ) -> Self {
         let adapter = UnixAdapter::new(
             String::new(),

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -6,7 +6,7 @@ use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
 use winit::{platform::windows::WindowExtWindows, window::Window};
 
-pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
+pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
 
 pub struct Adapter {
     adapter: SubclassingAdapter,

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -6,6 +6,8 @@ use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
 use winit::{platform::windows::WindowExtWindows, window::Window};
 
+pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
+
 pub struct Adapter {
     adapter: SubclassingAdapter,
 }
@@ -14,7 +16,7 @@ impl Adapter {
     pub fn new(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send>,
+        action_handler: ActionHandlerBox,
     ) -> Self {
         let hwnd = HWND(window.hwnd());
         let adapter = SubclassingAdapter::new(hwnd, source, action_handler);

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -14,7 +14,7 @@ impl Adapter {
     pub fn new(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Self {
         let hwnd = HWND(window.hwnd());
         let adapter = SubclassingAdapter::new(hwnd, source, action_handler);


### PR DESCRIPTION
This PR has the following practical benefits:

* AccessKit no longer depends on parking_lot, except indirectly in the Unix adapter (via async-broadcast-channel which is used by zbus).
* Because the consumer crate no longer does thread synchronization itself, we're a step closer to making it compatible with no-std environments, e.g. embedded devices and game consoles.
* Because thread synchronization is now the responsibility of the platform adapters, we don't need any on macOS, since everything happens on the main thread on that platform. The same will likely be the case on iOS. That means that we don't need to use the somewhat inefficient pthread-based synchronization primitives on Apple platforms, but we don't need to use something with some global overhead, like parking_lot, either.
* Platform-specific implementations of `ActionHandler` only need to implement `Send` and `Sync` if the platform actually requires it, which isn't the case for macOS. This will let us optimize the AccessKit integration in glazier's macOS backend a bit. The same will also be true for iOS and WebAssembly when we get to those platforms.
* Speaking of WebAssembly, accesskit_winit now compiles for that target, though of course it uses the null backend for now.

We're close to being able to merge `Tree` and `TreeState` in the consumer crate, but we can't do that without reworking the API for handling tree changes, so I'm leaving that alone for now.

I needed to rework the Windows and Unix adapters to use a top-level context struct, as the macOS adapter already did. I was planning to do that at some point anyway.