### PR TITLE
refactor!: New C API for tree updates

### DIFF
--- a/bindings/c/cbindgen.toml
+++ b/bindings/c/cbindgen.toml
@@ -15,7 +15,7 @@ after_includes = """#ifdef _WIN32
 usize_is_size_t = true
 
 [export]
-include = ["Size", "tree_update", "Vec2"]
+include = ["Size", "Vec2"]
 prefix = "accesskit_"
 renaming_overrides_prefixing = true
 

--- a/bindings/c/src/macos.rs
+++ b/bindings/c/src/macos.rs
@@ -53,7 +53,7 @@ impl macos_adapter {
     ) -> *mut macos_adapter {
         let initial_state = box_from_ptr(initial_state);
         let handler = box_from_ptr(handler);
-        let adapter = Adapter::new(view, initial_state.into(), handler);
+        let adapter = Adapter::new(view, *initial_state, handler);
         BoxCastPtr::to_mut_ptr(adapter)
     }
 
@@ -71,7 +71,7 @@ impl macos_adapter {
     ) -> *mut macos_queued_events {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
-        let events = adapter.update(update.into());
+        let events = adapter.update(*update);
         BoxCastPtr::to_mut_ptr(events)
     }
 
@@ -130,7 +130,7 @@ impl macos_subclassing_adapter {
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::new(
             view,
-            move || box_from_ptr(source(source_userdata)).into(),
+            move || *box_from_ptr(source(source_userdata)),
             handler,
         );
         BoxCastPtr::to_mut_ptr(adapter)
@@ -157,7 +157,7 @@ impl macos_subclassing_adapter {
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::for_window(
             window,
-            move || box_from_ptr(source(source_userdata)).into(),
+            move || *box_from_ptr(source(source_userdata)),
             handler,
         );
         BoxCastPtr::to_mut_ptr(adapter)
@@ -179,7 +179,7 @@ impl macos_subclassing_adapter {
     ) -> *mut macos_queued_events {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
-        let events = adapter.update(update.into());
+        let events = adapter.update(*update);
         BoxCastPtr::to_mut_ptr(events)
     }
 
@@ -192,8 +192,8 @@ impl macos_subclassing_adapter {
     ) -> *mut macos_queued_events {
         let update_factory = update_factory.unwrap();
         let adapter = ref_from_ptr(adapter);
-        let events = adapter
-            .update_if_active(|| box_from_ptr(update_factory(update_factory_userdata)).into());
+        let events =
+            adapter.update_if_active(|| *box_from_ptr(update_factory(update_factory_userdata)));
         match events {
             Some(events) => BoxCastPtr::to_mut_ptr(events),
             None => ptr::null_mut(),

--- a/bindings/c/src/unix.rs
+++ b/bindings/c/src/unix.rs
@@ -43,7 +43,7 @@ impl unix_adapter {
             app_name,
             toolkit_name,
             toolkit_version,
-            move || box_from_ptr(initial_state(initial_state_userdata)).into(),
+            move || *box_from_ptr(initial_state(initial_state_userdata)),
             handler,
         );
         adapter.map_or_else(ptr::null_mut, BoxCastPtr::to_mut_ptr)
@@ -72,6 +72,6 @@ impl unix_adapter {
     ) {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
-        adapter.update(update.into());
+        adapter.update(*update);
     }
 }

--- a/bindings/c/src/windows.rs
+++ b/bindings/c/src/windows.rs
@@ -77,7 +77,7 @@ impl windows_adapter {
         let initial_state = box_from_ptr(initial_state);
         let handler = box_from_ptr(handler);
         let uia_init_marker = *box_from_ptr(uia_init_marker);
-        let adapter = Adapter::new(hwnd, initial_state.into(), handler, uia_init_marker);
+        let adapter = Adapter::new(hwnd, *initial_state, handler, uia_init_marker);
         BoxCastPtr::to_mut_ptr(adapter)
     }
 
@@ -95,7 +95,7 @@ impl windows_adapter {
     ) -> *mut windows_queued_events {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
-        let events = adapter.update(update.into());
+        let events = adapter.update(*update);
         BoxCastPtr::to_mut_ptr(events)
     }
 
@@ -134,7 +134,7 @@ impl windows_subclassing_adapter {
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::new(
             hwnd,
-            move || box_from_ptr(source(source_userdata)).into(),
+            move || *box_from_ptr(source(source_userdata)),
             handler,
         );
         BoxCastPtr::to_mut_ptr(adapter)
@@ -156,7 +156,7 @@ impl windows_subclassing_adapter {
     ) -> *mut windows_queued_events {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
-        let events = adapter.update(update.into());
+        let events = adapter.update(*update);
         BoxCastPtr::to_mut_ptr(events)
     }
 
@@ -169,8 +169,8 @@ impl windows_subclassing_adapter {
     ) -> *mut windows_queued_events {
         let update_factory = update_factory.unwrap();
         let adapter = ref_from_ptr(adapter);
-        let events = adapter
-            .update_if_active(|| box_from_ptr(update_factory(update_factory_userdata)).into());
+        let events =
+            adapter.update_if_active(|| *box_from_ptr(update_factory(update_factory_userdata)));
         match events {
             Some(events) => BoxCastPtr::to_mut_ptr(events),
             None => ptr::null_mut(),


### PR DESCRIPTION
`accesskit_tree_update` is now an opaque struct like the other wrapper structs around boxed types. I think this API is safer, lower-overhead, and more pleasant to use (as C APIs go). It will also let us experiment with passing a serialized tree update across the FFI boundary, as we did in the proof-of-concept Unity plugin, by adding a function like `accesskit_tree_update_from_json`.