### PR TITLE
fix!: Drop `Tree::root_scroller`

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -873,16 +873,12 @@ impl node_builder {
 #[repr(C)]
 pub struct tree {
     pub root: node_id,
-    pub root_scroller: opt_node_id,
 }
 
 impl tree {
     #[no_mangle]
     pub extern "C" fn accesskit_tree_new(root: node_id) -> tree {
-        tree {
-            root,
-            root_scroller: opt_node_id::default(),
-        }
+        tree { root }
     }
 }
 
@@ -890,7 +886,6 @@ impl From<tree> for Tree {
     fn from(tree: tree) -> Self {
         Self {
             root: tree.root.into(),
-            root_scroller: tree.root_scroller.into(),
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2336,20 +2336,12 @@ impl JsonSchema for Node {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Tree {
     pub root: NodeId,
-
-    /// The node that's used as the root scroller, if any. On some platforms
-    /// like Android we need to ignore accessibility scroll offsets for
-    /// that node and get them from the viewport instead.
-    pub root_scroller: Option<NodeId>,
 }
 
 impl Tree {
     #[inline]
     pub fn new(root: NodeId) -> Tree {
-        Tree {
-            root,
-            root_scroller: None,
-        }
+        Tree { root }
     }
 }
 

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -33,9 +33,6 @@ impl State {
     fn validate_global(&self) {
         assert!(self.nodes.contains_key(&self.data.root));
         assert!(self.nodes.contains_key(&self.focus));
-        if let Some(id) = self.data.root_scroller {
-            assert!(self.nodes.contains_key(&id));
-        }
     }
 
     fn update(


### PR DESCRIPTION
I believe this was always overly specific to the requirements of Chromium on Android. I'm sure the current rules around relative coordinates, especially when using transforms, are flexible enough to allow for such special cases.