### PR TITLE
fix!: Drop next/previous focus properties

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -587,9 +587,7 @@ node_id_property_methods! {
     (popup_for, set_popup_for, clear_popup_for),
     (table_header, set_table_header, clear_table_header),
     (table_row_header, set_table_row_header, clear_table_row_header),
-    (table_column_header, set_table_column_header, clear_table_column_header),
-    (next_focus, set_next_focus, clear_next_focus),
-    (previous_focus, set_previous_focus, clear_previous_focus)
+    (table_column_header, set_table_column_header, clear_table_column_header)
 }
 
 /// Only call this function with a string that originated from AccessKit.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -864,8 +864,6 @@ enum PropertyId {
     TableHeader,
     TableRowHeader,
     TableColumnHeader,
-    NextFocus,
-    PreviousFocus,
 
     // String
     Name,
@@ -1591,9 +1589,7 @@ node_id_property_methods! {
     (PopupFor, popup_for, set_popup_for, clear_popup_for),
     (TableHeader, table_header, set_table_header, clear_table_header),
     (TableRowHeader, table_row_header, set_table_row_header, clear_table_row_header),
-    (TableColumnHeader, table_column_header, set_table_column_header, clear_table_column_header),
-    (NextFocus, next_focus, set_next_focus, clear_next_focus),
-    (PreviousFocus, previous_focus, set_previous_focus, clear_previous_focus)
+    (TableColumnHeader, table_column_header, set_table_column_header, clear_table_column_header)
 }
 
 string_property_methods! {
@@ -2016,9 +2012,7 @@ impl<'de> Visitor<'de> for NodeVisitor {
                             PopupFor,
                             TableHeader,
                             TableRowHeader,
-                            TableColumnHeader,
-                            NextFocus,
-                            PreviousFocus
+                            TableColumnHeader
                         },
                         String {
                             Name,
@@ -2221,9 +2215,7 @@ impl JsonSchema for Node {
                 PopupFor,
                 TableHeader,
                 TableRowHeader,
-                TableColumnHeader,
-                NextFocus,
-                PreviousFocus
+                TableColumnHeader
             },
             Box<str> {
                 Name,


### PR DESCRIPTION
I decided that, as shown in #284, these properties only add unnecessary complexity for GUI toolkit developers. None of the platform adapters use them, and there's probably no way they ever could. The equivalent properties in Chromium are only used by ChromeVox. My understanding is that the only purpose of these properties is to allow tabbing to the correct control when a screen reader's browse mode, scan mode, or equivalent is active, and the screen reader's cursor is not on a focusable control. In my opinion, that purpose is better served by the existing `SetSequentialFocusNavigationStartingPoint` action, which will remain optional for toolkit developers.