### PR TITLE
fix: Bump async-channel dependency to `2.1.1`

### DIFF
--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -26,3 +26,4 @@ once_cell = "1.17.1"
 serde = "1.0"
 tokio = { version = "1.32.0", optional = true, features = ["rt", "net", "time"] }
 zbus = { version = "3.14", default-features = false }
+


### PR DESCRIPTION
This is really just a dummy commit because the previous one, having been tagged with `chore`, won't get release-please to release a new version of the unix adapter.