### PR TITLE
refactor!: Make `ActionHandler::do_action` take `&mut self`

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -1000,7 +1000,6 @@ pub type ActionHandlerCallback =
 struct FfiActionHandlerUserdata(*mut c_void);
 
 unsafe impl Send for FfiActionHandlerUserdata {}
-unsafe impl Sync for FfiActionHandlerUserdata {}
 
 pub(crate) struct FfiActionHandler {
     callback: ActionHandlerCallback,
@@ -1035,7 +1034,7 @@ impl action_handler {
 }
 
 impl ActionHandler for FfiActionHandler {
-    fn do_action(&self, request: ActionRequest) {
+    fn do_action(&mut self, request: ActionRequest) {
         if let Some(callback) = self.callback {
             let request = request.into();
             callback(&request, self.userdata.0);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2348,5 +2348,5 @@ pub trait ActionHandler {
     /// This method may queue the request and handle it asynchronously.
     /// This behavior is preferred over blocking, e.g. when dispatching
     /// the request to another thread.
-    fn do_action(&self, request: ActionRequest);
+    fn do_action(&mut self, request: ActionRequest);
 }

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, NodeId};
+use accesskit::{ActionHandler, ActionRequest, NodeId};
 use accesskit_consumer::Tree;
 use objc2::{
     foundation::MainThreadMarker,
@@ -16,7 +16,7 @@ use crate::{appkit::*, node::PlatformNode};
 pub(crate) struct Context {
     pub(crate) view: WeakId<NSView>,
     pub(crate) tree: RefCell<Tree>,
-    pub(crate) action_handler: Box<dyn ActionHandler>,
+    pub(crate) action_handler: RefCell<Box<dyn ActionHandler>>,
     platform_nodes: RefCell<HashMap<NodeId, Id<PlatformNode, Shared>>>,
     _mtm: MainThreadMarker,
 }
@@ -31,7 +31,7 @@ impl Context {
         Rc::new(Self {
             view,
             tree: RefCell::new(tree),
-            action_handler,
+            action_handler: RefCell::new(action_handler),
             platform_nodes: RefCell::new(HashMap::new()),
             _mtm: mtm,
         })
@@ -54,6 +54,10 @@ impl Context {
     pub(crate) fn remove_platform_node(&self, id: NodeId) -> Option<Id<PlatformNode, Shared>> {
         let mut platform_nodes = self.platform_nodes.borrow_mut();
         platform_nodes.remove(&id)
+    }
+
+    pub(crate) fn do_action(&self, request: ActionRequest) {
+        self.action_handler.borrow_mut().do_action(request);
     }
 }
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -475,7 +475,7 @@ declare_class!(
             self.resolve_with_context(|node, context| {
                 if focused {
                     if node.is_focusable() {
-                        context.action_handler.do_action(ActionRequest {
+                        context.do_action(ActionRequest {
                             action: Action::Focus,
                             target: node.id(),
                             data: None,
@@ -484,7 +484,7 @@ declare_class!(
                 } else {
                     let root = node.tree_state.root();
                     if root.is_focusable() {
-                        context.action_handler.do_action(ActionRequest {
+                        context.do_action(ActionRequest {
                             action: Action::Focus,
                             target: root.id(),
                             data: None,
@@ -499,7 +499,7 @@ declare_class!(
             self.resolve_with_context(|node, context| {
                 let clickable = node.is_clickable();
                 if clickable {
-                    context.action_handler.do_action(ActionRequest {
+                    context.do_action(ActionRequest {
                         action: Action::Default,
                         target: node.id(),
                         data: None,
@@ -515,7 +515,7 @@ declare_class!(
             self.resolve_with_context(|node, context| {
                 let supports_increment = node.supports_increment();
                 if supports_increment {
-                    context.action_handler.do_action(ActionRequest {
+                    context.do_action(ActionRequest {
                         action: Action::Increment,
                         target: node.id(),
                         data: None,
@@ -531,7 +531,7 @@ declare_class!(
             self.resolve_with_context(|node, context| {
                 let supports_decrement = node.supports_decrement();
                 if supports_decrement {
-                    context.action_handler.do_action(ActionRequest {
+                    context.do_action(ActionRequest {
                         action: Action::Decrement,
                         target: node.id(),
                         data: None,
@@ -702,7 +702,7 @@ declare_class!(
             self.resolve_with_context(|node, context| {
                 if node.supports_text_ranges() {
                     if let Some(range) = from_ns_range(node, range) {
-                        context.action_handler.do_action(ActionRequest {
+                        context.do_action(ActionRequest {
                             action: Action::SetTextSelection,
                             target: node.id(),
                             data: Some(ActionData::SetTextSelection(range.to_text_selection())),

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -198,7 +198,7 @@ impl Adapter {
         toolkit_version: String,
         initial_state: impl 'static + FnOnce() -> TreeUpdate,
         is_window_focused: bool,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Option<Self> {
         let mut atspi_bus = block_on(async { Bus::a11y_bus().await })?;
         let (event_sender, event_receiver) = async_channel::unbounded();

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -3,16 +3,16 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::ActionHandler;
+use accesskit::{ActionHandler, ActionRequest};
 use accesskit_consumer::Tree;
 use once_cell::sync::OnceCell;
-use std::sync::{Arc, RwLock, RwLockReadGuard, Weak};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
 
 use crate::{atspi::OwnedObjectAddress, util::WindowBounds};
 
 pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
-    pub(crate) action_handler: Box<dyn ActionHandler + Send + Sync>,
+    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
     pub(crate) app_context: Arc<RwLock<AppContext>>,
     pub(crate) root_window_bounds: RwLock<WindowBounds>,
 }
@@ -20,12 +20,12 @@ pub(crate) struct Context {
 impl Context {
     pub(crate) fn new(
         tree: Tree,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
         app_context: &Arc<RwLock<AppContext>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             tree: RwLock::new(tree),
-            action_handler,
+            action_handler: Mutex::new(action_handler),
             app_context: app_context.clone(),
             root_window_bounds: RwLock::new(Default::default()),
         })
@@ -41,6 +41,10 @@ impl Context {
 
     pub(crate) fn read_root_window_bounds(&self) -> RwLockReadGuard<'_, WindowBounds> {
         self.root_window_bounds.read().unwrap()
+    }
+
+    pub fn do_action(&self, request: ActionRequest) {
+        self.action_handler.lock().unwrap().do_action(request);
     }
 }
 

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -700,7 +700,7 @@ impl PlatformNode {
         if tree.state().has_node(self.node_id) {
             let request = f(tree.state(), &context);
             drop(tree);
-            context.action_handler.do_action(request);
+            context.do_action(request);
             Ok(())
         } else {
             Err(unknown_object(&self.accessible_id()))

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -206,7 +206,7 @@ struct SimpleActionHandler {
 }
 
 impl ActionHandler for SimpleActionHandler {
-    fn do_action(&self, request: ActionRequest) {
+    fn do_action(&mut self, request: ActionRequest) {
         match request.action {
             Action::Focus => {
                 unsafe {

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -151,7 +151,7 @@ impl Adapter {
         hwnd: HWND,
         initial_state: TreeUpdate,
         is_window_focused: bool,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
         _uia_init_marker: UiaInitMarker,
     ) -> Self {
         let context = Context::new(

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -3,9 +3,9 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{ActionHandler, Point};
+use accesskit::{ActionHandler, ActionRequest, Point};
 use accesskit_consumer::Tree;
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
 use windows::Win32::Foundation::*;
 
 use crate::util::*;
@@ -13,19 +13,19 @@ use crate::util::*;
 pub(crate) struct Context {
     pub(crate) hwnd: HWND,
     pub(crate) tree: RwLock<Tree>,
-    pub(crate) action_handler: Box<dyn ActionHandler + Send + Sync>,
+    pub(crate) action_handler: Mutex<Box<dyn ActionHandler + Send>>,
 }
 
 impl Context {
     pub(crate) fn new(
         hwnd: HWND,
         tree: Tree,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Arc<Self> {
         Arc::new(Self {
             hwnd,
             tree: RwLock::new(tree),
-            action_handler,
+            action_handler: Mutex::new(action_handler),
         })
     }
 
@@ -35,5 +35,9 @@ impl Context {
 
     pub(crate) fn client_top_left(&self) -> Point {
         client_top_left(self.hwnd)
+    }
+
+    pub(crate) fn do_action(&self, request: ActionRequest) {
+        self.action_handler.lock().unwrap().do_action(request);
     }
 }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -563,7 +563,7 @@ impl PlatformNode {
         if tree.state().has_node(self.node_id) {
             drop(tree);
             let request = f();
-            context.action_handler.do_action(request);
+            context.do_action(request);
             Ok(())
         } else {
             Err(element_not_available())

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -62,7 +62,7 @@ impl SubclassImpl {
     fn new(
         hwnd: HWND,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Box<Self> {
         let is_window_focused = Rc::new(Cell::new(false));
         let uia_init_marker = UiaInitMarker::new();
@@ -150,7 +150,7 @@ impl SubclassingAdapter {
     pub fn new(
         hwnd: HWND,
         source: impl 'static + FnOnce() -> TreeUpdate,
-        action_handler: Box<dyn ActionHandler + Send + Sync>,
+        action_handler: Box<dyn ActionHandler + Send>,
     ) -> Self {
         let mut r#impl = SubclassImpl::new(hwnd, source, action_handler);
         r#impl.install();

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -47,7 +47,7 @@ fn get_initial_state() -> TreeUpdate {
 pub struct NullActionHandler;
 
 impl ActionHandler for NullActionHandler {
-    fn do_action(&self, _request: ActionRequest) {}
+    fn do_action(&mut self, _request: ActionRequest) {}
 }
 
 fn scope<F>(f: F) -> Result<()>

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -53,7 +53,7 @@ fn get_initial_state() -> TreeUpdate {
 pub struct NullActionHandler;
 
 impl ActionHandler for NullActionHandler {
-    fn do_action(&self, _request: ActionRequest) {}
+    fn do_action(&mut self, _request: ActionRequest) {}
 }
 
 // This module uses winit for the purpose of testing with a real third-party

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -295,7 +295,7 @@ impl PlatformRange {
         let range = self.upgrade_for_read(tree.state())?;
         let request = f(range);
         drop(tree);
-        context.action_handler.do_action(request);
+        context.do_action(request);
         Ok(())
     }
 

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -6,7 +6,7 @@ use accesskit::{ActionHandler, Rect, TreeUpdate};
 use accesskit_unix::Adapter as UnixAdapter;
 use winit::{event::WindowEvent, window::Window};
 
-pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
+pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
 
 pub struct Adapter {
     adapter: Option<UnixAdapter>,

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -6,7 +6,7 @@ use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
 use winit::{event::WindowEvent, platform::windows::WindowExtWindows, window::Window};
 
-pub type ActionHandlerBox = Box<dyn ActionHandler + Send + Sync>;
+pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
 
 pub struct Adapter {
     adapter: SubclassingAdapter,


### PR DESCRIPTION
I believe this isn't controversial like my previous, abandoned PR or the other API change I'm currently considering. I'm pretty sure it's conceptually correct, because an action handler needs to mutate the application's state, and it's better to have the platform adapters handle interior mutability in the way that's appropriate for each platform's threading requirements than to make the user do it. This simplifies the winit adapter and makes the C API a bit safer.