### PR TITLE
fix: Update windows-rs to 0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,25 +1686,31 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
  "windows-implement",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows-interface",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9539b6bd3eadbd9de66c9666b22d802b833da7e996bc06896142e09854a61767"
+checksum = "6ce87ca8e3417b02dc2a8a22769306658670ec92d78f1bd420d6310a67c245c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "853f69a591ecd4f810d29f17e902d40e349fb05b0b11fff63b08b826bfe39c7f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.13.0"
 paste = "1.0"
 
 [dependencies.windows]
-version = "0.42.0"
+version = "0.44.0"
 features = [
     "implement",
     "Win32_Foundation",

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -23,7 +23,7 @@ static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
     let wc = WNDCLASSW {
         hCursor: unsafe { LoadCursorW(None, IDC_ARROW) }.unwrap(),
         hInstance: unsafe { GetModuleHandleW(None) }.unwrap(),
-        lpszClassName: class_name.into(),
+        lpszClassName: class_name,
         style: CS_HREDRAW | CS_VREDRAW,
         lpfnWndProc: Some(wndproc),
         ..Default::default()

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -254,8 +254,8 @@ impl QueuedEvents {
                         UiaRaiseAutomationPropertyChangedEvent(
                             &element,
                             property_id,
-                            &old_value,
-                            &new_value,
+                            old_value,
+                            new_value,
                         )
                     }
                     .unwrap();

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -13,7 +13,7 @@ use windows::{
 
 use crate::{Adapter, QueuedEvents, UiaInitMarker};
 
-const PROP_NAME: &HSTRING = w!("AccessKitAdapter");
+const PROP_NAME: PCWSTR = w!("AccessKitAdapter");
 
 type LazyAdapter = Lazy<Adapter, Box<dyn FnOnce() -> Adapter>>;
 

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -78,7 +78,7 @@ fn is_button_named(element: &IUIAutomationElement, expected_name: &str) -> bool 
     let control_type = unsafe { element.CurrentControlType() }.unwrap();
     let name = unsafe { element.CurrentName() }.unwrap();
     let name: String = name.try_into().unwrap();
-    control_type == (UIA_ButtonControlTypeId.0 as i32) && name == expected_name
+    control_type == UIA_ButtonControlTypeId && name == expected_name
 }
 
 fn is_button_1(element: &IUIAutomationElement) -> bool {

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -400,7 +400,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
 
     fn FindAttribute(
         &self,
-        _id: i32,
+        _id: UIA_TEXTATTRIBUTE_ID,
         _value: &VARIANT,
         _backward: BOOL,
     ) -> Result<ITextRangeProvider> {
@@ -421,8 +421,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
         Err(Error::OK)
     }
 
-    fn GetAttributeValue(&self, id: i32) -> Result<VARIANT> {
-        let id = UIA_TEXTATTRIBUTE_ID(id as _);
+    fn GetAttributeValue(&self, id: UIA_TEXTATTRIBUTE_ID) -> Result<VARIANT> {
         match id {
             UIA_IsReadOnlyAttributeId => {
                 // TBD: do we ever want to support mixed read-only/editable text?

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -130,7 +130,7 @@ impl From<bool> for VariantFactory {
         Self(
             VT_BOOL,
             VARIANT_0_0_0 {
-                boolVal: if value { VARIANT_TRUE } else { VARIANT_FALSE },
+                boolVal: VARIANT_BOOL(if value { VARIANT_TRUE } else { VARIANT_FALSE }),
             },
         )
     }
@@ -240,7 +240,7 @@ pub(crate) fn window_title(hwnd: HWND) -> Option<BSTR> {
     }
     let len = result.0 as usize;
     unsafe { buffer.set_len(len) };
-    Some(BSTR::from_wide(&buffer))
+    Some(BSTR::from_wide(&buffer).unwrap())
 }
 
 pub(crate) fn upgrade<T>(weak: &Weak<T>) -> Result<Arc<T>> {


### PR DESCRIPTION
The immediate motivation is a CI failure in the Bevy AccessKit PR. While Bevy is indirectly depending on windows-rs 0.43, I was told we should go ahead and update to 0.44.