### PR TITLE
chore: Update Unix adapter dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -210,7 +219,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
  "windows-sys 0.42.0",
 ]
@@ -231,6 +240,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
 
 [[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 0.37.7",
+ "signal-hook",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +265,7 @@ checksum = "3b015a331cc64ebd1774ba119538573603427eaace0a1950c423ab971f903796"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -255,7 +282,7 @@ checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -266,29 +293,50 @@ checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "atspi"
-version = "0.10.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674e7a3376837b2e7d12d34d58ac47073c491dc3bf6f71a7adaf687d4d817faa"
+checksum = "6059f350ab6f593ea00727b334265c4dfc7fd442ee32d264794bd9bdc68e87ca"
 dependencies = [
- "async-recursion",
- "async-trait",
- "atspi-macros",
- "enumflags2",
- "futures-lite",
- "serde",
- "tracing",
- "zbus",
- "zbus_names",
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
 ]
 
 [[package]]
-name = "atspi-macros"
-version = "0.2.0"
+name = "atspi-common"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb4870a32c0eaa17e35bca0e6b16020635157121fb7d45593d242c295bc768"
+checksum = "92af95f966d2431f962bc632c2e68eda7777330158bf640c4af4249349b2cdf5"
 dependencies = [
- "quote",
- "syn",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c65e7d70f86d4c0e3b2d585d9bf3f979f0b19d635a336725a88d279f76b939"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6495661273703e7a229356dcbe8c8f38223d697aacfaf0e13590a9ac9977bb52"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
 ]
 
 [[package]]
@@ -296,6 +344,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide 0.7.1",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bitflags"
@@ -498,7 +561,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -509,26 +572,6 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -560,9 +603,9 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.5"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75d4cd21b95383444831539909fbb14b9dc3fdceb2a6f5d36577329a1f55ccb"
+checksum = "5998b4f30320c9d93aed72f63af821bfdac50465b75428fce77b48ec482c3939"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -570,13 +613,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58dc3c5e468259f19f2d46304a6b28f1c3d034442e14b322d2b850e36f6d5ae"
+checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -587,7 +630,7 @@ checksum = "1940ea32e14d489b401074558be4567f35ca9507c4628b4b3fd6fe6eb2ca7b88"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -599,6 +642,17 @@ dependencies = [
  "errno-dragonfly",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -633,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -665,9 +719,9 @@ checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -726,6 +780,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "hashbrown"
@@ -822,9 +882,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -841,6 +901,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -914,6 +980,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -994,7 +1069,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
- "pin-utils",
  "static_assertions",
 ]
 
@@ -1026,7 +1100,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1053,6 +1127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
 dependencies = [
  "objc-sys",
+]
+
+[[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1135,9 +1218,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1160,7 +1243,7 @@ dependencies = [
  "bitflags",
  "crc32fast",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -1250,7 +1333,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1261,7 +1344,7 @@ checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1328,17 +1411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,16 +1428,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.3",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.45.0",
 ]
 
@@ -1396,7 +1488,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1441,7 +1533,7 @@ checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1452,7 +1544,7 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1474,7 +1566,7 @@ checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1486,6 +1578,25 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1542,6 +1653,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +1711,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.2.16",
- "rustix",
+ "rustix 0.36.9",
  "windows-sys 0.42.0",
 ]
 
@@ -1600,7 +1732,7 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1630,18 +1762,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.5.4",
  "tracing",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1681,7 +1814,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1772,7 +1905,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1794,7 +1927,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1929,7 +2062,7 @@ checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1940,7 +2073,7 @@ checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1965,6 +2098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2146,6 +2288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+dependencies = [
+ "nix 0.26.2",
+ "winapi",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,28 +2305,28 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zbus"
-version = "3.11.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20aae5dd5b051971cd2f49f9f3b860e57b2b495ba5ba254eaec42d34ede57e97"
+checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
 dependencies = [
  "async-broadcast",
  "async-executor",
  "async-fs",
  "async-io",
  "async-lock",
+ "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
+ "blocking",
  "byteorder",
  "derivative",
- "dirs",
  "enumflags2",
  "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
- "lazy_static",
  "nix 0.26.2",
  "once_cell",
  "ordered-stream",
@@ -2187,6 +2339,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "winapi",
+ "xdg-home",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -2194,23 +2347,23 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.11.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9264b3a1bcf5503d4e0348b6e7efe1da58d4f92a913c15ed9e63b52de85faaa1"
+checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.109",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34f314916bd89bdb9934154627fab152f4f28acdda03e7c4c68181b214fe7e3"
+checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
 dependencies = [
  "serde",
  "static_assertions",
@@ -2219,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.12.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe4914a985446d6fd287019b5fceccce38303d71407d9e6e711d44954a05d8"
+checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
 dependencies = [
  "byteorder",
  "enumflags2",
@@ -2233,24 +2386,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.12.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c20260af4b28b3275d6676c7e2a6be0d4332e8e0aba4616d34007fd84e462a"
+checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b22993dbc4d128a17a3b6c92f1c63872dd67198537ee728d8b5d7c40640a8b"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -12,18 +12,17 @@ edition = "2021"
 
 [features]
 default = ["async-io"]
-async-io = ["zbus/async-io"]
-tokio = ["dep:tokio", "zbus/tokio"]
+async-io = ["atspi/async-std", "zbus/async-io"]
+tokio = ["dep:tokio", "atspi/tokio", "zbus/tokio"]
 
 [dependencies]
 accesskit = { version = "0.11.2", path = "../../common" }
 accesskit_consumer = { version = "0.15.2", path = "../../consumer" }
-async-channel = "1.8.0"
+async-channel = "1.9"
 async-once-cell = "0.5.3"
-atspi = { version = "0.10.1", default-features = false }
-futures-lite = "1.12.0"
+atspi = { version = "0.19", default-features = false }
+futures-lite = "1.13"
 once_cell = "1.17.1"
 serde = "1.0"
-tokio = { version = "1.10.0", optional = true, features = ["rt", "net", "time"] }
-zbus = { version = "3.6", default-features = false }
-
+tokio = { version = "1.32.0", optional = true, features = ["rt", "net", "time"] }
+zbus = { version = "3.14", default-features = false }

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -9,7 +9,10 @@ use crate::{
     PlatformRootNode,
 };
 use async_once_cell::OnceCell;
-use atspi::{bus::BusProxy, socket::SocketProxy, EventBody};
+use atspi::{
+    events::EventBody,
+    proxy::{bus::BusProxy, socket::SocketProxy},
+};
 use serde::Serialize;
 use std::{
     collections::HashMap,

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -24,26 +24,25 @@ impl<T> AccessibleInterface<T> {
 #[dbus_interface(name = "org.a11y.atspi.Accessible")]
 impl AccessibleInterface<PlatformNode> {
     #[dbus_interface(property)]
-    fn name(&self) -> String {
-        self.node.name().unwrap_or_default()
+    fn name(&self) -> fdo::Result<String> {
+        self.node.name()
     }
 
     #[dbus_interface(property)]
-    fn description(&self) -> String {
-        self.node.description().unwrap_or_default()
+    fn description(&self) -> fdo::Result<String> {
+        self.node.description()
     }
 
     #[dbus_interface(property)]
-    fn parent(&self) -> OwnedObjectAddress {
-        match self.node.parent() {
-            Ok(parent) => parent.to_address(self.bus_name.clone()),
-            _ => OwnedObjectAddress::null(self.bus_name.clone()),
-        }
+    fn parent(&self) -> fdo::Result<OwnedObjectAddress> {
+        self.node
+            .parent()
+            .map(|parent| parent.to_address(self.bus_name.clone()))
     }
 
     #[dbus_interface(property)]
-    fn child_count(&self) -> i32 {
-        self.node.child_count().unwrap_or(0)
+    fn child_count(&self) -> fdo::Result<i32> {
+        self.node.child_count()
     }
 
     #[dbus_interface(property)]
@@ -103,7 +102,7 @@ impl AccessibleInterface<PlatformNode> {
 #[dbus_interface(name = "org.a11y.atspi.Accessible")]
 impl AccessibleInterface<PlatformRootNode> {
     #[dbus_interface(property)]
-    fn name(&self) -> String {
+    fn name(&self) -> fdo::Result<String> {
         self.node.name()
     }
 
@@ -113,14 +112,15 @@ impl AccessibleInterface<PlatformRootNode> {
     }
 
     #[dbus_interface(property)]
-    fn parent(&self) -> OwnedObjectAddress {
-        self.node
-            .parent()
-            .unwrap_or_else(|| OwnedObjectAddress::null(self.bus_name.clone()))
+    fn parent(&self) -> fdo::Result<OwnedObjectAddress> {
+        Ok(self
+            .node
+            .parent()?
+            .unwrap_or_else(|| OwnedObjectAddress::null(self.bus_name.clone())))
     }
 
     #[dbus_interface(property)]
-    fn child_count(&self) -> i32 {
+    fn child_count(&self) -> fdo::Result<i32> {
         self.node.child_count()
     }
 

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -7,7 +7,7 @@ use crate::{
     atspi::{ObjectId, OwnedObjectAddress},
     PlatformNode, PlatformRootNode,
 };
-use atspi::{accessible::Role, Interface, InterfaceSet, StateSet};
+use atspi::{Interface, InterfaceSet, Role, StateSet};
 use zbus::{fdo, names::OwnedUniqueName, MessageHeader};
 
 pub(crate) struct AccessibleInterface<T> {

--- a/platforms/unix/src/atspi/interfaces/action.rs
+++ b/platforms/unix/src/atspi/interfaces/action.rs
@@ -25,8 +25,8 @@ impl ActionInterface {
 #[dbus_interface(name = "org.a11y.atspi.Action")]
 impl ActionInterface {
     #[dbus_interface(property)]
-    fn n_actions(&self) -> i32 {
-        self.0.n_actions().unwrap_or(0)
+    fn n_actions(&self) -> fdo::Result<i32> {
+        self.0.n_actions()
     }
 
     fn get_description(&self, _index: i32) -> &str {

--- a/platforms/unix/src/atspi/interfaces/application.rs
+++ b/platforms/unix/src/atspi/interfaces/application.rs
@@ -11,12 +11,12 @@ pub(crate) struct ApplicationInterface(pub PlatformRootNode);
 #[dbus_interface(name = "org.a11y.atspi.Application")]
 impl ApplicationInterface {
     #[dbus_interface(property)]
-    fn toolkit_name(&self) -> String {
+    fn toolkit_name(&self) -> fdo::Result<String> {
         self.0.toolkit_name()
     }
 
     #[dbus_interface(property)]
-    fn version(&self) -> String {
+    fn version(&self) -> fdo::Result<String> {
         self.0.toolkit_version()
     }
 
@@ -26,7 +26,7 @@ impl ApplicationInterface {
     }
 
     #[dbus_interface(property)]
-    fn id(&self) -> i32 {
+    fn id(&self) -> fdo::Result<i32> {
         self.0.id()
     }
 

--- a/platforms/unix/src/atspi/interfaces/component.rs
+++ b/platforms/unix/src/atspi/interfaces/component.rs
@@ -7,7 +7,7 @@ use crate::{
     atspi::{OwnedObjectAddress, Rect},
     PlatformNode,
 };
-use atspi::{component::Layer, CoordType};
+use atspi::{CoordType, Layer};
 use zbus::{fdo, MessageHeader};
 
 pub(crate) struct ComponentInterface {

--- a/platforms/unix/src/atspi/interfaces/events.rs
+++ b/platforms/unix/src/atspi/interfaces/events.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use crate::atspi::{ObjectId, Rect};
-use atspi::{accessible::Role, State};
+use atspi::{Role, State};
 
 pub(crate) enum Event {
     Object {

--- a/platforms/unix/src/atspi/interfaces/value.rs
+++ b/platforms/unix/src/atspi/interfaces/value.rs
@@ -4,6 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use crate::PlatformNode;
+use zbus::fdo;
 
 pub(crate) struct ValueInterface {
     node: PlatformNode,
@@ -18,27 +19,27 @@ impl ValueInterface {
 #[dbus_interface(name = "org.a11y.atspi.Value")]
 impl ValueInterface {
     #[dbus_interface(property)]
-    fn minimum_value(&self) -> f64 {
-        self.node.minimum_value().unwrap()
+    fn minimum_value(&self) -> fdo::Result<f64> {
+        self.node.minimum_value()
     }
 
     #[dbus_interface(property)]
-    fn maximum_value(&self) -> f64 {
-        self.node.maximum_value().unwrap()
+    fn maximum_value(&self) -> fdo::Result<f64> {
+        self.node.maximum_value()
     }
 
     #[dbus_interface(property)]
-    fn minimum_increment(&self) -> f64 {
-        self.node.minimum_increment().unwrap()
+    fn minimum_increment(&self) -> fdo::Result<f64> {
+        self.node.minimum_increment()
     }
 
     #[dbus_interface(property)]
-    fn current_value(&self) -> f64 {
-        self.node.current_value().unwrap()
+    fn current_value(&self) -> fdo::Result<f64> {
+        self.node.current_value()
     }
 
     #[dbus_interface(property)]
-    fn set_current_value(&self, value: f64) {
-        self.node.set_current_value(value).unwrap();
+    fn set_current_value(&mut self, value: f64) -> fdo::Result<()> {
+        self.node.set_current_value(value)
     }
 }

--- a/platforms/unix/src/atspi/object_address.rs
+++ b/platforms/unix/src/atspi/object_address.rs
@@ -3,6 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
+use atspi::Accessible;
 use serde::{Deserialize, Serialize};
 use zbus::{
     names::{OwnedUniqueName, UniqueName},
@@ -30,11 +31,11 @@ impl OwnedObjectAddress {
     }
 }
 
-impl From<(String, OwnedObjectPath)> for OwnedObjectAddress {
-    fn from(value: (String, OwnedObjectPath)) -> Self {
+impl From<Accessible> for OwnedObjectAddress {
+    fn from(object: Accessible) -> Self {
         Self {
-            bus_name: OwnedUniqueName::from(UniqueName::from_string_unchecked(value.0)),
-            path: value.1,
+            bus_name: OwnedUniqueName::from(UniqueName::from_string_unchecked(object.name)),
+            path: object.path,
         }
     }
 }

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -994,20 +994,19 @@ impl PlatformRootNode {
         Err(unknown_object(&self.accessible_id()))
     }
 
-    pub(crate) fn name(&self) -> String {
+    pub(crate) fn name(&self) -> fdo::Result<String> {
         self.resolve_app_context(|context| Ok(context.name.clone()))
-            .unwrap_or_default()
     }
 
-    pub(crate) fn parent(&self) -> Option<OwnedObjectAddress> {
+    pub(crate) fn parent(&self) -> fdo::Result<Option<OwnedObjectAddress>> {
         self.resolve_app_context(|context| Ok(context.desktop_address.clone()))
-            .ok()
-            .flatten()
     }
 
-    pub(crate) fn child_count(&self) -> i32 {
-        self.resolve_app_context(|context| Ok(i32::try_from(context.adapters.len()).unwrap_or(-1)))
-            .unwrap_or(-1)
+    pub(crate) fn child_count(&self) -> fdo::Result<i32> {
+        self.resolve_app_context(|context| {
+            i32::try_from(context.adapters.len())
+                .map_err(|_| fdo::Error::Failed("Too many children.".into()))
+        })
     }
 
     pub(crate) fn accessible_id(&self) -> ObjectId {
@@ -1043,19 +1042,16 @@ impl PlatformRootNode {
         })
     }
 
-    pub(crate) fn toolkit_name(&self) -> String {
+    pub(crate) fn toolkit_name(&self) -> fdo::Result<String> {
         self.resolve_app_context(|context| Ok(context.toolkit_name.clone()))
-            .unwrap_or_default()
     }
 
-    pub(crate) fn toolkit_version(&self) -> String {
+    pub(crate) fn toolkit_version(&self) -> fdo::Result<String> {
         self.resolve_app_context(|context| Ok(context.toolkit_version.clone()))
-            .unwrap_or_default()
     }
 
-    pub(crate) fn id(&self) -> i32 {
+    pub(crate) fn id(&self) -> fdo::Result<i32> {
         self.resolve_app_context(|context| Ok(context.id.unwrap_or(-1)))
-            .unwrap_or(-1)
     }
 
     pub(crate) fn set_id(&mut self, id: i32) -> fdo::Result<()> {

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -23,10 +23,7 @@ use accesskit::{
 };
 use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
 use async_channel::Sender;
-use atspi::{
-    accessible::Role as AtspiRole, component::Layer, CoordType, Interface, InterfaceSet, State,
-    StateSet,
-};
+use atspi::{CoordType, Interface, InterfaceSet, Layer, Role as AtspiRole, State, StateSet};
 use std::{
     iter::FusedIterator,
     sync::{Arc, RwLock, RwLockReadGuard, Weak},


### PR DESCRIPTION
- By updating to atspi 0.19 we get the new [Live](https://docs.rs/atspi/latest/atspi/enum.Live.html) enum which will be needed to implement live regions on Unix.
- By updating zbus we get some small API improvements, notably around property methods, allowing us to remove quite a few `unwrap` calls.