### PR TITLE
feat: Add role for terminals

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -249,6 +249,11 @@ pub enum Role {
     /// `TableView` and its subclasses, so they can be exposed correctly
     /// on certain platforms.
     ListGrid,
+
+    /// This is just like a multi-line document, but signals that assistive
+    /// technologies should implement behavior specific to a VT-100-style
+    /// terminal.
+    Terminal,
 }
 
 impl Default for Role {

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -838,7 +838,7 @@ impl<'a> Node<'a> {
     pub fn supports_text_ranges(&self) -> bool {
         matches!(
             self.role(),
-            Role::StaticText | Role::TextField | Role::Document | Role::SpinButton
+            Role::StaticText | Role::TextField | Role::Document | Role::SpinButton | Role::Terminal
         ) && self.inline_text_boxes().next().is_some()
     }
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -227,6 +227,7 @@ fn ns_role(node_state: &NodeState) -> &'static NSString {
             Role::DocTip => NSAccessibilityGroupRole,
             Role::DocToc => NSAccessibilityGroupRole,
             Role::ListGrid => NSAccessibilityUnknownRole,
+            Role::Terminal => NSAccessibilityTextAreaRole,
         }
     }
 }

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -326,6 +326,7 @@ impl<'a> NodeWrapper<'a> {
             // TODO: Are there special cases to consider?
             Role::Presentation | Role::Unknown => AtspiRole::Unknown,
             Role::ImeCandidate | Role::Keyboard => AtspiRole::RedundantObject,
+            Role::Terminal => AtspiRole::Terminal,
         }
     }
 

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -160,7 +160,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Dialog => UIA_PaneControlTypeId,
             Role::Directory => UIA_ListControlTypeId,
             Role::DisclosureTriangle => UIA_ButtonControlTypeId,
-            Role::Document => UIA_DocumentControlTypeId,
+            Role::Document | Role::Terminal => UIA_DocumentControlTypeId,
             Role::EmbeddedObject => UIA_PaneControlTypeId,
             Role::Emphasis => UIA_TextControlTypeId,
             Role::Feed => UIA_GroupControlTypeId,


### PR DESCRIPTION
This just adds the role and maps it appropriately in the platform adapters. To really make this useful, we may need to fire some extra events, and we still need to implement text support in the Unix adapter. I'm not sure if we can really do anything useful with this on Windows without implementing a way of pushing AccessKit tree updates directly to ATs like NVDA, as I've had in mind for a while. But I want to start putting the necessary pieces in place.