### PR TITLE
Add a rwh_05 feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,8 @@ dependencies = [
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "winit",
 ]
 
@@ -1122,7 +1124,8 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "thiserror",
 ]
 
@@ -1500,6 +1503,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
@@ -2479,7 +2488,8 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
- "raw-window-handle",
+ "raw-window-handle 0.5.2",
+ "raw-window-handle 0.6.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.21",
  "sctk-adwaita",

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -14,13 +14,17 @@ edition = "2021"
 features = ["winit/rwh_06", "winit/x11", "winit/wayland"]
 
 [features]
-default = ["accesskit_unix", "async-io"]
+default = ["accesskit_unix", "async-io", "rwh_06"]
+rwh_05 = ["winit/rwh_05", "dep:rwh_05"]
+rwh_06 = ["winit/rwh_06", "dep:rwh_06"]
 async-io = ["accesskit_unix/async-io"]
 tokio = ["accesskit_unix/tokio"]
 
 [dependencies]
 accesskit = { version = "0.12.1", path = "../../common" }
-winit = { version = "0.29", default-features = false, features = ["rwh_06"] }
+winit = { version = "0.29", default-features = false }
+rwh_05 = { package = "raw-window-handle", version = "0.5", features = ["std"], optional = true }
+rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.15.1", path = "../windows" }
@@ -34,4 +38,4 @@ accesskit_unix = { version = "0.6.1", path = "../unix", optional = true, default
 [dev-dependencies.winit]
 version = "0.29"
 default-features = false
-features = ["rwh_06", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -9,7 +9,17 @@ use winit::{
     window::{Window, WindowId},
 };
 
+#[cfg(feature = "rwh_05")]
+#[allow(unused)]
+use rwh_05 as raw_window_handle;
+#[cfg(feature = "rwh_06")]
+#[allow(unused)]
+use rwh_06 as raw_window_handle;
+
 mod platform_impl;
+
+#[cfg(all(feature = "rwh_05", feature = "rwh_06"))]
+compile_error!("Cannot enable both 'rwh_05' and 'rwh_06' features at the same time");
 
 #[derive(Debug)]
 pub struct ActionRequestEvent {

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 The AccessKit Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (found in
 // the LICENSE-APACHE file).
+#[allow(unused)]
 use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, TreeUpdate};

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 The AccessKit Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (found in
 // the LICENSE-APACHE file).
-#[allow(unused)]
+#[cfg(feature = "rwh_05")]
+use crate::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+#[cfg(feature = "rwh_06")]
 use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, TreeUpdate};

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -1,10 +1,11 @@
 // Copyright 2022 The AccessKit Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (found in
 // the LICENSE-APACHE file).
+#[allow(unused)]
 use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, TreeUpdate};
-use accesskit_windows::SubclassingAdapter;
+use accesskit_windows::{SubclassingAdapter, HWND};
 use winit::{event::WindowEvent, window::Window};
 
 pub type ActionHandlerBox = Box<dyn ActionHandler + Send>;
@@ -27,12 +28,12 @@ impl Adapter {
         };
         #[cfg(feature = "rwh_06")]
         let hwnd = match window.window_handle().unwrap().as_raw() {
-            RawWindowHandle::Win32(handle) => accesskit_windows::HWND(handle.hwnd.get()),
+            RawWindowHandle::Win32(handle) => handle.hwnd.get(),
             RawWindowHandle::WinRt(_) => unimplemented!(),
             _ => unreachable!(),
         };
 
-        let adapter = SubclassingAdapter::new(hwnd, source, action_handler);
+        let adapter = SubclassingAdapter::new(HWND(hwnd), source, action_handler);
         Self { adapter }
     }
 

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 The AccessKit Authors. All rights reserved.
 // Licensed under the Apache License, Version 2.0 (found in
 // the LICENSE-APACHE file).
-#[allow(unused)]
+#[cfg(feature = "rwh_05")]
+use crate::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+#[cfg(feature = "rwh_06")]
 use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, TreeUpdate};


### PR DESCRIPTION
This allows using accesskit with current and older versions of wgpu. Typically this is a requirement for game developers, or low level UI toolkit developers.

# Changelog

Added the `rwh_05` and `rwh_06` feature flags to the `accesskit_winit` crate.

This allows consumers of the `accesskit_winit` crate to pick and chose which version of `raw-window-handle` `accesskit_winit` will depend on.

* `rwh_05` enables the `winit` `rwh_05` feature flag, which uses the `raw-window-handle` version `0.5`.
* `rwh_06` is similar to `rwh_05`, but for `raw-window-handle` version `0.6`.

See https://github.com/rust-windowing/winit/pull/3075 for a discussion of why this is wanted.

`rwh_06` is enabled by default, following `winit`'s convention. If both features are enabled at the same time, a `compile_error!` is emitted.

## Tests

Tested on
- [x] linux/X11
- [x] macos
- [x] windows

Steps to test:

```sh
git clone https://github.com/AccessKit/accesskit.git
cd accesskit
cargo test
cargo test -p accesskit_{yourplateform}
cargo check -p accesskit_winit --no-default-features --features  'async-io rwh_05'
cargo check -p accesskit_winit
```