### PR TITLE
fix: Use common filters across platform adapters

### DIFF
--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit::Role;
+
+use crate::node::{DetachedNode, Node, NodeState};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FilterResult {
+    Include,
+    ExcludeNode,
+    ExcludeSubtree,
+}
+
+fn common_filter_base(node: &NodeState) -> FilterResult {
+    if node.is_hidden() {
+        return FilterResult::ExcludeSubtree;
+    }
+
+    let role = node.role();
+    if role == Role::Presentation || role == Role::GenericContainer || role == Role::InlineTextBox {
+        return FilterResult::ExcludeNode;
+    }
+
+    FilterResult::Include
+}
+
+pub fn common_filter(node: &Node) -> FilterResult {
+    if node.is_focused() {
+        return FilterResult::Include;
+    }
+    common_filter_base(node.state())
+}
+
+pub fn common_filter_detached(node: &DetachedNode) -> FilterResult {
+    if node.is_focused() {
+        return FilterResult::Include;
+    }
+    common_filter_base(node.state())
+}
+
+pub fn common_filter_with_root_exception(node: &Node) -> FilterResult {
+    if node.is_root() {
+        return FilterResult::Include;
+    }
+    common_filter(node)
+}

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -12,7 +12,7 @@ use std::iter::FusedIterator;
 
 use accesskit::NodeId;
 
-use crate::{node::Node, tree::State as TreeState};
+use crate::{filters::FilterResult, node::Node, tree::State as TreeState};
 
 /// An iterator that yields following siblings of a node.
 ///
@@ -177,13 +177,6 @@ impl<'a> DoubleEndedIterator for PrecedingSiblings<'a> {
 impl<'a> ExactSizeIterator for PrecedingSiblings<'a> {}
 
 impl<'a> FusedIterator for PrecedingSiblings<'a> {}
-
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum FilterResult {
-    Include,
-    ExcludeNode,
-    ExcludeSubtree,
-}
 
 fn next_filtered_sibling<'a>(
     node: Option<Node<'a>>,

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -9,8 +9,12 @@ pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
 pub(crate) mod node;
 pub use node::{DetachedNode, Node, NodeState};
 
+pub(crate) mod filters;
+pub use filters::{
+    common_filter, common_filter_detached, common_filter_with_root_exception, FilterResult,
+};
+
 pub(crate) mod iterators;
-pub use iterators::FilterResult;
 
 pub(crate) mod text;
 pub use text::{

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -15,8 +15,9 @@ use accesskit::{
     Role, TextSelection,
 };
 
+use crate::filters::FilterResult;
 use crate::iterators::{
-    FilterResult, FilteredChildren, FollowingFilteredSiblings, FollowingSiblings, LabelledBy,
+    FilteredChildren, FollowingFilteredSiblings, FollowingSiblings, LabelledBy,
     PrecedingFilteredSiblings, PrecedingSiblings,
 };
 use crate::tree::State as TreeState;

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -15,7 +15,8 @@ use crate::{
     appkit::NSView,
     context::Context,
     event::{EventGenerator, QueuedEvents},
-    node::{can_be_focused, filter},
+    filters::filter,
+    node::can_be_focused,
     util::*,
 };
 

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -14,7 +14,8 @@ use std::{collections::HashSet, rc::Rc};
 use crate::{
     appkit::*,
     context::Context,
-    node::{filter, filter_detached, NodeWrapper},
+    filters::{filter, filter_detached},
+    node::NodeWrapper,
 };
 
 // Workaround for https://github.com/madsmtm/objc2/issues/306

--- a/platforms/macos/src/filters.rs
+++ b/platforms/macos/src/filters.rs
@@ -1,0 +1,8 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+pub(crate) use accesskit_consumer::{
+    common_filter as filter, common_filter_detached as filter_detached,
+};

--- a/platforms/macos/src/lib.rs
+++ b/platforms/macos/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod appkit;
 mod context;
+mod filters;
 mod node;
 mod util;
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -28,7 +28,7 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use crate::{appkit::*, context::Context, util::*};
+use crate::{appkit::*, context::Context, filters::filter, util::*};
 
 fn ns_role(node_state: &NodeState) -> &'static NSString {
     let role = node_state.role();
@@ -230,35 +230,6 @@ fn ns_role(node_state: &NodeState) -> &'static NSString {
             Role::Terminal => NSAccessibilityTextAreaRole,
         }
     }
-}
-
-fn filter_common(node_state: &NodeState) -> FilterResult {
-    let ns_role = ns_role(node_state);
-    if ns_role == unsafe { NSAccessibilityUnknownRole } {
-        return FilterResult::ExcludeNode;
-    }
-
-    if node_state.is_hidden() {
-        return FilterResult::ExcludeSubtree;
-    }
-
-    FilterResult::Include
-}
-
-pub(crate) fn filter(node: &Node) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
-}
-
-pub(crate) fn filter_detached(node: &DetachedNode) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
 }
 
 pub(crate) fn can_be_focused(node: &Node) -> bool {

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -12,7 +12,8 @@ use crate::{
         Bus, ObjectId, ACCESSIBLE_PATH_PREFIX,
     },
     context::Context,
-    node::{filter, filter_detached, NodeWrapper, PlatformNode},
+    filters::{filter, filter_detached},
+    node::{NodeWrapper, PlatformNode},
     util::{block_on, AppContext},
 };
 use accesskit::{ActionHandler, NodeId, Rect, Role, TreeUpdate};

--- a/platforms/unix/src/filters.rs
+++ b/platforms/unix/src/filters.rs
@@ -1,0 +1,8 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+pub(crate) use accesskit_consumer::{
+    common_filter as filter, common_filter_detached as filter_detached,
+};

--- a/platforms/unix/src/lib.rs
+++ b/platforms/unix/src/lib.rs
@@ -9,6 +9,7 @@ extern crate zbus;
 mod adapter;
 mod atspi;
 mod context;
+mod filters;
 mod node;
 mod util;
 

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -14,6 +14,7 @@ use crate::{
         ObjectId, ObjectRef, Rect as AtspiRect, ACCESSIBLE_PATH_PREFIX,
     },
     context::Context,
+    filters::{filter, filter_detached},
     util::WindowBounds,
 };
 use accesskit::{
@@ -31,35 +32,6 @@ use std::{
     sync::{Arc, Weak},
 };
 use zbus::fdo;
-
-fn filter_common(node: &NodeState) -> FilterResult {
-    if node.is_hidden() {
-        return FilterResult::ExcludeSubtree;
-    }
-
-    let role = node.role();
-    if role == Role::Presentation || role == Role::GenericContainer || role == Role::InlineTextBox {
-        return FilterResult::ExcludeNode;
-    }
-
-    FilterResult::Include
-}
-
-pub(crate) fn filter(node: &Node) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
-}
-
-pub(crate) fn filter_detached(node: &DetachedNode) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
-}
 
 pub(crate) enum NodeWrapper<'a> {
     Node(&'a Node<'a>),

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -13,8 +13,9 @@ use windows::Win32::{
 
 use crate::{
     context::Context,
+    filters::{filter, filter_detached},
     init::UiaInitMarker,
-    node::{filter, filter_detached, NodeWrapper, PlatformNode},
+    node::{NodeWrapper, PlatformNode},
     util::QueuedEvent,
 };
 

--- a/platforms/windows/src/filters.rs
+++ b/platforms/windows/src/filters.rs
@@ -1,0 +1,9 @@
+// Copyright 2023 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+pub(crate) use accesskit_consumer::{
+    common_filter as filter, common_filter_detached as filter_detached,
+    common_filter_with_root_exception as filter_with_root_exception,
+};

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -4,6 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 mod context;
+mod filters;
 mod node;
 mod text;
 mod util;

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -21,7 +21,12 @@ use windows::{
     Win32::{Foundation::*, System::Com::*, UI::Accessibility::*},
 };
 
-use crate::{context::Context, text::PlatformRange as PlatformTextRange, util::*};
+use crate::{
+    context::Context,
+    filters::{filter, filter_detached, filter_with_root_exception},
+    text::PlatformRange as PlatformTextRange,
+    util::*,
+};
 
 const RUNTIME_ID_SIZE: usize = 3;
 
@@ -33,42 +38,6 @@ fn runtime_id_from_node_id(id: NodeId) -> [i32; RUNTIME_ID_SIZE] {
         ((id >> 32) & 0xFFFFFFFF) as _,
         (id & 0xFFFFFFFF) as _,
     ]
-}
-
-fn filter_common(node: &NodeState) -> FilterResult {
-    if node.is_hidden() {
-        return FilterResult::ExcludeSubtree;
-    }
-
-    let role = node.role();
-    if role == Role::Presentation || role == Role::GenericContainer || role == Role::InlineTextBox {
-        return FilterResult::ExcludeNode;
-    }
-
-    FilterResult::Include
-}
-
-pub(crate) fn filter(node: &Node) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
-}
-
-pub(crate) fn filter_detached(node: &DetachedNode) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-
-    filter_common(node.state())
-}
-
-fn filter_with_root_exception(node: &Node) -> FilterResult {
-    if node.is_root() {
-        return FilterResult::Include;
-    }
-    filter(node)
 }
 
 pub(crate) enum NodeWrapper<'a> {


### PR DESCRIPTION
The Windows and Unix adapters use duplicated filter functions, and I decided that the macOS adapter should use those same filters as well. So now those functions are defined in the consumer crate.