### PR TITLE
chore: Add compiler settings to our release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ default-members = [
 [profile.release]
 lto = true
 panic = "abort"
+debug = true
+opt-level = "z"
+codegen-units = 1


### PR DESCRIPTION
I've wanted to add these for a while, and we'll soon release a new version of our C bindings, so now is a good time.

The `debug` flag enables as much debug info as possible in release builds without compromising optimizations. This is important for doing postmortem debugging of problems found in release builds. Windows uses a setting like this in its release builds, and I believe Chromium does too.

Maximizing optimization for size is perhaps more controversial, but I believe it's the best choice for us. Our library will look better to some decision-makers if it's smaller, and the difference is particularly dramatic with the Unix adapter. If we ever find that this decision noticeably hurts real-world performance, I'll be happy to reverse it.