### PR TITLE
feat: Feature-gate the Unix adapter in accesskit_winit

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/AccessKit/accesskit"
 readme = "README.md"
 edition = "2021"
 
+[features]
+default = ["accesskit_unix"]
+
 [dependencies]
 accesskit = { version = "0.10.0", path = "../../common" }
 winit = { version = "0.28", default-features = false }
@@ -21,7 +24,7 @@ accesskit_windows = { version = "0.13.0", path = "../windows" }
 accesskit_macos = { version = "0.6.0", path = "../macos" }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-accesskit_unix = { version = "0.3.0", path = "../unix" }
+accesskit_unix = { version = "0.3.0", path = "../unix", optional = true }
 
 [dev-dependencies]
 winit = "0.28"

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -143,12 +143,15 @@ fn main() {
     println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
     #[cfg(target_os = "windows")]
     println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
+    #[cfg(all(
+        feature = "accesskit_unix",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
     ))]
     println!("Enable Orca with [Super]+[Alt]+[S].");
 

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -4,11 +4,16 @@
 
 use accesskit::{ActionHandler, ActionRequest, TreeUpdate};
 #[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
+    all(
+        feature = "accesskit_unix",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
+    ),
     target_os = "windows"
 ))]
 use std::sync::{Mutex, MutexGuard};
@@ -29,20 +34,30 @@ pub struct ActionRequestEvent {
 struct WinitActionHandler<T: From<ActionRequestEvent> + Send + 'static> {
     window_id: WindowId,
     #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     ))]
     proxy: Mutex<EventLoopProxy<T>>,
     #[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     )))]
     proxy: EventLoopProxy<T>,
@@ -50,11 +65,16 @@ struct WinitActionHandler<T: From<ActionRequestEvent> + Send + 'static> {
 
 impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
     #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     ))]
     fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
@@ -64,11 +84,16 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
         }
     }
     #[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     )))]
     fn new(window_id: WindowId, proxy: EventLoopProxy<T>) -> Self {
@@ -76,22 +101,32 @@ impl<T: From<ActionRequestEvent> + Send + 'static> WinitActionHandler<T> {
     }
 
     #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     ))]
     fn proxy(&self) -> MutexGuard<'_, EventLoopProxy<T>> {
         self.proxy.lock().unwrap()
     }
     #[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd",
+        all(
+            feature = "accesskit_unix",
+            any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )
+        ),
         target_os = "windows"
     )))]
     fn proxy(&self) -> &EventLoopProxy<T> {
@@ -136,23 +171,29 @@ impl Adapter {
         Self { adapter }
     }
 
-    #[cfg(all(
-        not(target_os = "linux"),
-        not(target_os = "dragonfly"),
-        not(target_os = "freebsd"),
-        not(target_os = "netbsd"),
-        not(target_os = "openbsd")
-    ))]
+    #[cfg(not(all(
+        feature = "accesskit_unix",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
+    )))]
     #[must_use]
     pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
         true
     }
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
+    #[cfg(all(
+        feature = "accesskit_unix",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
     ))]
     #[must_use]
     pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {

--- a/platforms/winit/src/platform_impl/mod.rs
+++ b/platforms/winit/src/platform_impl/mod.rs
@@ -14,24 +14,32 @@ mod platform;
 #[path = "macos.rs"]
 mod platform;
 
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
+#[cfg(all(
+    feature = "accesskit_unix",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )
 ))]
 #[path = "unix.rs"]
 mod platform;
 
-#[cfg(all(
-    not(target_os = "windows"),
-    not(target_os = "macos"),
-    not(target_os = "linux"),
-    not(target_os = "dragonfly"),
-    not(target_os = "freebsd"),
-    not(target_os = "netbsd"),
-    not(target_os = "openbsd")
-))]
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos",
+    all(
+        feature = "accesskit_unix",
+        any(
+            target_os = "linux",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )
+    )
+)))]
 #[path = "null.rs"]
 mod platform;


### PR DESCRIPTION
The current effort to integrate AccessKit in the Bevy game engine is meeting with some resistance because of the number of new dependencies added by the AccessKit Unix adapter. So, as a compromise, this PR allows just the Unix adapter to be turned off with a feature in accesskit_winit. If the feature is disabled, then accesskit_winit will use the null adapter on Unix platforms, as it does for unsupported platforms.