### PR TITLE
fix: Set proper target to build accesskit_macos documentation

### DIFF
--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/AccessKit/accesskit"
 readme = "README.md"
 edition = "2021"
 
+[package.metadata.docs.rs]
+default-target = "x86_64-apple-darwin"
+
 [dependencies]
 accesskit = { version = "0.10.1", path = "../../common" }
 accesskit_consumer = { version = "0.14.1", path = "../../consumer" }


### PR DESCRIPTION
MacOS adapter [documentation](https://docs.rs/crate/accesskit_macos/latest) is broken, and might have been for a long time actually. This is because docs.rs uses a Linux target to build the documentation by default, hence objc2 fails to compile.

Looking at other objc2 dependent crates I think this change should solve the issue, but I can't guarantee.