### PR TITLE
feat: Support custom role descriptions

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -358,6 +358,10 @@ impl NodeState {
         self.data().role_description().map(String::from)
     }
 
+    pub fn has_role_description(&self) -> bool {
+        self.data().role_description().is_some()
+    }
+
     pub fn is_hidden(&self) -> bool {
         self.data().is_hidden()
     }

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -354,6 +354,10 @@ impl NodeState {
         self.data().role()
     }
 
+    pub fn role_description(&self) -> Option<String> {
+        self.data().role_description().map(String::from)
+    }
+
     pub fn is_hidden(&self) -> bool {
         self.data().is_hidden()
     }

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -18,7 +18,7 @@ use objc2::{
     foundation::{
         NSArray, NSCopying, NSInteger, NSNumber, NSObject, NSPoint, NSRange, NSRect, NSString,
     },
-    msg_send, msg_send_id, ns_string, 
+    msg_send, msg_send_id, ns_string,
     rc::{Id, Owned, Shared},
     runtime::Sel,
     sel, ClassType,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -18,7 +18,7 @@ use objc2::{
     foundation::{
         NSArray, NSCopying, NSInteger, NSNumber, NSObject, NSPoint, NSRange, NSRect, NSString,
     },
-    msg_send_id, ns_string,
+    msg_send, msg_send_id, ns_string, 
     rc::{Id, Owned, Shared},
     runtime::Sel,
     sel, ClassType,
@@ -398,6 +398,18 @@ declare_class!(
                 .resolve(|node| ns_role(node.state()))
                 .unwrap_or(unsafe { NSAccessibilityUnknownRole });
             Id::autorelease_return(role.copy())
+        }
+
+        #[sel(accessibilityRoleDescription)]
+        fn role_description(&self) -> *mut NSString {
+            self.resolve(|node| {
+                if let Some(role_description) = node.role_description() {
+                    Id::autorelease_return(NSString::from_str(&role_description))
+                } else {
+                    unsafe { msg_send![super(self), accessibilityRoleDescription] }
+                }
+            })
+            .unwrap_or_else(null_mut)
         }
 
         #[sel(accessibilityTitle)]

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -83,6 +83,10 @@ impl AccessibleInterface<PlatformNode> {
         self.node.role()
     }
 
+    fn get_localized_role_name(&self) -> fdo::Result<String> {
+        self.node.localized_role_name()
+    }
+
     fn get_state(&self) -> fdo::Result<StateSet> {
         self.node.state()
     }

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -110,7 +110,7 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub fn role(&self) -> AtspiRole {
-        if self.node_state().role_description().is_some() {
+        if self.node_state().has_role_description() {
             return AtspiRole::Extended;
         }
 

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -110,6 +110,9 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub fn role(&self) -> AtspiRole {
+        if self.node_state().role_description().is_some() {
+            return AtspiRole::Extended;
+        }
         match self.node_state().role() {
             Role::Alert => AtspiRole::Notification,
             Role::AlertDialog => AtspiRole::Alert,
@@ -811,6 +814,10 @@ impl PlatformNode {
             let wrapper = self.node_wrapper(&node);
             Ok(wrapper.role())
         })
+    }
+
+    pub(crate) fn localized_role_name(&self) -> fdo::Result<String> {
+        self.resolve(|node| Ok(node.state().role_description().unwrap_or_default()))
     }
 
     pub fn state(&self) -> fdo::Result<StateSet> {

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -113,6 +113,7 @@ impl<'a> NodeWrapper<'a> {
         if self.node_state().role_description().is_some() {
             return AtspiRole::Extended;
         }
+
         match self.node_state().role() {
             Role::Alert => AtspiRole::Notification,
             Role::AlertDialog => AtspiRole::Alert,

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -266,6 +266,10 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn localized_control_type(&self) -> Option<String> {
+        self.node_state().role_description()
+    }
+
     fn name(&self) -> Option<String> {
         match self {
             Self::Node(node) => node.name(),
@@ -841,6 +845,7 @@ macro_rules! patterns {
 
 properties! {
     (ControlType, control_type),
+    (LocalizedControlType, localized_control_type),
     (Name, name),
     (IsContentElement, is_content_element),
     (IsControlElement, is_content_element),


### PR DESCRIPTION
Revamping an old branch, initial work by @mwcampbell.

Implement support for the `role_description` property on all adapters:
- Documented the fact that this property should be used sparingly,
- Tweaked the macOS and Windows implementations after rebase,
- On Unix: implemented the `GetLocalizedRoleName` method of the `org.a11y.atspi.Accessible` interface. Make use of `AtspiRole::Extended` if a value is supplied, as it is the only way to tell libatspi to query it. Orca still won't announce it because it currently explicitly ignore this role, Accerciser however displays it properly.

Tested on all platforms by modifying the winit example.