### PR TITLE
chore: Bump async-channel dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When reporting an issue, in order to help the maintainers understand what the pr
 
 When making a code contribution to AccessKit, before opening your pull request please make sure that:
 
-- your patch builds with AccessKit's minimal supported rust version - Rust 1.64
+- your patch builds with AccessKit's minimal supported rust version - Rust 1.68
 - you added tests where applicable
 - you tested your modifications on all impacted platforms (see below)
 - you updated any relevant documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "0.6.1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "async-channel",
+ "async-channel 2.1.1",
  "async-once-cell",
  "atspi",
  "futures-lite",
@@ -185,7 +185,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -196,8 +196,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -252,7 +265,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -272,7 +285,7 @@ dependencies = [
  "autocfg",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
  "rustix 0.37.7",
  "signal-hook",
@@ -447,7 +460,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-lock",
  "async-task",
  "atomic-waker",
@@ -743,6 +756,27 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -2603,7 +2637,7 @@ dependencies = [
  "byteorder",
  "derivative",
  "enumflags2",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -18,7 +18,7 @@ tokio = ["dep:tokio", "atspi/tokio", "zbus/tokio"]
 [dependencies]
 accesskit = { version = "0.12.1", path = "../../common" }
 accesskit_consumer = { version = "0.16.1", path = "../../consumer" }
-async-channel = "1.9"
+async-channel = "2.1.1"
 async-once-cell = "0.5.3"
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -21,9 +21,12 @@ use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandl
 use async_channel::{Receiver, Sender};
 use atspi::{Interface, InterfaceSet, Live, State};
 use futures_lite::StreamExt;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use std::{
+    pin::pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 use zbus::Task;
 
@@ -519,6 +522,7 @@ impl Drop for Adapter {
 }
 
 async fn handle_events(bus: Bus, mut events: Receiver<Event>) {
+    let mut events = pin!(events);
     while let Some(event) = events.next().await {
         let _ = match event {
             Event::Object { target, event } => bus.emit_object_event(target, event).await,


### PR DESCRIPTION
Relates to #317 

Using the `pin!` macro bumps our MSRV to 1.68. I've checked downstream crates and I think this is acceptable, but I can find a way around if not.