### PR TITLE
feat!: Allow providing app_name, toolkit_name and toolkit_version in Tree, remove parameters from unix adapter constructor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Matt Campbell
 Arnold Loubriat
 Google LLC
+Leonard de Ruijter

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -230,7 +230,7 @@ accesskit_tree_update *window_state_build_initial_tree(
   accesskit_tree_update *result = accesskit_tree_update_with_capacity_and_focus(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
-  accesskit_tree_set_app_name(tree, WINDOW_TITLE);
+  accesskit_tree_set_app_name(tree, "Hello World");
   accesskit_tree_set_toolkit_info(tree, "SDL", "2.0");
   accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -64,7 +64,7 @@ struct accesskit_sdl_adapter {
 };
 
 void accesskit_sdl_adapter_init(struct accesskit_sdl_adapter *adapter,
-                                SDL_Window *window, const char *app_name,
+                                SDL_Window *window,
                                 accesskit_tree_update_factory source,
                                 void *source_userdata,
                                 accesskit_action_handler *handler) {
@@ -76,8 +76,8 @@ void accesskit_sdl_adapter_init(struct accesskit_sdl_adapter *adapter,
   adapter->adapter = accesskit_macos_subclassing_adapter_for_window(
       (void *)wmInfo.info.cocoa.window, source, source_userdata, handler);
 #elif defined(UNIX)
-  adapter->adapter = accesskit_unix_adapter_new(
-      app_name, "SDL", "2.0", source, source_userdata, false, handler);
+  adapter->adapter =
+      accesskit_unix_adapter_new(source, source_userdata, false, handler);
 #elif defined(_WIN32)
   SDL_SysWMinfo wmInfo;
   SDL_VERSION(&wmInfo.version);

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -16,7 +16,7 @@ const accesskit_node_id WINDOW_ID = 0;
 const accesskit_node_id BUTTON_1_ID = 1;
 const accesskit_node_id BUTTON_2_ID = 2;
 const accesskit_node_id ANNOUNCEMENT_ID = 3;
-const accesskit_node_id INITIAL_FOCUS = BUTTON_1_ID;
+#define INITIAL_FOCUS BUTTON_1_ID
 
 const accesskit_rect BUTTON_1_RECT = {20.0, 20.0, 100.0, 60.0};
 

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -229,7 +229,10 @@ accesskit_tree_update *window_state_build_initial_tree(
       build_button(BUTTON_2_ID, "Button 2", state->node_classes);
   accesskit_tree_update *result = accesskit_tree_update_with_capacity_and_focus(
       (state->announcement != NULL) ? 4 : 3, state->focus);
-  accesskit_tree_update_set_tree(result, accesskit_tree_new(WINDOW_ID));
+  accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
+  accesskit_tree_set_app_name(tree, WINDOW_TITLE);
+  accesskit_tree_set_toolkit_info(tree, "SDL", "2.0");
+  accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);
   accesskit_tree_update_push_node(result, BUTTON_2_ID, button_2);
@@ -343,7 +346,7 @@ int main(int argc, char *argv[]) {
   struct action_handler_state action_handler = {user_event, window_id};
   struct accesskit_sdl_adapter adapter;
   accesskit_sdl_adapter_init(
-      &adapter, window, "hello_world", build_initial_tree, &state,
+      &adapter, window, build_initial_tree, &state,
       accesskit_action_handler_new(do_action, &action_handler));
   SDL_ShowWindow(window);
 

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -231,8 +231,6 @@ accesskit_tree_update *window_state_build_initial_tree(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
   accesskit_tree_set_app_name(tree, "Hello World");
-  accesskit_tree_set_toolkit_name(tree, "SDL");
-  accesskit_tree_set_toolkit_version(tree, "2.0");
   accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -231,7 +231,8 @@ accesskit_tree_update *window_state_build_initial_tree(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
   accesskit_tree_set_app_name(tree, "Hello World");
-  accesskit_tree_set_toolkit_info(tree, "SDL", "2.0");
+  accesskit_tree_set_toolkit_name(tree, "SDL");
+  accesskit_tree_set_toolkit_version(tree, "2.0");
   accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -11,7 +11,7 @@ const accesskit_node_id WINDOW_ID = 0;
 const accesskit_node_id BUTTON_1_ID = 1;
 const accesskit_node_id BUTTON_2_ID = 2;
 const accesskit_node_id ANNOUNCEMENT_ID = 3;
-const accesskit_node_id INITIAL_FOCUS = BUTTON_1_ID;
+#define INITIAL_FOCUS BUTTON_1_ID
 
 const accesskit_rect BUTTON_1_RECT = {20.0, 20.0, 100.0, 60.0};
 

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -90,7 +90,6 @@ accesskit_tree_update *window_state_build_initial_tree(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
   accesskit_tree_set_app_name(tree, "Hello World");
-  accesskit_tree_set_toolkit_info(tree, "AccessKitTest", "2.0");
   accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -88,7 +88,10 @@ accesskit_tree_update *window_state_build_initial_tree(
       build_button(BUTTON_2_ID, "Button 2", state->node_classes);
   accesskit_tree_update *result = accesskit_tree_update_with_capacity_and_focus(
       (state->announcement != NULL) ? 4 : 3, state->focus);
-  accesskit_tree_update_set_tree(result, accesskit_tree_new(WINDOW_ID));
+  accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
+  accesskit_tree_set_app_name(tree, "Hello world");
+  accesskit_tree_set_toolkit_info(tree, "AccessKitTest", "2.0");
+  accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);
   accesskit_tree_update_push_node(result, BUTTON_2_ID, button_2);

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -89,7 +89,7 @@ accesskit_tree_update *window_state_build_initial_tree(
   accesskit_tree_update *result = accesskit_tree_update_with_capacity_and_focus(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
-  accesskit_tree_set_app_name(tree, "Hello world");
+  accesskit_tree_set_app_name(tree, "Hello World");
   accesskit_tree_set_toolkit_info(tree, "AccessKitTest", "2.0");
   accesskit_tree_update_set_tree(result, tree);
   accesskit_tree_update_push_node(result, WINDOW_ID, root);

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -864,8 +864,8 @@ impl BoxCastPtr for tree {}
 impl tree {
     #[no_mangle]
     pub extern "C" fn accesskit_tree_new(root: node_id) -> *mut tree {
-        let t = Tree::new(root.into());
-        BoxCastPtr::to_mut_ptr(t)
+        let internal_tree = Tree::new(root.into());
+        BoxCastPtr::to_mut_ptr(internal_tree)
     }
 
     #[no_mangle]
@@ -882,15 +882,19 @@ impl tree {
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_set_toolkit_info(
-        t: *mut tree,
-        toolkit_name: *const c_char,
-        toolkit_version: *const c_char,
-    ) {
+    pub extern "C" fn accesskit_tree_set_toolkit_name(t: *mut tree, toolkit_name: *const c_char) {
         let t = mut_from_ptr(t);
         t.toolkit_name = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_name) }.to_string_lossy(),
         ));
+    }
+
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_set_toolkit_version(
+        t: *mut tree,
+        toolkit_version: *const c_char,
+    ) {
+        let t = mut_from_ptr(t);
         t.toolkit_version = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_version) }.to_string_lossy(),
         ));

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -875,10 +875,10 @@ impl tree {
 
     /// Caller must call `accesskit_string_free` with the return value.
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_get_app_name(tree: *mut tree) -> *mut c_char {
-        let tree = box_from_ptr(tree);
-        match tree.app_name {
-            Some(value) => CString::new(value).unwrap().into_raw(),
+    pub extern "C" fn accesskit_tree_get_app_name(tree: *const tree) -> *mut c_char {
+        let tree = ref_from_ptr(tree);
+        match tree.app_name.as_ref() {
+            Some(value) => CString::new(value.clone()).unwrap().into_raw(),
             None => ptr::null_mut(),
         }
     }
@@ -899,10 +899,10 @@ impl tree {
 
     /// Caller must call `accesskit_string_free` with the return value.
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_get_toolkit_name(tree: *mut tree) -> *mut c_char {
-        let tree = box_from_ptr(tree);
-        match tree.toolkit_name {
-            Some(value) => CString::new(value).unwrap().into_raw(),
+    pub extern "C" fn accesskit_tree_get_toolkit_name(tree: *const tree) -> *mut c_char {
+        let tree = ref_from_ptr(tree);
+        match tree.toolkit_name.as_ref() {
+            Some(value) => CString::new(value.clone()).unwrap().into_raw(),
             None => ptr::null_mut(),
         }
     }
@@ -926,10 +926,10 @@ impl tree {
 
     /// Caller must call `accesskit_string_free` with the return value.
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_get_toolkit_version(tree: *mut tree) -> *mut c_char {
-        let tree = box_from_ptr(tree);
-        match tree.toolkit_version {
-            Some(value) => CString::new(value).unwrap().into_raw(),
+    pub extern "C" fn accesskit_tree_get_toolkit_version(tree: *const tree) -> *mut c_char {
+        let tree = ref_from_ptr(tree);
+        match tree.toolkit_version.as_ref() {
+            Some(value) => CString::new(value.clone()).unwrap().into_raw(),
             None => ptr::null_mut(),
         }
     }

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -882,19 +882,15 @@ impl tree {
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_set_toolkit_name(t: *mut tree, toolkit_name: *const c_char) {
+    pub extern "C" fn accesskit_tree_set_toolkit_info(
+        t: *mut tree,
+        toolkit_name: *const c_char,
+        toolkit_version: *const c_char,
+    ) {
         let t = mut_from_ptr(t);
         t.toolkit_name = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_name) }.to_string_lossy(),
         ));
-    }
-
-    #[no_mangle]
-    pub extern "C" fn accesskit_tree_set_toolkit_version(
-        t: *mut tree,
-        toolkit_version: *const c_char,
-    ) {
-        let t = mut_from_ptr(t);
         t.toolkit_version = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_version) }.to_string_lossy(),
         ));

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -864,40 +864,91 @@ impl BoxCastPtr for tree {}
 impl tree {
     #[no_mangle]
     pub extern "C" fn accesskit_tree_new(root: node_id) -> *mut tree {
-        let internal_tree = Tree::new(root.into());
-        BoxCastPtr::to_mut_ptr(internal_tree)
+        let tree = Tree::new(root.into());
+        BoxCastPtr::to_mut_ptr(tree)
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_free(t: *mut tree) {
-        drop(box_from_ptr(t));
+    pub extern "C" fn accesskit_tree_free(tree: *mut tree) {
+        drop(box_from_ptr(tree));
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_get_app_name(tree: *mut tree) -> *mut c_char {
+        let tree = box_from_ptr(tree);
+        match tree.app_name {
+            Some(value) => CString::new(value).unwrap().into_raw(),
+            None => ptr::null_mut(),
+        }
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_set_app_name(t: *mut tree, app_name: *const c_char) {
-        let t = mut_from_ptr(t);
-        t.app_name = Some(String::from(
+    pub extern "C" fn accesskit_tree_set_app_name(tree: *mut tree, app_name: *const c_char) {
+        let tree = mut_from_ptr(tree);
+        tree.app_name = Some(String::from(
             unsafe { CStr::from_ptr(app_name) }.to_string_lossy(),
         ));
     }
 
     #[no_mangle]
-    pub extern "C" fn accesskit_tree_set_toolkit_name(t: *mut tree, toolkit_name: *const c_char) {
-        let t = mut_from_ptr(t);
-        t.toolkit_name = Some(String::from(
+    pub extern "C" fn accesskit_tree_clear_app_name(tree: *mut tree) {
+        let tree = mut_from_ptr(tree);
+        tree.app_name = None;
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_get_toolkit_name(tree: *mut tree) -> *mut c_char {
+        let tree = box_from_ptr(tree);
+        match tree.toolkit_name {
+            Some(value) => CString::new(value).unwrap().into_raw(),
+            None => ptr::null_mut(),
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_set_toolkit_name(
+        tree: *mut tree,
+        toolkit_name: *const c_char,
+    ) {
+        let tree = mut_from_ptr(tree);
+        tree.toolkit_name = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_name) }.to_string_lossy(),
         ));
     }
 
     #[no_mangle]
+    pub extern "C" fn accesskit_tree_clear_toolkit_name(tree: *mut tree) {
+        let tree = mut_from_ptr(tree);
+        tree.toolkit_name = None;
+    }
+
+    /// Caller must call `accesskit_string_free` with the return value.
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_get_toolkit_version(tree: *mut tree) -> *mut c_char {
+        let tree = box_from_ptr(tree);
+        match tree.toolkit_version {
+            Some(value) => CString::new(value).unwrap().into_raw(),
+            None => ptr::null_mut(),
+        }
+    }
+
+    #[no_mangle]
     pub extern "C" fn accesskit_tree_set_toolkit_version(
-        t: *mut tree,
+        tree: *mut tree,
         toolkit_version: *const c_char,
     ) {
-        let t = mut_from_ptr(t);
-        t.toolkit_version = Some(String::from(
+        let tree = mut_from_ptr(tree);
+        tree.toolkit_version = Some(String::from(
             unsafe { CStr::from_ptr(toolkit_version) }.to_string_lossy(),
         ));
+    }
+
+    #[no_mangle]
+    pub extern "C" fn accesskit_tree_clear_toolkit_version(tree: *mut tree) {
+        let tree = mut_from_ptr(tree);
+        tree.toolkit_version = None;
     }
 }
 

--- a/bindings/c/src/unix.rs
+++ b/bindings/c/src/unix.rs
@@ -26,27 +26,17 @@ impl CastPtr for unix_adapter {
 impl BoxCastPtr for unix_adapter {}
 
 impl unix_adapter {
-    /// Caller is responsible for freeing `app_name`, `toolkit_name` and `toolkit_version`.
     /// This function will take ownership of the pointer returned by `initial_state`, which can't be null.
     #[no_mangle]
     pub extern "C" fn accesskit_unix_adapter_new(
-        app_name: *const c_char,
-        toolkit_name: *const c_char,
-        toolkit_version: *const c_char,
         initial_state: tree_update_factory,
         initial_state_userdata: *mut c_void,
         is_window_focused: bool,
         handler: *mut action_handler,
     ) -> *mut unix_adapter {
-        let app_name = unsafe { CStr::from_ptr(app_name).to_string_lossy().into() };
-        let toolkit_name = unsafe { CStr::from_ptr(toolkit_name).to_string_lossy().into() };
-        let toolkit_version = unsafe { CStr::from_ptr(toolkit_version).to_string_lossy().into() };
         let initial_state = initial_state.unwrap();
         let handler = box_from_ptr(handler);
         let adapter = Adapter::new(
-            app_name,
-            toolkit_name,
-            toolkit_version,
             move || *box_from_ptr(initial_state(initial_state_userdata)),
             is_window_focused,
             handler,

--- a/bindings/c/src/unix.rs
+++ b/bindings/c/src/unix.rs
@@ -9,11 +9,7 @@ use crate::{
 };
 use accesskit::Rect;
 use accesskit_unix::Adapter;
-use std::{
-    ffi::CStr,
-    os::raw::{c_char, c_void},
-    ptr,
-};
+use std::{os::raw::c_void, ptr};
 
 pub struct unix_adapter {
     _private: [u8; 0],

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2239,13 +2239,10 @@ pub struct Tree {
     /// The identifier of the tree's root node
     pub root: NodeId,
     /// The name of the application this tree belongs to.
-    /// This value is optional.
     pub app_name: Option<String>,
     /// The name of the UI toolkit in use.
-    /// This value is optional.
     pub toolkit_name: Option<String>,
     /// The version of the UI toolkit.
-    /// This value is optional.
     pub toolkit_version: Option<String>,
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2236,13 +2236,28 @@ impl JsonSchema for Node {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Tree {
+    /// The identifier of the tree's root node
     pub root: NodeId,
+    /// The name of the application this tree belongs to.
+    /// This value is optional.
+    pub app_name: Option<String>,
+    /// The name of the used UI toolkit.
+    /// This value is optional.
+    pub toolkit_name: Option<String>,
+    /// The version of the UI toolkit.
+    /// This value is optional.
+    pub toolkit_version: Option<String>,
 }
 
 impl Tree {
     #[inline]
     pub fn new(root: NodeId) -> Tree {
-        Tree { root }
+        Tree {
+            root,
+            app_name: None,
+            toolkit_name: None,
+            toolkit_version: None,
+        }
     }
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2236,7 +2236,7 @@ impl JsonSchema for Node {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Tree {
-    /// The identifier of the tree's root node
+    /// The identifier of the tree's root node.
     pub root: NodeId,
     /// The name of the application this tree belongs to.
     pub app_name: Option<String>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2241,7 +2241,7 @@ pub struct Tree {
     /// The name of the application this tree belongs to.
     /// This value is optional.
     pub app_name: Option<String>,
-    /// Name of the UI toolkit in use.
+    /// The name of the UI toolkit in use.
     /// This value is optional.
     pub toolkit_name: Option<String>,
     /// The version of the UI toolkit.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2241,7 +2241,7 @@ pub struct Tree {
     /// The name of the application this tree belongs to.
     /// This value is optional.
     pub app_name: Option<String>,
-    /// The name of the used UI toolkit.
+    /// Name of the UI toolkit in use.
     /// This value is optional.
     pub toolkit_name: Option<String>,
     /// The version of the UI toolkit.

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -270,33 +270,6 @@ impl State {
     pub fn toolkit_version(&self) -> Option<String> {
         self.data.toolkit_version.clone()
     }
-
-    pub fn app_and_toolkit_description(&self) -> Option<String> {
-        let app_name = self.app_name();
-        let toolkit_name = self.toolkit_name();
-        let toolkit_version = self.toolkit_version();
-        if let (Some(app_name), Some(toolkit_name), Some(toolkit_version)) =
-            (&app_name, &toolkit_name, &toolkit_version)
-        {
-            return Some(format!(
-                "{} <{} {}>",
-                app_name, toolkit_name, toolkit_version
-            ));
-        } else if let (Some(app_name), Some(toolkit_name), None) =
-            (&app_name, &toolkit_name, &toolkit_version)
-        {
-            return Some(format!("{} <{}>", app_name, toolkit_name));
-        } else if let (None, Some(toolkit_name), Some(toolkit_version)) =
-            (&app_name, &toolkit_name, &toolkit_version)
-        {
-            return Some(format!("{} {}", toolkit_name, toolkit_version));
-        } else if toolkit_name.is_some() {
-            return toolkit_name;
-        } else if app_name.is_some() {
-            return app_name;
-        }
-        None
-    }
 }
 
 pub trait ChangeHandler {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -258,6 +258,45 @@ impl State {
     pub fn focus(&self) -> Option<Node<'_>> {
         self.focus_id().map(|id| self.node_by_id(id).unwrap())
     }
+
+    pub fn app_name(&self) -> Option<String> {
+        self.data.app_name.clone()
+    }
+
+    pub fn toolkit_name(&self) -> Option<String> {
+        self.data.toolkit_name.clone()
+    }
+
+    pub fn toolkit_version(&self) -> Option<String> {
+        self.data.toolkit_version.clone()
+    }
+
+    pub fn app_and_toolkit_description(&self) -> Option<String> {
+        let app_name = self.app_name();
+        let toolkit_name = self.toolkit_name();
+        let toolkit_version = self.toolkit_version();
+        if let (Some(app_name), Some(toolkit_name), Some(toolkit_version)) =
+            (&app_name, &toolkit_name, &toolkit_version)
+        {
+            return Some(format!(
+                "{} <{} {}>",
+                app_name, toolkit_name, toolkit_version
+            ));
+        } else if let (Some(app_name), Some(toolkit_name), None) =
+            (&app_name, &toolkit_name, &toolkit_version)
+        {
+            return Some(format!("{} <{}>", app_name, toolkit_name));
+        } else if let (None, Some(toolkit_name), Some(toolkit_version)) =
+            (&app_name, &toolkit_name, &toolkit_version)
+        {
+            return Some(format!("{} {}", toolkit_name, toolkit_version));
+        } else if toolkit_name.is_some() {
+            return toolkit_name;
+        } else if app_name.is_some() {
+            return app_name;
+        }
+        None
+    }
 }
 
 pub trait ChangeHandler {

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -211,7 +211,11 @@ impl Adapter {
         let tree = Tree::new(initial_state(), is_window_focused);
         let id = NEXT_ADAPTER_ID.fetch_add(1, Ordering::SeqCst);
         let root_id = tree.state().root_id();
-        let app_context = AppContext::get_or_init("".into(), "".into(), "".into());
+        let app_context = AppContext::get_or_init(
+            tree.state().app_name().unwrap_or_default(),
+            tree.state().toolkit_name().unwrap_or_default(),
+            tree.state().toolkit_version().unwrap_or_default(),
+        );
         let context = Context::new(tree, action_handler, &app_context);
         let adapter_index = app_context.write().unwrap().push_adapter(id, &context);
         block_on(async {

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -193,9 +193,6 @@ pub struct Adapter {
 impl Adapter {
     /// Create a new Unix adapter.
     pub fn new(
-        app_name: String,
-        toolkit_name: String,
-        toolkit_version: String,
         initial_state: impl 'static + FnOnce() -> TreeUpdate,
         is_window_focused: bool,
         action_handler: Box<dyn ActionHandler + Send + Sync>,
@@ -214,7 +211,7 @@ impl Adapter {
         let tree = Tree::new(initial_state(), is_window_focused);
         let id = NEXT_ADAPTER_ID.fetch_add(1, Ordering::SeqCst);
         let root_id = tree.state().root_id();
-        let app_context = AppContext::get_or_init(app_name, toolkit_name, toolkit_version);
+        let app_context = AppContext::get_or_init("".into(), "".into(), "".into());
         let context = Context::new(tree, action_handler, &app_context);
         let adapter_index = app_context.write().unwrap().push_adapter(id, &context);
         block_on(async {

--- a/platforms/unix/src/atspi/interfaces/application.rs
+++ b/platforms/unix/src/atspi/interfaces/application.rs
@@ -17,7 +17,6 @@ impl ApplicationInterface {
 
     #[dbus_interface(property)]
     fn version(&self) -> String {
-
         self.0.toolkit_version()
     }
 

--- a/platforms/unix/src/atspi/interfaces/application.rs
+++ b/platforms/unix/src/atspi/interfaces/application.rs
@@ -17,6 +17,7 @@ impl ApplicationInterface {
 
     #[dbus_interface(property)]
     fn version(&self) -> String {
+
         self.0.toolkit_version()
     }
 

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -106,7 +106,7 @@ impl InnerWindowState {
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some(WINDOW_TITLE.to_string());
+        tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
         tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
         tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
 

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -105,13 +105,18 @@ impl InnerWindowState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
+        let mut tree = Tree::new(WINDOW_ID);
+        tree.app_name = Some(WINDOW_TITLE.to_string());
+        tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
+        tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
+
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),
                 (BUTTON_1_ID, button_1),
                 (BUTTON_2_ID, button_2),
             ],
-            tree: Some(Tree::new(WINDOW_ID)),
+            tree: Some(tree),
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -107,8 +107,6 @@ impl InnerWindowState {
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
         tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
-        tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
-        tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
 
         let mut result = TreeUpdate {
             nodes: vec![

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -628,7 +628,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
                 match property_id {
                     UIA_FrameworkIdPropertyId => result = state.toolkit_name().into(),
                     UIA_ProviderDescriptionPropertyId => {
-                        result = state.app_and_toolkit_description().into()
+                        result = app_and_toolkit_description(state).into()
                     }
                     _ => (),
                 }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -524,6 +524,19 @@ impl PlatformNode {
         })
     }
 
+    fn resolve_with_tree_state_and_context<F, T>(&self, f: F) -> Result<T>
+    where
+        for<'a> F: FnOnce(Node<'a>, &TreeState, &Context) -> Result<T>,
+    {
+        self.with_tree_state_and_context(|state, context| {
+            if let Some(node) = state.node_by_id(self.node_id) {
+                f(node, state, context)
+            } else {
+                Err(element_not_available())
+            }
+        })
+    }
+
     fn resolve<F, T>(&self, f: F) -> Result<T>
     where
         for<'a> F: FnOnce(Node<'a>) -> Result<T>,
@@ -597,16 +610,25 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
     }
 
     fn GetPropertyValue(&self, property_id: UIA_PROPERTY_ID) -> Result<VARIANT> {
-        self.resolve_with_context(|node, context| {
+        self.resolve_with_tree_state_and_context(|node, state, context| {
             let wrapper = NodeWrapper::Node(&node);
             let mut result = wrapper.get_property_value(property_id);
-            if result.is_empty() && node.is_root() {
-                match property_id {
-                    UIA_NamePropertyId => {
-                        result = window_title(context.hwnd).into();
+            if result.is_empty() {
+                if node.is_root() {
+                    match property_id {
+                        UIA_NamePropertyId => {
+                            result = window_title(context.hwnd).into();
+                        }
+                        UIA_NativeWindowHandlePropertyId => {
+                            result = (context.hwnd.0 as i32).into();
+                        }
+                        _ => (),
                     }
-                    UIA_NativeWindowHandlePropertyId => {
-                        result = (context.hwnd.0 as i32).into();
+                }
+                match property_id {
+                    UIA_FrameworkIdPropertyId => result = state.toolkit_name().into(),
+                    UIA_ProviderDescriptionPropertyId => {
+                        result = state.app_and_toolkit_description().into()
                     }
                     _ => (),
                 }

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -85,9 +85,8 @@ impl State {
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
         tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
-        tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
-        tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
-
+        tree.toolkit_name = Some(String::from("winit"));
+        tree.toolkit_version = Some(String::from("0.28"));
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -84,7 +84,7 @@ impl State {
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some(WINDOW_TITLE.to_string());
+        tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
         tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
         tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
 

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -83,13 +83,18 @@ impl State {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
+        let mut tree = Tree::new(WINDOW_ID);
+        tree.app_name = Some(WINDOW_TITLE.to_string());
+        tree.toolkit_name = Some(env!("CARGO_PKG_NAME").to_string());
+        tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").to_string());
+
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),
                 (BUTTON_1_ID, button_1),
                 (BUTTON_2_ID, button_2),
             ],
-            tree: Some(Tree::new(WINDOW_ID)),
+            tree: Some(tree),
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -85,8 +85,6 @@ impl State {
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
         tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
-        tree.toolkit_name = Some(String::from("winit"));
-        tree.toolkit_version = Some(String::from("0.28"));
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -18,14 +18,7 @@ impl Adapter {
         source: impl 'static + FnOnce() -> TreeUpdate,
         action_handler: ActionHandlerBox,
     ) -> Self {
-        let adapter = UnixAdapter::new(
-            String::new(),
-            String::new(),
-            String::new(),
-            source,
-            false,
-            action_handler,
-        );
+        let adapter = UnixAdapter::new(source, false, action_handler);
         Self { adapter }
     }
 


### PR DESCRIPTION
Similar to the unix crate, this adds `app_name`, `toolkit_name` and `toolkit_version` parameters to the adapter constructors.
- FrameworkIdProperty: exposes `toolkit_name`
- ProviderDescriptionProperty: exposes `app_name (toolkit_name toolkit_version)`

fixes #280