### PR TITLE
fix: Fix problems related to the root node

### DIFF
--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -101,10 +101,7 @@ impl Adapter {
         let state = tree.state();
         let root = state.root();
         let point = from_ns_point(&view, &root, point);
-        if let Some(node) = root.node_at_point(point, &filter) {
-            return Id::autorelease_return(self.context.get_or_create_platform_node(node.id()))
-                as *mut _;
-        }
-        null_mut()
+        let node = root.node_at_point(point, &filter).unwrap_or(root);
+        Id::autorelease_return(self.context.get_or_create_platform_node(node.id())) as *mut _
     }
 }

--- a/platforms/macos/src/appkit/view.rs
+++ b/platforms/macos/src/appkit/view.rs
@@ -47,5 +47,11 @@ extern_methods!(
 
         #[sel(backingScaleFactor)]
         pub(crate) fn backing_scale_factor(&self) -> CGFloat;
+
+        // NSView actually implements the full NSAccessibility protocol,
+        // but since we don't have complete metadata for that, it's easier
+        // to just expose the accessibilityFrame method here.
+        #[sel(accessibilityFrame)]
+        pub(crate) fn accessibility_frame(&self) -> NSRect;
     }
 );

--- a/platforms/macos/src/appkit/view.rs
+++ b/platforms/macos/src/appkit/view.rs
@@ -50,8 +50,10 @@ extern_methods!(
 
         // NSView actually implements the full NSAccessibility protocol,
         // but since we don't have complete metadata for that, it's easier
-        // to just expose the accessibilityFrame method here.
+        // to just expose the needed methods here.
         #[sel(accessibilityFrame)]
         pub(crate) fn accessibility_frame(&self) -> NSRect;
+        #[sel(accessibilityParent)]
+        pub(crate) fn accessibility_parent(&self) -> *mut NSObject;
     }
 );

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -403,8 +403,16 @@ declare_class!(
                     }
                 };
 
-                node.bounding_box()
-                    .map_or(NSRect::ZERO, |rect| to_ns_rect(&view, rect))
+                node.bounding_box().map_or_else(
+                    || {
+                        if node.is_root() {
+                            view.accessibility_frame()
+                        } else {
+                            NSRect::ZERO
+                        }
+                    },
+                    |rect| to_ns_rect(&view, rect),
+                )
             })
             .unwrap_or(NSRect::ZERO)
         }

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -376,7 +376,7 @@ declare_class!(
                     context
                         .view
                         .load()
-                        .map_or_else(null_mut, |view| Id::autorelease_return(view) as *mut _)
+                        .map_or_else(null_mut, |view| view.accessibility_parent())
                 }
             })
             .unwrap_or_else(null_mut)


### PR DESCRIPTION
AccessKit allows the root node to omit the bounding rectangle. On Windows and Linux, we can use the window's own rectangle as a fallback. This PR implements the equivalent behavior on macOS.