### PR TITLE
fix: Use raw-window-handle 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,6 @@ dependencies = [
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
- "raw-window-handle 0.5.2",
  "winit",
 ]
 
@@ -1123,8 +1122,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -1502,12 +1500,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
@@ -2487,8 +2479,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.0",
+ "raw-window-handle",
  "redox_syscall 0.3.5",
  "rustix 0.38.21",
  "sctk-adwaita",

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["winit/rwh_05", "winit/x11", "winit/wayland"]
+features = ["winit/rwh_06", "winit/x11", "winit/wayland"]
 
 [features]
 default = ["accesskit_unix", "async-io"]
@@ -20,8 +20,7 @@ tokio = ["accesskit_unix/tokio"]
 
 [dependencies]
 accesskit = { version = "0.12.0", path = "../../common" }
-raw-window-handle = "0.5"
-winit = { version = "0.29", default-features = false, features = ["rwh_05"] }
+winit = { version = "0.29", default-features = false, features = ["rwh_06"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.15.0", path = "../windows" }
@@ -35,4 +34,4 @@ accesskit_unix = { version = "0.6.0", path = "../unix", optional = true, default
 [dev-dependencies.winit]
 version = "0.29"
 default-features = false
-features = ["rwh_05", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+features = ["rwh_06", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -4,8 +4,11 @@
 
 use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_macos::SubclassingAdapter;
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-use winit::{event::WindowEvent, window::Window};
+use winit::{
+    event::WindowEvent,
+    raw_window_handle::{HasWindowHandle, RawWindowHandle},
+    window::Window,
+};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler>;
 
@@ -19,8 +22,8 @@ impl Adapter {
         source: impl 'static + FnOnce() -> TreeUpdate,
         action_handler: ActionHandlerBox,
     ) -> Self {
-        let view = match window.raw_window_handle() {
-            RawWindowHandle::AppKit(handle) => handle.ns_view,
+        let view = match window.window_handle().unwrap().as_raw() {
+            RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr(),
             RawWindowHandle::UiKit(_) => unimplemented!(),
             _ => unreachable!(),
         };

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -4,8 +4,11 @@
 
 use accesskit::{ActionHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
-use winit::{event::WindowEvent, window::Window};
+use winit::{
+    event::WindowEvent,
+    raw_window_handle::{HasWindowHandle, RawWindowHandle},
+    window::Window,
+};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
 
@@ -19,11 +22,11 @@ impl Adapter {
         source: impl 'static + FnOnce() -> TreeUpdate,
         action_handler: ActionHandlerBox,
     ) -> Self {
-        let hwnd = HWND(match window.raw_window_handle() {
-            RawWindowHandle::Win32(handle) => handle.hwnd as isize,
+        let hwnd = match window.window_handle().unwrap().as_raw() {
+            RawWindowHandle::Win32(handle) => HWND(handle.hwnd.get()),
             RawWindowHandle::WinRt(_) => unimplemented!(),
             _ => unreachable!(),
-        });
+        };
         let adapter = SubclassingAdapter::new(hwnd, source, action_handler);
         Self { adapter }
     }


### PR DESCRIPTION
Following up on an [earlier comment](https://github.com/AccessKit/accesskit/pull/305#issuecomment-1793515487), I don't think it would be right for us to do a new release that depends on an old version of raw-window-handle, if we can easily avoid it. So this PR switches accesskit_winit to use rwh_06. @Vrixyz I believe this can coexist with your code that requires rwh_05, since it seems that those winit features don't actually conflict, but please check.