### PR TITLE
fix: Support text fields without a value property

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -50,6 +50,7 @@ impl<'a> Node<'a> {
             is_focused: self.is_focused(),
             is_root: self.is_root(),
             name: self.name(),
+            value: self.value(),
             live: self.live(),
             supports_text_ranges: self.supports_text_ranges(),
         }
@@ -379,10 +380,6 @@ impl NodeState {
         self.data().checked_state()
     }
 
-    pub fn value(&self) -> Option<&str> {
-        self.data().value()
-    }
-
     pub fn numeric_value(&self) -> Option<f64> {
         self.data().numeric_value()
     }
@@ -534,6 +531,20 @@ impl<'a> Node<'a> {
             (!names.is_empty()).then(move || names.join(" "))
         }
     }
+
+    pub fn value(&self) -> Option<String> {
+        if let Some(value) = &self.data().value() {
+            Some(value.to_string())
+        } else if self.supports_text_ranges() && !self.is_multiline() {
+            Some(self.document_range().text())
+        } else {
+            None
+        }
+    }
+
+    pub fn has_value(&self) -> bool {
+        self.data().value().is_some() || (self.supports_text_ranges() && !self.is_multiline())
+    }
 }
 
 impl NodeState {
@@ -605,6 +616,10 @@ impl NodeState {
 
     pub fn raw_text_selection(&self) -> Option<&TextSelection> {
         self.data().text_selection()
+    }
+
+    pub fn raw_value(&self) -> Option<&str> {
+        self.data().value()
     }
 }
 
@@ -680,6 +695,7 @@ pub struct DetachedNode {
     pub(crate) is_focused: bool,
     pub(crate) is_root: bool,
     pub(crate) name: Option<String>,
+    pub(crate) value: Option<String>,
     pub(crate) live: Live,
     pub(crate) supports_text_ranges: bool,
 }
@@ -695,6 +711,14 @@ impl DetachedNode {
 
     pub fn name(&self) -> Option<String> {
         self.name.clone()
+    }
+
+    pub fn value(&self) -> Option<String> {
+        self.value.clone()
+    }
+
+    pub fn has_value(&self) -> bool {
+        self.value.is_some()
     }
 
     pub fn live(&self) -> Live {

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -60,7 +60,7 @@ impl<'a> InnerPosition<'a> {
     }
 
     fn is_paragraph_end(&self) -> bool {
-        self.is_line_end() && self.node.value().unwrap().ends_with('\n')
+        self.is_line_end() && self.node.data().value().unwrap().ends_with('\n')
     }
 
     fn is_document_start(&self, root_node: &Node) -> bool {
@@ -237,7 +237,7 @@ impl<'a> Position<'a> {
     pub fn to_global_utf16_index(&self) -> usize {
         let mut total_length = 0usize;
         for node in self.root_node.inline_text_boxes() {
-            let node_text = node.value().unwrap();
+            let node_text = node.data().value().unwrap();
             if node.id() == self.inner.node.id() {
                 let character_lengths = node.data().character_lengths();
                 let slice_end = character_lengths[..self.inner.character_index]
@@ -538,7 +538,7 @@ impl<'a> Range<'a> {
             } else {
                 character_lengths.len()
             };
-            let value = node.value().unwrap();
+            let value = node.data().value().unwrap();
             let s = if start_index == end_index {
                 ""
             } else if start_index == 0 && end_index == character_lengths.len() {
@@ -983,7 +983,7 @@ impl<'a> Node<'a> {
     pub fn text_position_from_global_utf16_index(&self, index: usize) -> Option<Position> {
         let mut total_length = 0usize;
         for node in self.inline_text_boxes() {
-            let node_text = node.value().unwrap();
+            let node_text = node.data().value().unwrap();
             let node_text_length = node_text.chars().map(char::len_utf16).sum::<usize>();
             let new_total_length = total_length + node_text_length;
             if index >= total_length && index < new_total_length {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -182,6 +182,7 @@ impl State {
                             is_focused: old_focus_id == Some(id),
                             is_root: old_root_id == id,
                             name: None,
+                            value: None,
                             live: Live::Off,
                             supports_text_ranges: false,
                         };

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -303,13 +303,20 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn node_value(&self) -> Option<String> {
+        match self {
+            Self::Node(node) => node.value(),
+            Self::DetachedNode(node) => node.value(),
+        }
+    }
+
     // TODO: implement proper logic for title, description, and value;
     // see Chromium's content/browser/accessibility/browser_accessibility_cocoa.mm
     // and figure out how this is different in the macOS 10.10+ protocol
 
     pub(crate) fn title(&self) -> Option<String> {
         let state = self.node_state();
-        if state.role() == Role::StaticText && state.value().is_none() {
+        if state.role() == Role::StaticText && state.raw_value().is_none() {
             // In this case, macOS wants the text to be the value, not title.
             return None;
         }
@@ -321,8 +328,8 @@ impl<'a> NodeWrapper<'a> {
         if let Some(state) = state.checked_state() {
             return Some(Value::Bool(state != CheckedState::False));
         }
-        if let Some(value) = state.value() {
-            return Some(Value::String(value.into()));
+        if let Some(value) = self.node_value() {
+            return Some(Value::String(value));
         }
         if let Some(value) = state.numeric_value() {
             return Some(Value::Number(value));

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -112,7 +112,7 @@ impl Adapter {
                 }
             }
             fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
-                if old_node.value() != new_node.value() {
+                if old_node.raw_value() != new_node.raw_value() {
                     self.insert_text_change_if_needed(new_node);
                 }
                 if filter(new_node) != FilterResult::Include {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -358,15 +358,21 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn is_value_pattern_supported(&self) -> bool {
-        self.node_state().value().is_some()
+        match self {
+            Self::Node(node) => node.has_value(),
+            Self::DetachedNode(node) => node.has_value(),
+        }
     }
 
     fn is_range_value_pattern_supported(&self) -> bool {
         self.node_state().numeric_value().is_some()
     }
 
-    fn value(&self) -> &str {
-        self.node_state().value().unwrap()
+    fn value(&self) -> String {
+        match self {
+            Self::Node(node) => node.value().unwrap(),
+            Self::DetachedNode(node) => node.value().unwrap(),
+        }
     }
 
     fn is_read_only(&self) -> bool {


### PR DESCRIPTION
When a provider properly implements text field controls, setting the value property on the outer text field node is redundant, because the text is already provided in the inner inline text boxes. I expect that this would be a performance problem for large amounts of text. So now, `accesskit_consumer` provides its own value property for single-line text controls, based on the inner text. For multi-line controls without an outer value property, the macOS adapter fires value change events as appropriate, just as the Windows adapter already fires text change events. I've tested these changes on both Windows and macOS using a modified version of egui that doesn't set the value property on the text field.