### PR TITLE
fix: Account for window decorations when `accesskit_winit::Adapter::process_event` receives a resizing event on Unix

### DIFF
--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -62,19 +62,19 @@ impl Adapter {
                     Rect::from_origin_size(inner_position, inner_size),
                 )
             }
-            WindowEvent::Resized(outer_size) => {
+            WindowEvent::Resized(inner_size) => {
                 let outer_position: (_, _) = window
                     .outer_position()
                     .unwrap_or_default()
                     .cast::<f64>()
                     .into();
-                let outer_size: (_, _) = outer_size.cast::<f64>().into();
+                let outer_size: (_, _) = window.outer_size().cast::<f64>().into();
                 let inner_position: (_, _) = window
                     .inner_position()
                     .unwrap_or_default()
                     .cast::<f64>()
                     .into();
-                let inner_size: (_, _) = window.inner_size().cast::<f64>().into();
+                let inner_size: (_, _) = inner_size.cast::<f64>().into();
                 self.set_root_window_bounds(
                     Rect::from_origin_size(outer_position, outer_size),
                     Rect::from_origin_size(inner_position, inner_size),


### PR DESCRIPTION
Closes #311 
