### PR TITLE
bindings/c: disable doc

### DIFF
--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [lib]
 name = "accesskit"
 crate-type = ["cdylib", "staticlib"]
+doc = false
 
 [features]
 cbindgen = []


### PR DESCRIPTION
Partial fix for `cargo doc --all --no-deps`.

But on Linux you also need `--features winit/wayland` and then still get an error due to `platforms/macos`.