### PR TITLE
fix: Make the Windows subclassing test more robust

### DIFF
--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -185,7 +185,7 @@ impl Scope {
 }
 
 // It's not safe to run these UI-related tests concurrently.
-static MUTEX: Mutex<()> = Mutex::new(());
+pub(crate) static MUTEX: Mutex<()> = Mutex::new(());
 
 pub(crate) fn scope<F>(
     window_title: &str,

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -14,8 +14,8 @@ use winit::{
     window::WindowBuilder,
 };
 
-use crate::SubclassingAdapter;
 use super::MUTEX;
+use crate::SubclassingAdapter;
 
 const WINDOW_TITLE: &str = "Simple test";
 

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -66,14 +66,10 @@ fn has_native_uia() {
     let event_loop = EventLoopBuilder::<()>::new().with_any_thread(true).build();
     let window = WindowBuilder::new()
         .with_title(WINDOW_TITLE)
+        .with_visible(false)
         .build(&event_loop)
         .unwrap();
     let hwnd = HWND(window.hwnd());
-    assert!(!unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
-    let adapter = SubclassingAdapter::new(hwnd, get_initial_state, Box::new(NullActionHandler {}));
-    assert!(unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
-    drop(adapter);
-    assert!(!unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
     let adapter = SubclassingAdapter::new(hwnd, get_initial_state, Box::new(NullActionHandler {}));
     assert!(unsafe { UiaHasServerSideProvider(hwnd) }.as_bool());
     drop(window);

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -15,6 +15,7 @@ use winit::{
 };
 
 use crate::SubclassingAdapter;
+use super::MUTEX;
 
 const WINDOW_TITLE: &str = "Simple test";
 
@@ -63,6 +64,9 @@ impl ActionHandler for NullActionHandler {
 fn has_native_uia() {
     // This test is simple enough that we know it's fine to run entirely
     // on one thread, so we don't need a full multithreaded test harness.
+    // Still, we must prevent this test from running concurrently with other
+    // tests, especially the focus test.
+    let _lock_guard = MUTEX.lock().unwrap();
     let event_loop = EventLoopBuilder::<()>::new().with_any_thread(true).build();
     let window = WindowBuilder::new()
         .with_title(WINDOW_TITLE)


### PR DESCRIPTION
I see from a [recent failed CI job](https://github.com/AccessKit/accesskit/actions/runs/6755825086/job/18364643052) that the subclassing test can also intermittently fail. I noticed that my own test broke the cardinal rule of using the subclassing adapter: the window must be created invisible. So I fixed that, but I also made a couple of changes:

* The test no longer repeatedly calls `UiaHasServerSideProvider`, and it doesn't drop and re-create the adapter, because these things aren't testing realistic scenarios. In real use, the window is created invisible, the adapter is created once afterward, and nobody would call `UiaHasServerSideProvider` (or equivalent) on the window until after the adapter is created. I've seen that sometimes `UiaHasServerSIdeProvider` appears to cache the result of an earlier call, so it's safer to only call it the one time.
* We actually never show the window, because that's not strictly necessary for this test, and it might actually be what's causing the focus test to intermittently fail in CI, since the focus test can run concurrently with this one. Let's see if this fixes that intermittent failure.