### PR TITLE
deps: Update proc-macro2 to fix nightly build.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
The nightly builds removed something that nighly builds of `proc-macro2` had used and so the version of `proc-macro2` that we use no longer works.

The easiest thing to do is to update that dependency.

More details upstream at https://github.com/rust-lang/rust/issues/113152

This can be confirmed to work and fix the issue by running `cargo +nightly build` with and without this change using a recent enough nightly build. Without this change, it fails.