### PR TITLE
fix!: Force a non-patch version bump in downstream crates

### DIFF
--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2021"
 
 [dependencies]
 accesskit = { version = "0.11.0", path = "../common" }
+

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -15,3 +15,4 @@ accesskit = { version = "0.11.0", path = "../../common" }
 accesskit_consumer = { version = "0.14.2", path = "../../consumer" }
 objc2 = ">=0.3.0-beta.3, <0.3.0-beta.4" # Allow `0.3.0-beta.3.patch-leaks`
 once_cell = "1.13.0"
+

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -18,3 +18,4 @@ atspi = "0.10.1"
 futures-lite = "1.12.0"
 serde = "1.0"
 zbus = "3.6"
+

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -35,3 +35,4 @@ features = [
 [dev-dependencies]
 scopeguard = "1.1.0"
 winit = "0.28"
+

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -28,3 +28,4 @@ accesskit_unix = { version = "0.3.3", path = "../unix", optional = true }
 
 [dev-dependencies]
 winit = "0.28"
+


### PR DESCRIPTION
Fixes #233

Unfortunately, the only way I know to do this with release-please is to make dummy changes to the contents of these crates. A blank line added to the end of Cargo.toml is the most innocuous possible change that will do the job.