### PR TITLE
fix: Remove objc and Core Foundation types from C bindings public API

### DIFF
--- a/bindings/c/cbindgen.toml
+++ b/bindings/c/cbindgen.toml
@@ -10,10 +10,6 @@ include_guard = "ACCESSKIT_H"
 cpp_compat = true
 after_includes = """#ifdef _WIN32
 #include <windows.h>
-#endif
-#ifdef __APPLE__
-#include <Foundation/NSObjCRuntime.h>
-#include <CoreGraphics/CGGeometry.h>
 #endif"""
 
 usize_is_size_t = true
@@ -47,9 +43,6 @@ renaming_overrides_prefixing = true
 "LRESULT" = "LRESULT"
 "ListStyle" = "accesskit_list_style"
 "Live" = "accesskit_live"
-"NSArray" = "NSArray"
-"NSObject" = "NSObject"
-"NSPoint" = "CGPoint"
 "NameFrom" = "accesskit_name_from"
 "Orientation" = "accesskit_orientation"
 "Point" = "accesskit_point"

--- a/bindings/c/src/macos.rs
+++ b/bindings/c/src/macos.rs
@@ -87,14 +87,15 @@ impl macos_adapter {
         adapter.focus() as *mut _
     }
 
+    /// Returns a pointer to an `NSObject`. Ownership of the pointer is not transfered.
     #[no_mangle]
     pub extern "C" fn accesskit_macos_adapter_hit_test(
         adapter: *const macos_adapter,
         x: f64,
         y: f64,
-    ) -> *mut NSObject {
+    ) -> *mut c_void {
         let adapter = ref_from_ptr(adapter);
-        adapter.hit_test(NSPoint::new(x, y))
+        adapter.hit_test(NSPoint::new(x, y)) as *mut _
     }
 }
 

--- a/bindings/c/src/macos.rs
+++ b/bindings/c/src/macos.rs
@@ -10,9 +10,6 @@ use crate::{
 use accesskit_macos::{Adapter, NSObject, NSPoint, QueuedEvents, SubclassingAdapter};
 use std::{os::raw::c_void, ptr};
 
-#[cfg(not(feature = "cbindgen"))]
-pub type NSArray = c_void;
-
 pub struct macos_queued_events {
     _private: [u8; 0],
 }
@@ -74,29 +71,30 @@ impl macos_adapter {
         BoxCastPtr::to_mut_ptr(events)
     }
 
+    /// Returns a pointer to an `NSArray`. Ownership of the pointer is not transfered.
     #[no_mangle]
     pub extern "C" fn accesskit_macos_adapter_view_children(
         adapter: *const macos_adapter,
-    ) -> *mut NSArray {
+    ) -> *mut c_void {
         let adapter = ref_from_ptr(adapter);
         adapter.view_children() as *mut _
     }
 
+    /// Returns a pointer to an `NSObject`. Ownership of the pointer is not transfered.
     #[no_mangle]
-    pub extern "C" fn accesskit_macos_adapter_focus(
-        adapter: *const macos_adapter,
-    ) -> *mut NSObject {
+    pub extern "C" fn accesskit_macos_adapter_focus(adapter: *const macos_adapter) -> *mut c_void {
         let adapter = ref_from_ptr(adapter);
-        adapter.focus()
+        adapter.focus() as *mut _
     }
 
     #[no_mangle]
     pub extern "C" fn accesskit_macos_adapter_hit_test(
         adapter: *const macos_adapter,
-        point: NSPoint,
+        x: f64,
+        y: f64,
     ) -> *mut NSObject {
         let adapter = ref_from_ptr(adapter);
-        adapter.hit_test(point)
+        adapter.hit_test(NSPoint::new(x, y))
     }
 }
 


### PR DESCRIPTION
Fixes #242 

It compiles, does it actually do what it is supposed to?

Feedback appreciated.

CC @bruvzg