### PR TITLE
clippy: Fix reserve_after_initialization warning.

### DIFF
--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -458,8 +458,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
                 return Ok(std::ptr::null_mut());
             }
             let client_top_left = context.client_top_left();
-            let mut result = Vec::<f64>::new();
-            result.reserve(rects.len() * 4);
+            let mut result = Vec::<f64>::with_capacity(rects.len() * 4);
             for rect in rects {
                 result.push(rect.x0 + client_top_left.x);
                 result.push(rect.y0 + client_top_left.y);


### PR DESCRIPTION
When calling `Vec::new()` and then immediately calling `Vec::reserve()` on the resulting vector, it is more concise and less complex to just use `Vec::with_capacity()` instead.

This is a new clippy lint coming in 1.73.