### PR TITLE
refactor!: Decouple in-tree focus from host window/view focus

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -907,16 +907,24 @@ impl BoxCastPtr for tree_update {}
 
 impl tree_update {
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_update_new() -> *mut tree_update {
-        let update = TreeUpdate::default();
+    pub extern "C" fn accesskit_tree_update_with_focus(focus: node_id) -> *mut tree_update {
+        let update = TreeUpdate {
+            nodes: vec![],
+            tree: None,
+            focus: focus.into(),
+        };
         BoxCastPtr::to_mut_ptr(update)
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_update_with_capacity(capacity: usize) -> *mut tree_update {
+    pub extern "C" fn accesskit_tree_update_with_capacity_and_focus(
+        capacity: usize,
+        focus: node_id,
+    ) -> *mut tree_update {
         let update = TreeUpdate {
             nodes: Vec::with_capacity(capacity),
-            ..Default::default()
+            tree: None,
+            focus: focus.into(),
         };
         BoxCastPtr::to_mut_ptr(update)
     }
@@ -954,13 +962,7 @@ impl tree_update {
     #[no_mangle]
     pub extern "C" fn accesskit_tree_update_set_focus(update: *mut tree_update, focus: node_id) {
         let update = mut_from_ptr(update);
-        update.focus = Some(focus.into());
-    }
-
-    #[no_mangle]
-    pub extern "C" fn accesskit_tree_update_clear_focus(update: *mut tree_update) {
-        let update = mut_from_ptr(update);
-        update.focus = None;
+        update.focus = focus.into();
     }
 }
 

--- a/bindings/c/src/unix.rs
+++ b/bindings/c/src/unix.rs
@@ -35,6 +35,7 @@ impl unix_adapter {
         toolkit_version: *const c_char,
         initial_state: tree_update_factory,
         initial_state_userdata: *mut c_void,
+        is_window_focused: bool,
         handler: *mut action_handler,
     ) -> *mut unix_adapter {
         let app_name = unsafe { CStr::from_ptr(app_name).to_string_lossy().into() };
@@ -47,6 +48,7 @@ impl unix_adapter {
             toolkit_name,
             toolkit_version,
             move || *box_from_ptr(initial_state(initial_state_userdata)),
+            is_window_focused,
             handler,
         );
         adapter.map_or_else(ptr::null_mut, BoxCastPtr::to_mut_ptr)
@@ -76,5 +78,15 @@ impl unix_adapter {
         let adapter = ref_from_ptr(adapter);
         let update = box_from_ptr(update);
         adapter.update(*update);
+    }
+
+    /// Update the tree state based on whether the window is focused.
+    #[no_mangle]
+    pub extern "C" fn accesskit_unix_adapter_update_window_focus_state(
+        adapter: *const unix_adapter,
+        is_focused: bool,
+    ) {
+        let adapter = ref_from_ptr(adapter);
+        adapter.update_window_focus_state(is_focused);
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2364,7 +2364,7 @@ impl Tree {
 /// events for nodes that have not changed since the previous update,
 /// but there is still a cost in processing these nodes and replacing
 /// the previous instances.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -2398,18 +2398,12 @@ pub struct TreeUpdate {
     /// a tree.
     pub tree: Option<Tree>,
 
-    /// The node with keyboard focus within this tree, if any.
-    /// The most recent focus, if any,must be provided with every tree update.
-    ///
-    /// This field must contain a value if and only if the native host
-    /// (e.g. window) currently has the keyboard focus. This implies
-    /// that the AccessKit provider must track the native focus state
-    /// and send matching tree updates. Rationale: A robust GUI toolkit
-    /// must do this native focus tracking anyway in order to correctly
-    /// render widgets (e.g. to draw or not draw a focus rectangle),
-    /// so this focus tracking should not be duplicated between the toolkit
-    /// and the AccessKit platform adapters.
-    pub focus: Option<NodeId>,
+    /// The node within this tree that has keyboard focus when the native
+    /// host (e.g. window) has focus. If no specific node within the tree
+    /// has keyboard focus, this must be set to the root. The latest focus state
+    /// must be provided with every tree update, even if the focus state
+    /// didn't change in a given update.
+    pub focus: NodeId,
 }
 
 impl<T: FnOnce() -> TreeUpdate> From<T> for TreeUpdate {

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -142,9 +142,9 @@ mod tests {
                 (EMPTY_CONTAINER_3_3_IGNORED_ID, empty_container_3_3_ignored),
             ],
             tree: Some(Tree::new(ROOT_ID)),
-            focus: None,
+            focus: ROOT_ID,
         };
-        crate::tree::Tree::new(initial_update)
+        crate::tree::Tree::new(initial_update, false)
     }
 
     pub fn test_tree_filter(node: &crate::Node) -> FilterResult {

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -57,7 +57,7 @@ impl<'a> Node<'a> {
     }
 
     pub fn is_focused(&self) -> bool {
-        self.tree_state.focus == Some(self.id())
+        self.tree_state.focus_id() == Some(self.id())
     }
 }
 
@@ -1021,9 +1021,9 @@ mod tests {
                 ),
             ],
             tree: Some(Tree::new(NodeId(0))),
-            focus: None,
+            focus: NodeId(0),
         };
-        let tree = crate::Tree::new(update);
+        let tree = crate::Tree::new(update, false);
         assert_eq!(None, tree.state().node_by_id(NodeId(1)).unwrap().name());
     }
 
@@ -1064,9 +1064,9 @@ mod tests {
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
-            focus: None,
+            focus: NodeId(0),
         };
-        let tree = crate::Tree::new(update);
+        let tree = crate::Tree::new(update, false);
         assert_eq!(
             Some([LABEL_1, LABEL_2].join(" ")),
             tree.state().node_by_id(NodeId(1)).unwrap().name()
@@ -1117,9 +1117,9 @@ mod tests {
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
-            focus: None,
+            focus: NodeId(0),
         };
-        let tree = crate::Tree::new(update);
+        let tree = crate::Tree::new(update, false);
         assert_eq!(
             Some(BUTTON_LABEL.into()),
             tree.state().node_by_id(NodeId(1)).unwrap().name()

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -1213,10 +1213,10 @@ mod tests {
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
-            focus: Some(NodeId(1)),
+            focus: NodeId(1),
         };
 
-        crate::Tree::new(update)
+        crate::Tree::new(update, true)
     }
 
     fn multiline_end_selection() -> TextSelection {

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -18,6 +18,125 @@ use crate::{
     util::QueuedEvent,
 };
 
+struct AdapterChangeHandler<'a> {
+    context: &'a Arc<Context>,
+    queue: Vec<QueuedEvent>,
+    text_changed: HashSet<NodeId>,
+}
+
+impl AdapterChangeHandler<'_> {
+    fn insert_text_change_if_needed_parent(&mut self, node: Node) {
+        if !node.supports_text_ranges() {
+            return;
+        }
+        let id = node.id();
+        if self.text_changed.contains(&id) {
+            return;
+        }
+        let platform_node = PlatformNode::new(self.context, node.id());
+        let element: IRawElementProviderSimple = platform_node.into();
+        // Text change events must come before selection change
+        // events. It doesn't matter if text change events come
+        // before other events.
+        self.queue.insert(
+            0,
+            QueuedEvent::Simple {
+                element,
+                event_id: UIA_Text_TextChangedEventId,
+            },
+        );
+        self.text_changed.insert(id);
+    }
+
+    fn insert_text_change_if_needed(&mut self, node: &Node) {
+        if node.role() != Role::InlineTextBox {
+            return;
+        }
+        if let Some(node) = node.filtered_parent(&filter) {
+            self.insert_text_change_if_needed_parent(node);
+        }
+    }
+
+    fn insert_text_change_if_needed_for_removed_node(
+        &mut self,
+        node: &DetachedNode,
+        current_state: &TreeState,
+    ) {
+        if node.role() != Role::InlineTextBox {
+            return;
+        }
+        if let Some(id) = node.parent_id() {
+            if let Some(node) = current_state.node_by_id(id) {
+                self.insert_text_change_if_needed_parent(node);
+            }
+        }
+    }
+}
+
+impl TreeChangeHandler for AdapterChangeHandler<'_> {
+    fn node_added(&mut self, node: &Node) {
+        self.insert_text_change_if_needed(node);
+        if filter(node) != FilterResult::Include {
+            return;
+        }
+        if node.name().is_some() && node.live() != Live::Off {
+            let platform_node = PlatformNode::new(self.context, node.id());
+            let element: IRawElementProviderSimple = platform_node.into();
+            self.queue.push(QueuedEvent::Simple {
+                element,
+                event_id: UIA_LiveRegionChangedEventId,
+            });
+        }
+    }
+
+    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
+        if old_node.raw_value() != new_node.raw_value() {
+            self.insert_text_change_if_needed(new_node);
+        }
+        if filter(new_node) != FilterResult::Include {
+            return;
+        }
+        let platform_node = PlatformNode::new(self.context, new_node.id());
+        let element: IRawElementProviderSimple = platform_node.into();
+        let old_wrapper = NodeWrapper::DetachedNode(old_node);
+        let new_wrapper = NodeWrapper::Node(new_node);
+        new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
+        if new_node.name().is_some()
+            && new_node.live() != Live::Off
+            && (new_node.name() != old_node.name()
+                || new_node.live() != old_node.live()
+                || filter_detached(old_node) != FilterResult::Include)
+        {
+            self.queue.push(QueuedEvent::Simple {
+                element,
+                event_id: UIA_LiveRegionChangedEventId,
+            });
+        }
+    }
+
+    fn focus_moved(
+        &mut self,
+        _old_node: Option<&DetachedNode>,
+        new_node: Option<&Node>,
+        _current_state: &TreeState,
+    ) {
+        if let Some(new_node) = new_node {
+            let platform_node = PlatformNode::new(self.context, new_node.id());
+            let element: IRawElementProviderSimple = platform_node.into();
+            self.queue.push(QueuedEvent::Simple {
+                element,
+                event_id: UIA_AutomationFocusChangedEventId,
+            });
+        }
+    }
+
+    fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
+        self.insert_text_change_if_needed_for_removed_node(node, current_state);
+    }
+
+    // TODO: handle other events (#20)
+}
+
 pub struct Adapter {
     context: Arc<Context>,
 }
@@ -30,11 +149,24 @@ impl Adapter {
     pub fn new(
         hwnd: HWND,
         initial_state: TreeUpdate,
+        is_window_focused: bool,
         action_handler: Box<dyn ActionHandler + Send + Sync>,
         _uia_init_marker: UiaInitMarker,
     ) -> Self {
-        let context = Context::new(hwnd, Tree::new(initial_state), action_handler);
+        let context = Context::new(
+            hwnd,
+            Tree::new(initial_state, is_window_focused),
+            action_handler,
+        );
         Self { context }
+    }
+
+    fn change_handler(&self) -> AdapterChangeHandler {
+        AdapterChangeHandler {
+            context: &self.context,
+            queue: Vec::new(),
+            text_changed: HashSet::new(),
+        }
     }
 
     /// Apply the provided update to the tree.
@@ -45,123 +177,23 @@ impl Adapter {
     /// [`QueuedEvents::raise`] for restrictions on the context in which
     /// it should be called.
     pub fn update(&self, update: TreeUpdate) -> QueuedEvents {
-        struct Handler<'a> {
-            context: &'a Arc<Context>,
-            queue: Vec<QueuedEvent>,
-            text_changed: HashSet<NodeId>,
-        }
-        impl Handler<'_> {
-            fn insert_text_change_if_needed_parent(&mut self, node: Node) {
-                if !node.supports_text_ranges() {
-                    return;
-                }
-                let id = node.id();
-                if self.text_changed.contains(&id) {
-                    return;
-                }
-                let platform_node = PlatformNode::new(self.context, node.id());
-                let element: IRawElementProviderSimple = platform_node.into();
-                // Text change events must come before selection change
-                // events. It doesn't matter if text change events come
-                // before other events.
-                self.queue.insert(
-                    0,
-                    QueuedEvent::Simple {
-                        element,
-                        event_id: UIA_Text_TextChangedEventId,
-                    },
-                );
-                self.text_changed.insert(id);
-            }
-            fn insert_text_change_if_needed(&mut self, node: &Node) {
-                if node.role() != Role::InlineTextBox {
-                    return;
-                }
-                if let Some(node) = node.filtered_parent(&filter) {
-                    self.insert_text_change_if_needed_parent(node);
-                }
-            }
-            fn insert_text_change_if_needed_for_removed_node(
-                &mut self,
-                node: &DetachedNode,
-                current_state: &TreeState,
-            ) {
-                if node.role() != Role::InlineTextBox {
-                    return;
-                }
-                if let Some(id) = node.parent_id() {
-                    if let Some(node) = current_state.node_by_id(id) {
-                        self.insert_text_change_if_needed_parent(node);
-                    }
-                }
-            }
-        }
-        impl TreeChangeHandler for Handler<'_> {
-            fn node_added(&mut self, node: &Node) {
-                self.insert_text_change_if_needed(node);
-                if filter(node) != FilterResult::Include {
-                    return;
-                }
-                if node.name().is_some() && node.live() != Live::Off {
-                    let platform_node = PlatformNode::new(self.context, node.id());
-                    let element: IRawElementProviderSimple = platform_node.into();
-                    self.queue.push(QueuedEvent::Simple {
-                        element,
-                        event_id: UIA_LiveRegionChangedEventId,
-                    });
-                }
-            }
-            fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
-                if old_node.raw_value() != new_node.raw_value() {
-                    self.insert_text_change_if_needed(new_node);
-                }
-                if filter(new_node) != FilterResult::Include {
-                    return;
-                }
-                let platform_node = PlatformNode::new(self.context, new_node.id());
-                let element: IRawElementProviderSimple = platform_node.into();
-                let old_wrapper = NodeWrapper::DetachedNode(old_node);
-                let new_wrapper = NodeWrapper::Node(new_node);
-                new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
-                if new_node.name().is_some()
-                    && new_node.live() != Live::Off
-                    && (new_node.name() != old_node.name()
-                        || new_node.live() != old_node.live()
-                        || filter_detached(old_node) != FilterResult::Include)
-                {
-                    self.queue.push(QueuedEvent::Simple {
-                        element,
-                        event_id: UIA_LiveRegionChangedEventId,
-                    });
-                }
-            }
-            fn focus_moved(
-                &mut self,
-                _old_node: Option<&DetachedNode>,
-                new_node: Option<&Node>,
-                _current_state: &TreeState,
-            ) {
-                if let Some(new_node) = new_node {
-                    let platform_node = PlatformNode::new(self.context, new_node.id());
-                    let element: IRawElementProviderSimple = platform_node.into();
-                    self.queue.push(QueuedEvent::Simple {
-                        element,
-                        event_id: UIA_AutomationFocusChangedEventId,
-                    });
-                }
-            }
-            fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
-                self.insert_text_change_if_needed_for_removed_node(node, current_state);
-            }
-            // TODO: handle other events (#20)
-        }
-        let mut handler = Handler {
-            context: &self.context,
-            queue: Vec::new(),
-            text_changed: HashSet::new(),
-        };
+        let mut handler = self.change_handler();
         let mut tree = self.context.tree.write().unwrap();
         tree.update_and_process_changes(update, &mut handler);
+        QueuedEvents(handler.queue)
+    }
+
+    /// Update the tree state based on whether the window is focused.
+    ///
+    /// The caller must call [`QueuedEvents::raise`] on the return value.
+    ///
+    /// This method may be safely called on any thread, but refer to
+    /// [`QueuedEvents::raise`] for restrictions on the context in which
+    /// it should be called.
+    pub fn update_window_focus_state(&self, is_focused: bool) -> QueuedEvents {
+        let mut handler = self.change_handler();
+        let mut tree = self.context.tree.write().unwrap();
+        tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
         QueuedEvents(handler.queue)
     }
 

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -98,6 +98,7 @@ impl SubclassImpl {
         .unwrap();
         let result =
             unsafe { SetWindowLongPtrW(self.hwnd, GWLP_WNDPROC, wnd_proc as *const c_void as _) };
+        #[allow(clippy::unnecessary_literal_unwrap)]
         if result == 0 {
             let result: Result<()> = Err(Error::from_win32());
             result.unwrap();
@@ -124,6 +125,7 @@ impl SubclassImpl {
                 transmute::<WNDPROC, LongPtr>(self.prev_wnd_proc),
             )
         };
+        #[allow(clippy::unnecessary_literal_unwrap)]
         if result == 0 {
             let result: Result<()> = Err(Error::from_win32());
             result.unwrap();

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -40,7 +40,7 @@ fn get_initial_state() -> TreeUpdate {
             (BUTTON_2_ID, button_2),
         ],
         tree: Some(Tree::new(WINDOW_ID)),
-        focus: None,
+        focus: BUTTON_1_ID,
     }
 }
 
@@ -57,7 +57,6 @@ where
     super::scope(
         WINDOW_TITLE,
         get_initial_state(),
-        BUTTON_1_ID,
         Box::new(NullActionHandler {}),
         f,
     )

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -46,7 +46,7 @@ fn get_initial_state() -> TreeUpdate {
             (BUTTON_2_ID, button_2),
         ],
         tree: Some(Tree::new(WINDOW_ID)),
-        focus: None,
+        focus: BUTTON_1_ID,
     }
 }
 

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -232,6 +232,9 @@ impl Adapter {
                     Rect::from_origin_size(inner_position, inner_size),
                 )
             }
+            WindowEvent::Focused(is_focused) => {
+                self.adapter.update_window_focus_state(*is_focused);
+            }
             _ => (),
         }
         true

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -171,73 +171,9 @@ impl Adapter {
         Self { adapter }
     }
 
-    #[cfg(not(all(
-        feature = "accesskit_unix",
-        any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )
-    )))]
-    #[must_use]
-    pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
-        true
-    }
-    #[cfg(all(
-        feature = "accesskit_unix",
-        any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )
-    ))]
     #[must_use]
     pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {
-        use accesskit::Rect;
-
-        match event {
-            WindowEvent::Moved(outer_position) => {
-                let outer_position: (_, _) = outer_position.cast::<f64>().into();
-                let outer_size: (_, _) = window.outer_size().cast::<f64>().into();
-                let inner_position: (_, _) = window
-                    .inner_position()
-                    .unwrap_or_default()
-                    .cast::<f64>()
-                    .into();
-                let inner_size: (_, _) = window.inner_size().cast::<f64>().into();
-                self.adapter.set_root_window_bounds(
-                    Rect::from_origin_size(outer_position, outer_size),
-                    Rect::from_origin_size(inner_position, inner_size),
-                )
-            }
-            WindowEvent::Resized(outer_size) => {
-                let outer_position: (_, _) = window
-                    .outer_position()
-                    .unwrap_or_default()
-                    .cast::<f64>()
-                    .into();
-                let outer_size: (_, _) = outer_size.cast::<f64>().into();
-                let inner_position: (_, _) = window
-                    .inner_position()
-                    .unwrap_or_default()
-                    .cast::<f64>()
-                    .into();
-                let inner_size: (_, _) = window.inner_size().cast::<f64>().into();
-                self.adapter.set_root_window_bounds(
-                    Rect::from_origin_size(outer_position, outer_size),
-                    Rect::from_origin_size(inner_position, inner_size),
-                )
-            }
-            WindowEvent::Focused(is_focused) => {
-                self.adapter.update_window_focus_state(*is_focused);
-            }
-            _ => (),
-        }
-        true
+        self.adapter.on_event(window, event)
     }
 
     pub fn update(&self, update: TreeUpdate) {

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -149,6 +149,10 @@ pub struct Adapter {
 }
 
 impl Adapter {
+    /// Creates a new AccessKit adapter for a winit window. This must be done
+    /// before the window is shown for the first time. This means that you must
+    /// use [`winit::window::WindowBuilder::with_visible`] to make the window
+    /// initially invisible, then create the adapter, then show the window.
     pub fn new<T: From<ActionRequestEvent> + Send + 'static>(
         window: &Window,
         source: impl 'static + FnOnce() -> TreeUpdate + Send,
@@ -158,6 +162,11 @@ impl Adapter {
         Self::with_action_handler(window, source, Box::new(action_handler))
     }
 
+    /// Creates a new AccessKit adapter for a winit window. This must be done
+    /// before the window is shown for the first time. This means that you must
+    /// use [`winit::window::WindowBuilder::with_visible`] to make the window
+    /// initially invisible, then create the adapter, then show the window.
+    ///
     /// Use this if you need to provide your own AccessKit action handler
     /// rather than dispatching action requests through the winit event loop.
     /// Remember that an AccessKit action handler can be called on any thread,

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -4,7 +4,7 @@
 
 use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_macos::SubclassingAdapter;
-use winit::{platform::macos::WindowExtMacOS, window::Window};
+use winit::{event::WindowEvent, platform::macos::WindowExtMacOS, window::Window};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler>;
 
@@ -32,5 +32,15 @@ impl Adapter {
         if let Some(events) = self.adapter.update_if_active(updater) {
             events.raise();
         }
+    }
+
+    pub fn on_event(&self, _window: &Window, event: &WindowEvent) -> bool {
+        if let WindowEvent::Focused(is_focused) = event {
+            if let Some(events) = self.adapter.update_view_focus_state(*is_focused) {
+                events.raise();
+            }
+        }
+
+        true
     }
 }

--- a/platforms/winit/src/platform_impl/null.rs
+++ b/platforms/winit/src/platform_impl/null.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file).
 
 use accesskit::{ActionHandler, TreeUpdate};
-use winit::window::Window;
+use winit::{event::WindowEvent, window::Window};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler>;
 
@@ -21,4 +21,8 @@ impl Adapter {
     pub fn update(&self, _update: TreeUpdate) {}
 
     pub fn update_if_active(&self, _updater: impl FnOnce() -> TreeUpdate) {}
+
+    pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
+        true
+    }
 }

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -23,6 +23,7 @@ impl Adapter {
             String::new(),
             String::new(),
             source,
+            false,
             action_handler,
         );
         Self { adapter }
@@ -43,6 +44,12 @@ impl Adapter {
     pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
         if let Some(adapter) = &self.adapter {
             adapter.update(updater());
+        }
+    }
+
+    pub fn update_window_focus_state(&self, is_focused: bool) {
+        if let Some(adapter) = &self.adapter {
+            adapter.update_window_focus_state(is_focused);
         }
     }
 }

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -4,7 +4,7 @@
 
 use accesskit::{ActionHandler, Rect, TreeUpdate};
 use accesskit_unix::Adapter as UnixAdapter;
-use winit::window::Window;
+use winit::{event::WindowEvent, window::Window};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
 
@@ -54,8 +54,6 @@ impl Adapter {
     }
 
     pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {
-        use accesskit::Rect;
-
         match event {
             WindowEvent::Moved(outer_position) => {
                 let outer_position: (_, _) = outer_position.cast::<f64>().into();

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -29,7 +29,7 @@ impl Adapter {
         Self { adapter }
     }
 
-    pub fn set_root_window_bounds(&self, outer: Rect, inner: Rect) {
+    fn set_root_window_bounds(&self, outer: Rect, inner: Rect) {
         if let Some(adapter) = &self.adapter {
             adapter.set_root_window_bounds(outer, inner);
         }
@@ -47,9 +47,54 @@ impl Adapter {
         }
     }
 
-    pub fn update_window_focus_state(&self, is_focused: bool) {
+    fn update_window_focus_state(&self, is_focused: bool) {
         if let Some(adapter) = &self.adapter {
             adapter.update_window_focus_state(is_focused);
         }
+    }
+
+    pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {
+        use accesskit::Rect;
+
+        match event {
+            WindowEvent::Moved(outer_position) => {
+                let outer_position: (_, _) = outer_position.cast::<f64>().into();
+                let outer_size: (_, _) = window.outer_size().cast::<f64>().into();
+                let inner_position: (_, _) = window
+                    .inner_position()
+                    .unwrap_or_default()
+                    .cast::<f64>()
+                    .into();
+                let inner_size: (_, _) = window.inner_size().cast::<f64>().into();
+                self.set_root_window_bounds(
+                    Rect::from_origin_size(outer_position, outer_size),
+                    Rect::from_origin_size(inner_position, inner_size),
+                )
+            }
+            WindowEvent::Resized(outer_size) => {
+                let outer_position: (_, _) = window
+                    .outer_position()
+                    .unwrap_or_default()
+                    .cast::<f64>()
+                    .into();
+                let outer_size: (_, _) = outer_size.cast::<f64>().into();
+                let inner_position: (_, _) = window
+                    .inner_position()
+                    .unwrap_or_default()
+                    .cast::<f64>()
+                    .into();
+                let inner_size: (_, _) = window.inner_size().cast::<f64>().into();
+                self.set_root_window_bounds(
+                    Rect::from_origin_size(outer_position, outer_size),
+                    Rect::from_origin_size(inner_position, inner_size),
+                )
+            }
+            WindowEvent::Focused(is_focused) => {
+                self.update_window_focus_state(*is_focused);
+            }
+            _ => (),
+        }
+
+        true
     }
 }

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -4,7 +4,7 @@
 
 use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
-use winit::{platform::windows::WindowExtWindows, window::Window};
+use winit::{event::WindowEvent, platform::windows::WindowExtWindows, window::Window};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
 
@@ -31,5 +31,9 @@ impl Adapter {
         if let Some(events) = self.adapter.update_if_active(updater) {
             events.raise();
         }
+    }
+
+    pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
+        true
     }
 }


### PR DESCRIPTION
I'm making this change for two reasons. First, I've found that toolkit developers are confused by the existing rules around `TreeUpdate::focus`, and they tend to get it wrong. Second, the old design doesn't fully align with [my proposed vision for a new accessibility architecture for GNOME and other free desktops](https://github.com/mwcampbell/ng-a11y), because it mixes some global state into the tree update.

I've prioritized doing this change now because I already did the `NodeId` breaking change, so I think we should do all anticipated breaking changes at once.