### PR TITLE
fix!: Rename `accesskit_winit::Adapter::on_event` to `process_event`

### DIFF
--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -177,37 +177,40 @@ fn main() -> Result<(), impl std::error::Error> {
         event_loop.set_control_flow(ControlFlow::Wait);
 
         match event {
-            Event::WindowEvent { event, .. } if adapter.on_event(&window, &event) => match event {
-                WindowEvent::CloseRequested => {
-                    event_loop.exit();
-                }
-                WindowEvent::KeyboardInput {
-                    event:
-                        KeyEvent {
-                            logical_key: virtual_code,
-                            state: ElementState::Pressed,
-                            ..
-                        },
-                    ..
-                } => match virtual_code {
-                    Key::Named(winit::keyboard::NamedKey::Tab) => {
-                        let mut state = state.lock().unwrap();
-                        let new_focus = if state.focus == BUTTON_1_ID {
-                            BUTTON_2_ID
-                        } else {
-                            BUTTON_1_ID
-                        };
-                        state.set_focus(&adapter, new_focus);
+            Event::WindowEvent { event, .. } => {
+                adapter.process_event(&window, &event);
+                match event {
+                    WindowEvent::CloseRequested => {
+                        event_loop.exit();
                     }
-                    Key::Named(winit::keyboard::NamedKey::Space) => {
-                        let mut state = state.lock().unwrap();
-                        let id = state.focus;
-                        state.press_button(&adapter, id);
-                    }
+                    WindowEvent::KeyboardInput {
+                        event:
+                            KeyEvent {
+                                logical_key: virtual_code,
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    } => match virtual_code {
+                        Key::Named(winit::keyboard::NamedKey::Tab) => {
+                            let mut state = state.lock().unwrap();
+                            let new_focus = if state.focus == BUTTON_1_ID {
+                                BUTTON_2_ID
+                            } else {
+                                BUTTON_1_ID
+                            };
+                            state.set_focus(&adapter, new_focus);
+                        }
+                        Key::Named(winit::keyboard::NamedKey::Space) => {
+                            let mut state = state.lock().unwrap();
+                            let id = state.focus;
+                            state.press_button(&adapter, id);
+                        }
+                        _ => (),
+                    },
                     _ => (),
-                },
-                _ => (),
-            },
+                }
+            }
             Event::UserEvent(ActionRequestEvent {
                 request:
                     ActionRequest {

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -74,9 +74,12 @@ impl Adapter {
         Self { adapter }
     }
 
-    #[must_use]
-    pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {
-        self.adapter.on_event(window, event)
+    /// Allows reacting to window events.
+    ///
+    /// This must be called whenever a new window event is received
+    /// and before it is handled by the application.
+    pub fn process_event(&self, window: &Window, event: &WindowEvent) {
+        self.adapter.process_event(window, event);
     }
 
     pub fn update(&self, update: TreeUpdate) {

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -39,13 +39,11 @@ impl Adapter {
         }
     }
 
-    pub fn on_event(&self, _window: &Window, event: &WindowEvent) -> bool {
+    pub fn process_event(&self, _window: &Window, event: &WindowEvent) {
         if let WindowEvent::Focused(is_focused) = event {
             if let Some(events) = self.adapter.update_view_focus_state(*is_focused) {
                 events.raise();
             }
         }
-
-        true
     }
 }

--- a/platforms/winit/src/platform_impl/null.rs
+++ b/platforms/winit/src/platform_impl/null.rs
@@ -22,7 +22,5 @@ impl Adapter {
 
     pub fn update_if_active(&self, _updater: impl FnOnce() -> TreeUpdate) {}
 
-    pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
-        true
-    }
+    pub fn process_event(&self, _window: &Window, _event: &WindowEvent) {}
 }

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -46,7 +46,7 @@ impl Adapter {
         }
     }
 
-    pub fn on_event(&self, window: &Window, event: &WindowEvent) -> bool {
+    pub fn process_event(&self, window: &Window, event: &WindowEvent) {
         match event {
             WindowEvent::Moved(outer_position) => {
                 let outer_position: (_, _) = outer_position.cast::<f64>().into();
@@ -85,7 +85,5 @@ impl Adapter {
             }
             _ => (),
         }
-
-        true
     }
 }

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -38,7 +38,5 @@ impl Adapter {
         }
     }
 
-    pub fn on_event(&self, _window: &Window, _event: &WindowEvent) -> bool {
-        true
-    }
+    pub fn process_event(&self, _window: &Window, _event: &WindowEvent) {}
 }


### PR DESCRIPTION
Closes #300 

The name `on_event` suggests that this function won't have side effects, which is not the case.

We received strong push-back from developers who don't want AccessKit to filter events. We previously agreed on keeping the mechanism around even though we didn't use it for keyboard events on Unix. Even though we might need it in the future for other features, this is not currently the case, therefore it is hard to convince people to use it. I propose to remove it for now.