### PR TITLE
chore: Fix some clippy warnings

### DIFF
--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -31,8 +31,7 @@ static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
 
     let atom = unsafe { RegisterClassW(&wc) };
     if atom == 0 {
-        let result: Result<()> = Err(Error::from_win32());
-        result.unwrap();
+        panic!("{}", Error::from_win32());
     }
     atom
 });

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -8,7 +8,7 @@ use once_cell::{sync::Lazy as SyncLazy, unsync::Lazy};
 use std::{
     cell::RefCell,
     rc::Rc,
-    sync::{Arc, Condvar, Mutex},
+    sync::{Condvar, Mutex},
     thread,
     time::Duration,
 };
@@ -267,12 +267,9 @@ pub(crate) struct ReceivedFocusEvent {
     cv: Condvar,
 }
 
-unsafe impl Send for ReceivedFocusEvent {}
-unsafe impl Sync for ReceivedFocusEvent {}
-
 impl ReceivedFocusEvent {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
+    fn new() -> Rc<Self> {
+        Rc::new(Self {
             mutex: Mutex::new(None),
             cv: Condvar::new(),
         })
@@ -304,14 +301,14 @@ impl ReceivedFocusEvent {
 
 #[implement(Windows::Win32::UI::Accessibility::IUIAutomationFocusChangedEventHandler)]
 pub(crate) struct FocusEventHandler {
-    received: Arc<ReceivedFocusEvent>,
+    received: Rc<ReceivedFocusEvent>,
 }
 
 impl FocusEventHandler {
     #[allow(clippy::new_ret_no_self)] // it does return self, but wrapped
     pub(crate) fn new() -> (
         IUIAutomationFocusChangedEventHandler,
-        Arc<ReceivedFocusEvent>,
+        Rc<ReceivedFocusEvent>,
     ) {
         let received = ReceivedFocusEvent::new();
         (

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -33,7 +33,7 @@ static WINDOW_CLASS_ATOM: SyncLazy<u16> = SyncLazy::new(|| {
     let wc = WNDCLASSW {
         hCursor: unsafe { LoadCursorW(None, IDC_ARROW) }.unwrap(),
         hInstance: unsafe { GetModuleHandleW(None) }.unwrap(),
-        lpszClassName: class_name.into(),
+        lpszClassName: class_name,
         style: CS_HREDRAW | CS_VREDRAW,
         lpfnWndProc: Some(wndproc),
         ..Default::default()
@@ -41,8 +41,7 @@ static WINDOW_CLASS_ATOM: SyncLazy<u16> = SyncLazy::new(|| {
 
     let atom = unsafe { RegisterClassW(&wc) };
     if atom == 0 {
-        let result: Result<()> = Err(Error::from_win32());
-        result.unwrap();
+        panic!("{}", Error::from_win32());
     }
     atom
 });
@@ -267,6 +266,9 @@ pub(crate) struct ReceivedFocusEvent {
     mutex: Mutex<Option<IUIAutomationElement>>,
     cv: Condvar,
 }
+
+unsafe impl Send for ReceivedFocusEvent {}
+unsafe impl Sync for ReceivedFocusEvent {}
 
 impl ReceivedFocusEvent {
     fn new() -> Arc<Self> {


### PR DESCRIPTION
I don't feel confident in how I fixed this warning, from a lint introduced in 1.72:

```
warning: usage of an `Arc` that is not `Send` or `Sync`
   --> platforms\windows\src\tests\mod.rs:273:9
    |
273 | /         Arc::new(Self {
274 | |             mutex: Mutex::new(None),
275 | |             cv: Condvar::new(),
276 | |         })
    | |__________^
    |
    = note: the trait `Send` is not implemented for `ReceivedFocusEvent`
    = note: the trait `Sync` is not implemented for `ReceivedFocusEvent`
    = note: required for `Arc<ReceivedFocusEvent>` to implement `Send` and `Sync`
    = help: consider using an `Rc` instead or wrapping the inner type with a `Mutex`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
    = note: `#[warn(clippy::arc_with_non_send_sync)]` on by default
```

I don't want to just ignore it, but I don't think we can send `IUIAutomationElement` across threads so easily.