### PR TITLE
fix!: Lazily activate Unix adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "async-once-cell",
  "atspi",
  "futures-lite",
+ "futures-util",
  "once_cell",
  "serde",
  "tokio",
@@ -860,6 +861,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +891,7 @@ checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "accesskit",
  "accesskit_consumer",
  "async-channel 2.1.1",
+ "async-lock",
  "async-once-cell",
  "atspi",
  "futures-lite",

--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -77,7 +77,7 @@ void accesskit_sdl_adapter_init(struct accesskit_sdl_adapter *adapter,
       (void *)wmInfo.info.cocoa.window, source, source_userdata, handler);
 #elif defined(UNIX)
   adapter->adapter =
-      accesskit_unix_adapter_new(source, source_userdata, false, handler);
+      accesskit_unix_adapter_new(source, source_userdata, handler);
 #elif defined(_WIN32)
   SDL_SysWMinfo wmInfo;
   SDL_VERSION(&wmInfo.version);
@@ -111,10 +111,8 @@ void accesskit_sdl_adapter_update_if_active(
     accesskit_macos_queued_events_raise(events);
   }
 #elif defined(UNIX)
-  if (adapter->adapter != NULL) {
-    accesskit_unix_adapter_update(adapter->adapter,
-                                  update_factory(update_factory_userdata));
-  }
+  accesskit_unix_adapter_update_if_active(adapter->adapter, update_factory,
+                                          update_factory_userdata);
 #elif defined(_WIN32)
   accesskit_windows_queued_events *events =
       accesskit_windows_subclassing_adapter_update_if_active(
@@ -135,10 +133,8 @@ void accesskit_sdl_adapter_update_window_focus_state(
     accesskit_macos_queued_events_raise(events);
   }
 #elif defined(UNIX)
-  if (adapter->adapter != NULL) {
-    accesskit_unix_adapter_update_window_focus_state(adapter->adapter,
-                                                     is_focused);
-  }
+  accesskit_unix_adapter_update_window_focus_state(adapter->adapter,
+                                                   is_focused);
 #endif
   /* On Windows, the subclassing adapter takes care of this. */
 }
@@ -146,18 +142,16 @@ void accesskit_sdl_adapter_update_window_focus_state(
 void accesskit_sdl_adapter_update_root_window_bounds(
     const struct accesskit_sdl_adapter *adapter, SDL_Window *window) {
 #if defined(UNIX)
-  if (adapter->adapter != NULL) {
-    int x, y, width, height;
-    SDL_GetWindowPosition(window, &x, &y);
-    SDL_GetWindowSize(window, &width, &height);
-    int top, left, bottom, right;
-    SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right);
-    accesskit_rect outer_bounds = {x - left, y - top, x + width + right,
-                                   y + height + bottom};
-    accesskit_rect inner_bounds = {x, y, x + width, y + height};
-    accesskit_unix_adapter_set_root_window_bounds(adapter->adapter,
-                                                  outer_bounds, inner_bounds);
-  }
+  int x, y, width, height;
+  SDL_GetWindowPosition(window, &x, &y);
+  SDL_GetWindowSize(window, &width, &height);
+  int top, left, bottom, right;
+  SDL_GetWindowBordersSize(window, &top, &left, &bottom, &right);
+  accesskit_rect outer_bounds = {x - left, y - top, x + width + right,
+                                 y + height + bottom};
+  accesskit_rect inner_bounds = {x, y, x + width, y + height};
+  accesskit_unix_adapter_set_root_window_bounds(adapter->adapter, outer_bounds,
+                                                inner_bounds);
 #endif
 }
 

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -1123,5 +1123,11 @@ impl ActionHandler for FfiActionHandler {
     }
 }
 
+#[repr(transparent)]
+pub struct tree_update_factory_userdata(pub *mut c_void);
+
+unsafe impl Send for tree_update_factory_userdata {}
+
 /// This function can't return a null pointer. Ownership of the returned value will be transfered to the caller.
-pub type tree_update_factory = Option<extern "C" fn(*mut c_void) -> *mut tree_update>;
+pub type tree_update_factory =
+    Option<extern "C" fn(tree_update_factory_userdata) -> *mut tree_update>;

--- a/bindings/c/src/macos.rs
+++ b/bindings/c/src/macos.rs
@@ -4,8 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use crate::{
-    action_handler, box_from_ptr, ref_from_ptr, tree_update, tree_update_factory, BoxCastPtr,
-    CastPtr,
+    action_handler, box_from_ptr, ref_from_ptr, tree_update, tree_update_factory,
+    tree_update_factory_userdata, BoxCastPtr, CastPtr,
 };
 use accesskit_macos::{
     add_focus_forwarder_to_window_class, Adapter, NSPoint, QueuedEvents, SubclassingAdapter,
@@ -147,6 +147,7 @@ impl macos_subclassing_adapter {
         handler: *mut action_handler,
     ) -> *mut macos_subclassing_adapter {
         let source = source.unwrap();
+        let source_userdata = tree_update_factory_userdata(source_userdata);
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::new(
             view,
@@ -174,6 +175,7 @@ impl macos_subclassing_adapter {
         handler: *mut action_handler,
     ) -> *mut macos_subclassing_adapter {
         let source = source.unwrap();
+        let source_userdata = tree_update_factory_userdata(source_userdata);
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::for_window(
             window,
@@ -211,6 +213,7 @@ impl macos_subclassing_adapter {
         update_factory_userdata: *mut c_void,
     ) -> *mut macos_queued_events {
         let update_factory = update_factory.unwrap();
+        let update_factory_userdata = tree_update_factory_userdata(update_factory_userdata);
         let adapter = ref_from_ptr(adapter);
         let events =
             adapter.update_if_active(|| *box_from_ptr(update_factory(update_factory_userdata)));

--- a/bindings/c/src/windows.rs
+++ b/bindings/c/src/windows.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     action_handler, box_from_ptr, opt_struct, ref_from_ptr, tree_update, tree_update_factory,
-    BoxCastPtr, CastPtr,
+    tree_update_factory_userdata, BoxCastPtr, CastPtr,
 };
 use accesskit_windows::*;
 use std::{os::raw::c_void, ptr};
@@ -151,6 +151,7 @@ impl windows_subclassing_adapter {
         handler: *mut action_handler,
     ) -> *mut windows_subclassing_adapter {
         let source = source.unwrap();
+        let source_userdata = tree_update_factory_userdata(source_userdata);
         let handler = box_from_ptr(handler);
         let adapter = SubclassingAdapter::new(
             hwnd,
@@ -188,6 +189,7 @@ impl windows_subclassing_adapter {
         update_factory_userdata: *mut c_void,
     ) -> *mut windows_queued_events {
         let update_factory = update_factory.unwrap();
+        let update_factory_userdata = tree_update_factory_userdata(update_factory_userdata);
         let adapter = ref_from_ptr(adapter);
         let events =
             adapter.update_if_active(|| *box_from_ptr(update_factory(update_factory_userdata)));

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -19,6 +19,7 @@ tokio = ["dep:tokio", "atspi/tokio", "zbus/tokio"]
 accesskit = { version = "0.12.1", path = "../../common" }
 accesskit_consumer = { version = "0.16.1", path = "../../consumer" }
 async-channel = "2.1.1"
+async-lock = "2.7.0"
 async-once-cell = "0.5.3"
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"
@@ -26,4 +27,3 @@ once_cell = "1.17.1"
 serde = "1.0"
 tokio = { version = "1.32.0", optional = true, features = ["rt", "net", "time"] }
 zbus = { version = "3.14", default-features = false }
-

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -23,6 +23,7 @@ async-lock = "2.7.0"
 async-once-cell = "0.5.3"
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"
+futures-util = "0.3.27"
 once_cell = "1.17.1"
 serde = "1.0"
 tokio = { version = "1.32.0", optional = true, features = ["rt", "net", "time"] }

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -5,31 +5,27 @@
 
 use crate::{
     atspi::{
-        interfaces::{
-            AccessibleInterface, ActionInterface, ComponentInterface, Event, ObjectEvent,
-            ValueInterface, WindowEvent,
-        },
-        Bus, ObjectId,
+        interfaces::{Event, ObjectEvent, WindowEvent},
+        ObjectId,
     },
     context::{ActivationContext, AppContext, Context},
     filters::{filter, filter_detached},
-    node::{NodeWrapper, PlatformNode},
+    node::NodeWrapper,
     util::{block_on, WindowBounds},
 };
 use accesskit::{ActionHandler, NodeId, Rect, Role, TreeUpdate};
 use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
-use async_channel::{Receiver, Sender};
+use async_channel::Sender;
 use async_once_cell::Lazy;
-use atspi::{Interface, InterfaceSet, Live, State};
-use futures_lite::{future::Boxed, FutureExt, StreamExt};
+use atspi::{InterfaceSet, Live, State};
+use futures_lite::{future::Boxed, FutureExt};
 use std::{
-    pin::{pin, Pin},
+    pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, Weak,
     },
 };
-use zbus::Task;
 
 struct AdapterChangeHandler<'a> {
     adapter: &'a AdapterImpl,
@@ -37,61 +33,63 @@ struct AdapterChangeHandler<'a> {
 
 impl AdapterChangeHandler<'_> {
     fn add_node(&mut self, node: &Node) {
-        let role = node.role();
-        let is_root = node.is_root();
-        let node = NodeWrapper::Node {
-            adapter: self.adapter.id,
-            node,
-        };
-        let interfaces = node.interfaces();
-        self.adapter
-            .register_interfaces(node.id(), interfaces)
-            .unwrap();
-        if is_root && role == Role::Window {
-            let adapter_index = AppContext::read().adapter_index(self.adapter.id).unwrap();
-            self.adapter.window_created(adapter_index, node.id());
-        }
-
-        let live = node.live();
-        if live != Live::None {
-            if let Some(name) = node.name() {
-                self.adapter
-                    .events
-                    .send_blocking(Event::Object {
-                        target: ObjectId::Node {
-                            adapter: self.adapter.id,
-                            node: node.id(),
-                        },
-                        event: ObjectEvent::Announcement(name, live),
-                    })
-                    .unwrap();
+        block_on(async {
+            let role = node.role();
+            let is_root = node.is_root();
+            let node = NodeWrapper::Node {
+                adapter: self.adapter.id,
+                node,
+            };
+            let interfaces = node.interfaces();
+            self.adapter
+                .register_interfaces(node.id(), interfaces)
+                .await;
+            if is_root && role == Role::Window {
+                let adapter_index = AppContext::read().adapter_index(self.adapter.id).unwrap();
+                self.adapter.window_created(adapter_index, node.id()).await;
             }
-        }
+
+            let live = node.live();
+            if live != Live::None {
+                if let Some(name) = node.name() {
+                    self.adapter
+                        .emit_object_event(
+                            ObjectId::Node {
+                                adapter: self.adapter.id,
+                                node: node.id(),
+                            },
+                            ObjectEvent::Announcement(name, live),
+                        )
+                        .await;
+                }
+            }
+        })
     }
 
     fn remove_node(&mut self, node: &DetachedNode) {
-        let role = node.role();
-        let is_root = node.is_root();
-        let node = NodeWrapper::DetachedNode {
-            adapter: self.adapter.id,
-            node,
-        };
-        if is_root && role == Role::Window {
-            self.adapter.window_destroyed(node.id());
-        }
-        self.adapter
-            .events
-            .send_blocking(Event::Object {
-                target: ObjectId::Node {
-                    adapter: self.adapter.id,
-                    node: node.id(),
-                },
-                event: ObjectEvent::StateChanged(State::Defunct, true),
-            })
-            .unwrap();
-        self.adapter
-            .unregister_interfaces(node.id(), node.interfaces())
-            .unwrap();
+        block_on(async {
+            let role = node.role();
+            let is_root = node.is_root();
+            let node = NodeWrapper::DetachedNode {
+                adapter: self.adapter.id,
+                node,
+            };
+            if is_root && role == Role::Window {
+                self.adapter.window_destroyed(node.id()).await;
+            }
+            self.adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: self.adapter.id,
+                        node: node.id(),
+                    },
+                    ObjectEvent::StateChanged(State::Defunct, true),
+                )
+                .await;
+            self.adapter
+                .unregister_interfaces(node.id(), node.interfaces())
+                .await;
+        });
     }
 }
 
@@ -123,17 +121,18 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
             let old_interfaces = old_wrapper.interfaces();
             let new_interfaces = new_wrapper.interfaces();
             let kept_interfaces = old_interfaces & new_interfaces;
-            self.adapter
-                .unregister_interfaces(new_wrapper.id(), old_interfaces ^ kept_interfaces)
-                .unwrap();
-            self.adapter
-                .register_interfaces(new_node.id(), new_interfaces ^ kept_interfaces)
-                .unwrap();
-            new_wrapper.notify_changes(
-                &self.adapter.context.read_root_window_bounds(),
-                &self.adapter.events,
-                &old_wrapper,
-            );
+            block_on(async {
+                self.adapter
+                    .unregister_interfaces(new_wrapper.id(), old_interfaces ^ kept_interfaces)
+                    .await;
+                self.adapter
+                    .register_interfaces(new_node.id(), new_interfaces ^ kept_interfaces)
+                    .await;
+                let bounds = *self.adapter.context.read_root_window_bounds();
+                new_wrapper
+                    .notify_changes(&bounds, self.adapter, &old_wrapper)
+                    .await;
+            });
         }
     }
 
@@ -143,49 +142,53 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         new_node: Option<&Node>,
         current_state: &TreeState,
     ) {
-        if let Some(root_window) = root_window(current_state) {
-            if old_node.is_none() && new_node.is_some() {
-                self.adapter.window_activated(&NodeWrapper::Node {
-                    adapter: self.adapter.id,
-                    node: &root_window,
-                });
-            } else if old_node.is_some() && new_node.is_none() {
-                self.adapter.window_deactivated(&NodeWrapper::Node {
-                    adapter: self.adapter.id,
-                    node: &root_window,
-                });
+        block_on(async {
+            if let Some(root_window) = root_window(current_state) {
+                if old_node.is_none() && new_node.is_some() {
+                    self.adapter
+                        .window_activated(&NodeWrapper::Node {
+                            adapter: self.adapter.id,
+                            node: &root_window,
+                        })
+                        .await;
+                } else if old_node.is_some() && new_node.is_none() {
+                    self.adapter
+                        .window_deactivated(&NodeWrapper::Node {
+                            adapter: self.adapter.id,
+                            node: &root_window,
+                        })
+                        .await;
+                }
             }
-        }
-        if let Some(node) = new_node.map(|node| NodeWrapper::Node {
-            adapter: self.adapter.id,
-            node,
-        }) {
-            self.adapter
-                .events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter: self.adapter.id,
-                        node: node.id(),
-                    },
-                    event: ObjectEvent::StateChanged(State::Focused, true),
-                })
-                .unwrap();
-        }
-        if let Some(node) = old_node.map(|node| NodeWrapper::DetachedNode {
-            adapter: self.adapter.id,
-            node,
-        }) {
-            self.adapter
-                .events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter: self.adapter.id,
-                        node: node.id(),
-                    },
-                    event: ObjectEvent::StateChanged(State::Focused, false),
-                })
-                .unwrap();
-        }
+            if let Some(node) = new_node.map(|node| NodeWrapper::Node {
+                adapter: self.adapter.id,
+                node,
+            }) {
+                self.adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: self.adapter.id,
+                            node: node.id(),
+                        },
+                        ObjectEvent::StateChanged(State::Focused, true),
+                    )
+                    .await;
+            }
+            if let Some(node) = old_node.map(|node| NodeWrapper::DetachedNode {
+                adapter: self.adapter.id,
+                node,
+            }) {
+                self.adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: self.adapter.id,
+                            node: node.id(),
+                        },
+                        ObjectEvent::StateChanged(State::Focused, false),
+                    )
+                    .await;
+            }
+        });
     }
 
     fn node_removed(&mut self, node: &DetachedNode, _: &TreeState) {
@@ -199,9 +202,7 @@ static NEXT_ADAPTER_ID: AtomicUsize = AtomicUsize::new(0);
 
 pub(crate) struct AdapterImpl {
     id: usize,
-    atspi_bus: Bus,
-    _event_task: Task<()>,
-    events: Sender<Event>,
+    messages: Sender<Message>,
     context: Arc<Context>,
 }
 
@@ -214,171 +215,95 @@ impl AdapterImpl {
     ) -> Option<Self> {
         let tree = Tree::new(initial_state, is_window_focused);
         let id = NEXT_ADAPTER_ID.fetch_add(1, Ordering::SeqCst);
-        let root_id = tree.state().root_id();
-        let (event_sender, event_receiver) = async_channel::unbounded();
-        let (mut atspi_bus, event_task, context, adapter_index) = {
+        let (messages, context) = {
             let mut app_context = AppContext::write();
-            app_context.name = tree.state().app_name();
-            app_context.toolkit_name = tree.state().toolkit_name();
-            app_context.toolkit_version = tree.state().toolkit_version();
-            let atspi_bus = app_context.atspi_bus.clone().unwrap();
-            let atspi_bus_copy = atspi_bus.clone();
-            #[cfg(feature = "tokio")]
-            let _guard = crate::util::TOKIO_RT.enter();
-            let event_task = atspi_bus.connection().executor().spawn(
-                async move {
-                    handle_events(atspi_bus_copy, event_receiver).await;
-                },
-                "accesskit_event_task",
-            );
+            let messages = app_context.messages.clone().unwrap();
             let context = Context::new(tree, action_handler, root_window_bounds);
-            let adapter_index = app_context.push_adapter(id, &context);
-            (atspi_bus, event_task, context, adapter_index)
+            app_context.push_adapter(id, &context);
+            (messages, context)
         };
-        block_on(async {
-            if !atspi_bus.register_root_node().await.ok()? {
-                atspi_bus
-                    .emit_object_event(
-                        ObjectId::Root,
-                        ObjectEvent::ChildAdded(
-                            adapter_index,
-                            ObjectId::Node {
-                                adapter: id,
-                                node: root_id,
-                            },
-                        ),
-                    )
-                    .await
-                    .ok()
-            } else {
-                Some(())
-            }
-        })?;
-        let r#impl = AdapterImpl {
+        Some(AdapterImpl {
             id,
-            atspi_bus,
-            _event_task: event_task,
-            events: event_sender,
+            messages,
             context,
-        };
-        r#impl.register_tree();
-        Some(r#impl)
+        })
     }
 
-    fn register_tree(&self) {
-        let tree = self.context.read_tree();
-        let tree_state = tree.state();
+    pub(crate) async fn register_tree(&self) {
+        fn add_children(
+            node: Node<'_>,
+            to_add: &mut Vec<(NodeId, InterfaceSet)>,
+            adapter_id: usize,
+        ) {
+            for child in node.filtered_children(&filter) {
+                let child_id = child.id();
+                let wrapper = NodeWrapper::Node {
+                    adapter: adapter_id,
+                    node: &child,
+                };
+                let interfaces = wrapper.interfaces();
+                to_add.push((child_id, interfaces));
+                add_children(child, to_add, adapter_id);
+            }
+        }
+
         let mut objects_to_add = Vec::new();
 
-        fn add_children(node: Node<'_>, to_add: &mut Vec<NodeId>) {
-            for child in node.filtered_children(&filter) {
-                to_add.push(child.id());
-                add_children(child, to_add);
-            }
-        }
-
-        objects_to_add.push(tree_state.root().id());
-        add_children(tree_state.root(), &mut objects_to_add);
-        for id in objects_to_add {
-            let node = tree_state.node_by_id(id).unwrap();
+        let (adapter_index, root_id) = {
+            let tree = self.context.read_tree();
+            let tree_state = tree.state();
+            let mut app_context = AppContext::write();
+            app_context.name = tree_state.app_name();
+            app_context.toolkit_name = tree_state.toolkit_name();
+            app_context.toolkit_version = tree_state.toolkit_version();
+            let adapter_index = app_context.adapter_index(self.id).unwrap();
+            let root = tree_state.root();
+            let root_id = root.id();
             let wrapper = NodeWrapper::Node {
                 adapter: self.id,
-                node: &node,
+                node: &root,
             };
-            let interfaces = wrapper.interfaces();
-            self.register_interfaces(id, interfaces).unwrap();
-            if node.is_root() && node.role() == Role::Window {
-                let adapter_index = AppContext::read().adapter_index(self.id).unwrap();
-                self.window_created(adapter_index, node.id());
+            objects_to_add.push((root_id, wrapper.interfaces()));
+            add_children(root, &mut objects_to_add, self.id);
+            (adapter_index, root_id)
+        };
+
+        for (id, interfaces) in objects_to_add {
+            self.register_interfaces(id, interfaces).await;
+            if id == root_id {
+                self.window_created(adapter_index, id).await;
             }
         }
     }
 
-    fn register_interfaces(&self, id: NodeId, new_interfaces: InterfaceSet) -> zbus::Result<bool> {
-        let path = ObjectId::Node {
-            adapter: self.id,
-            node: id,
-        }
-        .path();
-        if new_interfaces.contains(Interface::Accessible) {
-            block_on(async {
-                self.atspi_bus
-                    .register_interface(
-                        &path,
-                        AccessibleInterface::new(
-                            self.atspi_bus.unique_name().to_owned(),
-                            PlatformNode::new(&self.context, self.id, id),
-                        ),
-                    )
-                    .await
-            })?;
-        }
-        if new_interfaces.contains(Interface::Action) {
-            block_on(async {
-                self.atspi_bus
-                    .register_interface(
-                        &path,
-                        ActionInterface::new(PlatformNode::new(&self.context, self.id, id)),
-                    )
-                    .await
-            })?;
-        }
-        if new_interfaces.contains(Interface::Component) {
-            block_on(async {
-                self.atspi_bus
-                    .register_interface(
-                        &path,
-                        ComponentInterface::new(PlatformNode::new(&self.context, self.id, id)),
-                    )
-                    .await
-            })?;
-        }
-        if new_interfaces.contains(Interface::Value) {
-            block_on(async {
-                self.atspi_bus
-                    .register_interface(
-                        &path,
-                        ValueInterface::new(PlatformNode::new(&self.context, self.id, id)),
-                    )
-                    .await
-            })?;
-        }
-        Ok(true)
+    async fn register_interfaces(&self, id: NodeId, new_interfaces: InterfaceSet) {
+        self.messages
+            .send(Message::RegisterInterfaces {
+                adapter_id: self.id,
+                context: Arc::downgrade(&self.context),
+                node_id: id,
+                interfaces: new_interfaces,
+            })
+            .await
+            .unwrap();
     }
 
-    fn unregister_interfaces(
-        &self,
-        id: NodeId,
-        old_interfaces: InterfaceSet,
-    ) -> zbus::Result<bool> {
-        block_on(async {
-            let path = ObjectId::Node {
-                adapter: self.id,
-                node: id,
-            }
-            .path();
-            if old_interfaces.contains(Interface::Accessible) {
-                self.atspi_bus
-                    .unregister_interface::<AccessibleInterface<PlatformNode>>(&path)
-                    .await?;
-            }
-            if old_interfaces.contains(Interface::Action) {
-                self.atspi_bus
-                    .unregister_interface::<ActionInterface>(&path)
-                    .await?;
-            }
-            if old_interfaces.contains(Interface::Component) {
-                self.atspi_bus
-                    .unregister_interface::<ComponentInterface>(&path)
-                    .await?;
-            }
-            if old_interfaces.contains(Interface::Value) {
-                self.atspi_bus
-                    .unregister_interface::<ValueInterface>(&path)
-                    .await?;
-            }
-            Ok(true)
-        })
+    async fn unregister_interfaces(&self, id: NodeId, old_interfaces: InterfaceSet) {
+        self.messages
+            .send(Message::UnregisterInterfaces {
+                adapter_id: self.id,
+                node_id: id,
+                interfaces: old_interfaces,
+            })
+            .await
+            .unwrap();
+    }
+
+    pub(crate) async fn emit_object_event(&self, target: ObjectId, event: ObjectEvent) {
+        self.messages
+            .send(Message::EmitEvent(Event::Object { target, event }))
+            .await
+            .unwrap();
     }
 
     fn set_root_window_bounds(&self, bounds: WindowBounds) {
@@ -398,84 +323,81 @@ impl AdapterImpl {
         tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
     }
 
-    fn window_created(&self, adapter_index: usize, window: NodeId) {
-        self.events
-            .send_blocking(Event::Object {
-                target: ObjectId::Root,
-                event: ObjectEvent::ChildAdded(
-                    adapter_index,
-                    ObjectId::Node {
-                        adapter: self.id,
-                        node: window,
-                    },
-                ),
-            })
-            .unwrap();
+    async fn window_created(&self, adapter_index: usize, window: NodeId) {
+        self.emit_object_event(
+            ObjectId::Root,
+            ObjectEvent::ChildAdded(
+                adapter_index,
+                ObjectId::Node {
+                    adapter: self.id,
+                    node: window,
+                },
+            ),
+        )
+        .await;
     }
 
-    fn window_activated(&self, window: &NodeWrapper) {
-        self.events
-            .send_blocking(Event::Window {
+    async fn window_activated(&self, window: &NodeWrapper<'_>) {
+        self.messages
+            .send(Message::EmitEvent(Event::Window {
                 target: ObjectId::Node {
                     adapter: self.id,
                     node: window.id(),
                 },
                 name: window.name().unwrap_or_default(),
                 event: WindowEvent::Activated,
-            })
+            }))
+            .await
             .unwrap();
-        self.events
-            .send_blocking(Event::Object {
-                target: ObjectId::Node {
-                    adapter: self.id,
-                    node: window.id(),
-                },
-                event: ObjectEvent::StateChanged(State::Active, true),
-            })
-            .unwrap();
-        self.events
-            .send_blocking(Event::Object {
-                target: ObjectId::Root,
-                event: ObjectEvent::ActiveDescendantChanged(ObjectId::Node {
-                    adapter: self.id,
-                    node: window.id(),
-                }),
-            })
-            .unwrap();
+        self.emit_object_event(
+            ObjectId::Node {
+                adapter: self.id,
+                node: window.id(),
+            },
+            ObjectEvent::StateChanged(State::Active, true),
+        )
+        .await;
+        self.emit_object_event(
+            ObjectId::Root,
+            ObjectEvent::ActiveDescendantChanged(ObjectId::Node {
+                adapter: self.id,
+                node: window.id(),
+            }),
+        )
+        .await;
     }
 
-    fn window_deactivated(&self, window: &NodeWrapper) {
-        self.events
-            .send_blocking(Event::Window {
+    async fn window_deactivated(&self, window: &NodeWrapper<'_>) {
+        self.messages
+            .send(Message::EmitEvent(Event::Window {
                 target: ObjectId::Node {
                     adapter: self.id,
                     node: window.id(),
                 },
                 name: window.name().unwrap_or_default(),
                 event: WindowEvent::Deactivated,
-            })
+            }))
+            .await
             .unwrap();
-        self.events
-            .send_blocking(Event::Object {
-                target: ObjectId::Node {
-                    adapter: self.id,
-                    node: window.id(),
-                },
-                event: ObjectEvent::StateChanged(State::Active, false),
-            })
-            .unwrap();
+        self.emit_object_event(
+            ObjectId::Node {
+                adapter: self.id,
+                node: window.id(),
+            },
+            ObjectEvent::StateChanged(State::Active, false),
+        )
+        .await;
     }
 
-    fn window_destroyed(&self, window: NodeId) {
-        self.events
-            .send_blocking(Event::Object {
-                target: ObjectId::Root,
-                event: ObjectEvent::ChildRemoved(ObjectId::Node {
-                    adapter: self.id,
-                    node: window,
-                }),
-            })
-            .unwrap();
+    async fn window_destroyed(&self, window: NodeId) {
+        self.emit_object_event(
+            ObjectId::Root,
+            ObjectEvent::ChildRemoved(ObjectId::Node {
+                adapter: self.id,
+                node: window,
+            }),
+        )
+        .await;
     }
 }
 
@@ -491,34 +413,18 @@ fn root_window(current_state: &TreeState) -> Option<Node> {
 
 impl Drop for AdapterImpl {
     fn drop(&mut self) {
+        AppContext::write().remove_adapter(self.id);
+        let root_id = self.context.read_tree().state().root_id();
         block_on(async {
-            AppContext::write().remove_adapter(self.id);
-            let root_id = self.context.read_tree().state().root_id();
-            self.atspi_bus
-                .emit_object_event(
-                    ObjectId::Root,
-                    ObjectEvent::ChildRemoved(ObjectId::Node {
-                        adapter: self.id,
-                        node: root_id,
-                    }),
-                )
-                .await
-                .unwrap();
+            self.emit_object_event(
+                ObjectId::Root,
+                ObjectEvent::ChildRemoved(ObjectId::Node {
+                    adapter: self.id,
+                    node: root_id,
+                }),
+            )
+            .await;
         });
-    }
-}
-
-async fn handle_events(bus: Bus, mut events: Receiver<Event>) {
-    let mut events = pin!(events);
-    while let Some(event) = events.next().await {
-        let _ = match event {
-            Event::Object { target, event } => bus.emit_object_event(target, event).await,
-            Event::Window {
-                target,
-                name,
-                event,
-            } => bus.emit_window_event(target, name, event).await,
-        };
     }
 }
 
@@ -588,4 +494,19 @@ impl Adapter {
             r#impl.update_window_focus_state(is_focused);
         }
     }
+}
+
+pub(crate) enum Message {
+    RegisterInterfaces {
+        adapter_id: usize,
+        context: Weak<Context>,
+        node_id: NodeId,
+        interfaces: InterfaceSet,
+    },
+    UnregisterInterfaces {
+        adapter_id: usize,
+        node_id: NodeId,
+        interfaces: InterfaceSet,
+    },
+    EmitEvent(Event),
 }

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -5,15 +5,17 @@
 
 use crate::{
     atspi::{interfaces::*, ObjectId},
-    context::AppContext,
-    PlatformRootNode,
+    context::{AppContext, Context},
+    PlatformNode, PlatformRootNode,
 };
+use accesskit::NodeId;
 use atspi::{
     events::EventBody,
     proxy::{bus::BusProxy, socket::SocketProxy},
+    Interface, InterfaceSet,
 };
 use serde::Serialize;
-use std::{collections::HashMap, env::var};
+use std::{collections::HashMap, env::var, sync::Weak};
 use zbus::{
     names::{BusName, InterfaceName, MemberName, OwnedUniqueName},
     zvariant::{Str, Value},
@@ -27,35 +29,24 @@ pub(crate) struct Bus {
 }
 
 impl Bus {
-    pub async fn a11y_bus() -> Option<Self> {
-        let conn = a11y_bus().await?;
-        let socket_proxy = SocketProxy::new(&conn).await.ok()?;
-        Some(Bus { conn, socket_proxy })
+    pub(crate) async fn new(session_bus: &Connection) -> zbus::Result<Self> {
+        let address = match var("AT_SPI_BUS_ADDRESS") {
+            Ok(address) if !address.is_empty() => address,
+            _ => BusProxy::new(session_bus).await?.get_address().await?,
+        };
+        let address: Address = address.as_str().try_into()?;
+        let conn = ConnectionBuilder::address(address)?.build().await?;
+        let socket_proxy = SocketProxy::new(&conn).await?;
+        let mut bus = Bus { conn, socket_proxy };
+        bus.register_root_node().await?;
+        Ok(bus)
     }
 
-    pub(crate) fn connection(&self) -> &Connection {
-        &self.conn
-    }
-
-    pub fn unique_name(&self) -> &OwnedUniqueName {
+    fn unique_name(&self) -> &OwnedUniqueName {
         self.conn.unique_name().unwrap()
     }
 
-    pub async fn register_interface<T>(&self, path: &str, interface: T) -> Result<bool>
-    where
-        T: zbus::Interface,
-    {
-        self.conn.object_server().at(path, interface).await
-    }
-
-    pub async fn unregister_interface<T>(&self, path: &str) -> Result<bool>
-    where
-        T: zbus::Interface,
-    {
-        self.conn.object_server().remove::<T, _>(path).await
-    }
-
-    pub(crate) async fn register_root_node(&mut self) -> Result<bool> {
+    async fn register_root_node(&mut self) -> Result<()> {
         let node = PlatformRootNode::new();
         let path = ObjectId::Root.path();
 
@@ -80,10 +71,101 @@ impl Bus {
                 .await?;
             let mut app_context = AppContext::write();
             app_context.desktop_address = Some(desktop.into());
-            Ok(true)
-        } else {
-            Ok(false)
         }
+
+        Ok(())
+    }
+
+    pub(crate) async fn register_interfaces(
+        &self,
+        adapter_id: usize,
+        context: Weak<Context>,
+        node_id: NodeId,
+        new_interfaces: InterfaceSet,
+    ) -> zbus::Result<()> {
+        let path = ObjectId::Node {
+            adapter: adapter_id,
+            node: node_id,
+        }
+        .path();
+        if new_interfaces.contains(Interface::Accessible) {
+            self.register_interface(
+                &path,
+                AccessibleInterface::new(
+                    self.unique_name().to_owned(),
+                    PlatformNode::new(context.clone(), adapter_id, node_id),
+                ),
+            )
+            .await?;
+        }
+        if new_interfaces.contains(Interface::Action) {
+            self.register_interface(
+                &path,
+                ActionInterface::new(PlatformNode::new(context.clone(), adapter_id, node_id)),
+            )
+            .await?;
+        }
+        if new_interfaces.contains(Interface::Component) {
+            self.register_interface(
+                &path,
+                ComponentInterface::new(PlatformNode::new(context.clone(), adapter_id, node_id)),
+            )
+            .await?;
+        }
+        if new_interfaces.contains(Interface::Value) {
+            self.register_interface(
+                &path,
+                ValueInterface::new(PlatformNode::new(context, adapter_id, node_id)),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn register_interface<T>(&self, path: &str, interface: T) -> Result<()>
+    where
+        T: zbus::Interface,
+    {
+        self.conn.object_server().at(path, interface).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn unregister_interfaces(
+        &self,
+        adapter_id: usize,
+        node_id: NodeId,
+        old_interfaces: InterfaceSet,
+    ) -> zbus::Result<()> {
+        let path = ObjectId::Node {
+            adapter: adapter_id,
+            node: node_id,
+        }
+        .path();
+        if old_interfaces.contains(Interface::Accessible) {
+            self.unregister_interface::<AccessibleInterface<PlatformNode>>(&path)
+                .await?;
+        }
+        if old_interfaces.contains(Interface::Action) {
+            self.unregister_interface::<ActionInterface>(&path).await?;
+        }
+        if old_interfaces.contains(Interface::Component) {
+            self.unregister_interface::<ComponentInterface>(&path)
+                .await?;
+        }
+        if old_interfaces.contains(Interface::Value) {
+            self.unregister_interface::<ValueInterface>(&path).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn unregister_interface<T>(&self, path: &str) -> Result<()>
+    where
+        T: zbus::Interface,
+    {
+        self.conn.object_server().remove::<T, _>(path).await?;
+        Ok(())
     }
 
     pub(crate) async fn emit_object_event(
@@ -266,21 +348,4 @@ impl Bus {
             )
             .await
     }
-}
-
-async fn a11y_bus() -> Option<Connection> {
-    let address = match var("AT_SPI_BUS_ADDRESS") {
-        Ok(address) if !address.is_empty() => address,
-        _ => {
-            let session_bus = Connection::session().await.ok()?;
-            BusProxy::new(&session_bus)
-                .await
-                .ok()?
-                .get_address()
-                .await
-                .ok()?
-        }
-    };
-    let address: Address = address.as_str().try_into().ok()?;
-    ConnectionBuilder::address(address).ok()?.build().await.ok()
 }

--- a/platforms/unix/src/atspi/mod.rs
+++ b/platforms/unix/src/atspi/mod.rs
@@ -39,6 +39,6 @@ impl From<accesskit::Rect> for Rect {
     }
 }
 
-pub(crate) use bus::Bus;
+pub(crate) use bus::*;
 pub(crate) use object_address::OwnedObjectAddress;
 pub(crate) use object_id::ObjectId;

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -5,10 +5,19 @@
 
 use accesskit::{ActionHandler, ActionRequest};
 use accesskit_consumer::Tree;
+use async_lock::{Mutex as AsyncMutex, MutexGuard as AsyncMutexGuard};
+use async_once_cell::OnceCell as AsyncOnceCell;
+use atspi::proxy::bus::StatusProxy;
+use futures_lite::StreamExt;
 use once_cell::sync::OnceCell;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
+use zbus::{Connection, Task};
 
-use crate::{atspi::OwnedObjectAddress, util::WindowBounds};
+use crate::{
+    adapter::LazyAdapter,
+    atspi::{Bus, OwnedObjectAddress},
+    util::WindowBounds,
+};
 
 pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
@@ -53,32 +62,31 @@ impl AdapterAndContext {
 static APP_CONTEXT: OnceCell<Arc<RwLock<AppContext>>> = OnceCell::new();
 
 pub(crate) struct AppContext {
-    pub(crate) name: String,
-    pub(crate) toolkit_name: String,
-    pub(crate) toolkit_version: String,
+    pub(crate) atspi_bus: Option<Bus>,
+    pub(crate) name: Option<String>,
+    pub(crate) toolkit_name: Option<String>,
+    pub(crate) toolkit_version: Option<String>,
     pub(crate) id: Option<i32>,
     pub(crate) desktop_address: Option<OwnedObjectAddress>,
     pub(crate) adapters: Vec<AdapterAndContext>,
 }
 
 impl AppContext {
-    pub(crate) fn get_or_init(
-        name: String,
-        toolkit_name: String,
-        toolkit_version: String,
-    ) -> Arc<RwLock<Self>> {
+    fn get_or_init<'a>() -> RwLockWriteGuard<'a, Self> {
         APP_CONTEXT
             .get_or_init(|| {
                 Arc::new(RwLock::new(Self {
-                    name,
-                    toolkit_name,
-                    toolkit_version,
+                    atspi_bus: None,
+                    name: None,
+                    toolkit_name: None,
+                    toolkit_version: None,
                     id: None,
                     desktop_address: None,
                     adapters: Vec::new(),
                 }))
             })
-            .clone()
+            .write()
+            .unwrap()
     }
 
     pub(crate) fn read<'a>() -> RwLockReadGuard<'a, AppContext> {
@@ -105,4 +113,59 @@ impl AppContext {
             self.adapters.remove(index);
         }
     }
+}
+
+pub(crate) struct ActivationContext {
+    _monitoring_task: Task<()>,
+    adapters: Vec<LazyAdapter>,
+}
+
+static ACTIVATION_CONTEXT: AsyncOnceCell<Arc<AsyncMutex<ActivationContext>>> = AsyncOnceCell::new();
+
+impl ActivationContext {
+    async fn get_or_init<'a>() -> AsyncMutexGuard<'a, ActivationContext> {
+        ACTIVATION_CONTEXT
+            .get_or_init(async {
+                let session_bus = Connection::session().await.unwrap();
+                let session_bus_copy = session_bus.clone();
+                let monitoring_task = session_bus.executor().spawn(
+                    async move {
+                        let _ = monitor_a11y_status(session_bus_copy).await;
+                    },
+                    "accesskit_a11y_monitoring_task",
+                );
+                Arc::new(AsyncMutex::new(ActivationContext {
+                    _monitoring_task: monitoring_task,
+                    adapters: Vec::new(),
+                }))
+            })
+            .await
+            .lock()
+            .await
+    }
+
+    pub(crate) async fn activate_eventually(adapter: LazyAdapter) {
+        let mut activation_context = ActivationContext::get_or_init().await;
+        activation_context.adapters.push(adapter);
+        let adapter = activation_context.adapters.last().unwrap();
+        let is_a11y_enabled = AppContext::get_or_init().atspi_bus.is_some();
+        if is_a11y_enabled {
+            adapter.as_ref().await;
+        }
+    }
+}
+
+async fn monitor_a11y_status(session_bus: Connection) -> zbus::Result<()> {
+    let status = StatusProxy::new(&session_bus).await?;
+    let mut changes = status.receive_is_enabled_changed().await;
+
+    while let Some(change) = changes.next().await {
+        if let Ok(true) = change.get().await {
+            let atspi_bus = Bus::a11y_bus().await;
+            let mut app_context = AppContext::get_or_init();
+            app_context.atspi_bus = atspi_bus;
+        }
+    }
+
+    Ok(())
 }

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -21,13 +21,14 @@ impl Context {
     pub(crate) fn new(
         tree: Tree,
         action_handler: Box<dyn ActionHandler + Send>,
+        root_window_bounds: WindowBounds,
         app_context: &Arc<RwLock<AppContext>>,
     ) -> Arc<Self> {
         Arc::new(Self {
             tree: RwLock::new(tree),
             action_handler: Mutex::new(action_handler),
             app_context: app_context.clone(),
-            root_window_bounds: RwLock::new(Default::default()),
+            root_window_bounds: RwLock::new(root_window_bounds),
         })
     }
 

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -1015,7 +1015,7 @@ impl PlatformRootNode {
     }
 
     pub(crate) fn name(&self) -> fdo::Result<String> {
-        self.resolve_app_context(|context| Ok(context.name.clone()))
+        self.resolve_app_context(|context| Ok(context.name.clone().unwrap_or_default()))
     }
 
     pub(crate) fn parent(&self) -> fdo::Result<Option<OwnedObjectAddress>> {
@@ -1063,11 +1063,11 @@ impl PlatformRootNode {
     }
 
     pub(crate) fn toolkit_name(&self) -> fdo::Result<String> {
-        self.resolve_app_context(|context| Ok(context.toolkit_name.clone()))
+        self.resolve_app_context(|context| Ok(context.toolkit_name.clone().unwrap_or_default()))
     }
 
     pub(crate) fn toolkit_version(&self) -> fdo::Result<String> {
-        self.resolve_app_context(|context| Ok(context.toolkit_version.clone()))
+        self.resolve_app_context(|context| Ok(context.toolkit_version.clone().unwrap_or_default()))
     }
 
     pub(crate) fn id(&self) -> fdo::Result<i32> {

--- a/platforms/unix/src/node.rs
+++ b/platforms/unix/src/node.rs
@@ -9,8 +9,9 @@
 // found in the LICENSE.chromium file.
 
 use crate::{
+    adapter::AdapterImpl,
     atspi::{
-        interfaces::{Action as AtspiAction, Event, ObjectEvent, Property},
+        interfaces::{Action as AtspiAction, ObjectEvent, Property},
         ObjectId, OwnedObjectAddress, Rect as AtspiRect,
     },
     context::{AdapterAndContext, AppContext, Context},
@@ -22,7 +23,6 @@ use accesskit::{
     Rect, Role,
 };
 use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
-use async_channel::Sender;
 use atspi::{
     CoordType, Interface, InterfaceSet, Layer, Live as AtspiLive, Role as AtspiRole, State,
     StateSet,
@@ -482,171 +482,172 @@ impl<'a> NodeWrapper<'a> {
         self.node_state().numeric_value()
     }
 
-    pub fn notify_changes(
+    pub(crate) async fn notify_changes(
         &self,
         window_bounds: &WindowBounds,
-        events: &Sender<Event>,
-        old: &NodeWrapper,
+        adapter: &AdapterImpl,
+        old: &NodeWrapper<'_>,
     ) {
-        self.notify_state_changes(events, old);
-        self.notify_property_changes(events, old);
-        self.notify_bounds_changes(window_bounds, events, old);
-        self.notify_children_changes(events, old);
+        self.notify_state_changes(adapter, old).await;
+        self.notify_property_changes(adapter, old).await;
+        self.notify_bounds_changes(window_bounds, adapter, old)
+            .await;
+        self.notify_children_changes(adapter, old).await;
     }
 
-    fn notify_state_changes(&self, events: &Sender<Event>, old: &NodeWrapper) {
-        let adapter = self.adapter();
+    async fn notify_state_changes(&self, adapter: &AdapterImpl, old: &NodeWrapper<'_>) {
+        let adapter_id = self.adapter();
         let old_state = old.state(true);
         let new_state = self.state(true);
         let changed_states = old_state ^ new_state;
         for state in changed_states.iter() {
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter,
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: adapter_id,
                         node: self.id(),
                     },
-                    event: ObjectEvent::StateChanged(state, new_state.contains(state)),
-                })
-                .unwrap();
+                    ObjectEvent::StateChanged(state, new_state.contains(state)),
+                )
+                .await;
         }
     }
 
-    fn notify_property_changes(&self, events: &Sender<Event>, old: &NodeWrapper) {
-        let adapter = self.adapter();
+    async fn notify_property_changes(&self, adapter: &AdapterImpl, old: &NodeWrapper<'_>) {
+        let adapter_id = self.adapter();
         let name = self.name();
         if name != old.name() {
             let name = name.unwrap_or_default();
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter,
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: adapter_id,
                         node: self.id(),
                     },
-                    event: ObjectEvent::PropertyChanged(Property::Name(name.clone())),
-                })
-                .unwrap();
+                    ObjectEvent::PropertyChanged(Property::Name(name.clone())),
+                )
+                .await;
 
             let live = self.live();
             if live != AtspiLive::None {
-                events
-                    .send_blocking(Event::Object {
-                        target: ObjectId::Node {
-                            adapter,
+                adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: adapter_id,
                             node: self.id(),
                         },
-                        event: ObjectEvent::Announcement(name, live),
-                    })
-                    .unwrap();
+                        ObjectEvent::Announcement(name, live),
+                    )
+                    .await;
             }
         }
         let description = self.description();
         if description != old.description() {
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter,
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: adapter_id,
                         node: self.id(),
                     },
-                    event: ObjectEvent::PropertyChanged(Property::Description(description)),
-                })
-                .unwrap();
+                    ObjectEvent::PropertyChanged(Property::Description(description)),
+                )
+                .await;
         }
         let parent_id = self.parent_id();
         if parent_id != old.parent_id() {
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter,
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: adapter_id,
                         node: self.id(),
                     },
-                    event: ObjectEvent::PropertyChanged(Property::Parent(self.filtered_parent())),
-                })
-                .unwrap();
+                    ObjectEvent::PropertyChanged(Property::Parent(self.filtered_parent())),
+                )
+                .await;
         }
         let role = self.role();
         if role != old.role() {
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
-                        adapter,
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
+                        adapter: adapter_id,
                         node: self.id(),
                     },
-                    event: ObjectEvent::PropertyChanged(Property::Role(role)),
-                })
-                .unwrap();
+                    ObjectEvent::PropertyChanged(Property::Role(role)),
+                )
+                .await;
         }
         if let Some(value) = self.current_value() {
             if Some(value) != old.current_value() {
-                events
-                    .send_blocking(Event::Object {
-                        target: ObjectId::Node {
-                            adapter,
+                adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: adapter_id,
                             node: self.id(),
                         },
-                        event: ObjectEvent::PropertyChanged(Property::Value(value)),
-                    })
-                    .unwrap();
+                        ObjectEvent::PropertyChanged(Property::Value(value)),
+                    )
+                    .await;
             }
         }
     }
 
-    fn notify_bounds_changes(
+    async fn notify_bounds_changes(
         &self,
         window_bounds: &WindowBounds,
-        events: &Sender<Event>,
-        old: &NodeWrapper,
+        adapter: &AdapterImpl,
+        old: &NodeWrapper<'_>,
     ) {
         if self.raw_bounds_and_transform() != old.raw_bounds_and_transform() {
-            events
-                .send_blocking(Event::Object {
-                    target: ObjectId::Node {
+            adapter
+                .emit_object_event(
+                    ObjectId::Node {
                         adapter: self.adapter(),
                         node: self.id(),
                     },
-                    event: ObjectEvent::BoundsChanged(self.extents(window_bounds)),
-                })
-                .unwrap();
+                    ObjectEvent::BoundsChanged(self.extents(window_bounds)),
+                )
+                .await;
         }
     }
 
-    fn notify_children_changes(&self, events: &Sender<Event>, old: &NodeWrapper) {
-        let adapter = self.adapter();
+    async fn notify_children_changes(&self, adapter: &AdapterImpl, old: &NodeWrapper<'_>) {
+        let adapter_id = self.adapter();
         let old_children = old.child_ids().collect::<Vec<NodeId>>();
         let filtered_children = self.filtered_child_ids().collect::<Vec<NodeId>>();
         for (index, child) in filtered_children.iter().enumerate() {
             if !old_children.contains(child) {
-                events
-                    .send_blocking(Event::Object {
-                        target: ObjectId::Node {
-                            adapter,
+                adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: adapter_id,
                             node: self.id(),
                         },
-                        event: ObjectEvent::ChildAdded(
+                        ObjectEvent::ChildAdded(
                             index,
                             ObjectId::Node {
-                                adapter,
+                                adapter: adapter_id,
                                 node: *child,
                             },
                         ),
-                    })
-                    .unwrap();
+                    )
+                    .await;
             }
         }
         for child in old_children.into_iter() {
             if !filtered_children.contains(&child) {
-                events
-                    .send_blocking(Event::Object {
-                        target: ObjectId::Node {
-                            adapter,
+                adapter
+                    .emit_object_event(
+                        ObjectId::Node {
+                            adapter: adapter_id,
                             node: self.id(),
                         },
-                        event: ObjectEvent::ChildRemoved(ObjectId::Node {
-                            adapter,
+                        ObjectEvent::ChildRemoved(ObjectId::Node {
+                            adapter: adapter_id,
                             node: child,
                         }),
-                    })
-                    .unwrap();
+                    )
+                    .await;
             }
         }
     }
@@ -664,9 +665,9 @@ pub(crate) struct PlatformNode {
 }
 
 impl PlatformNode {
-    pub(crate) fn new(context: &Arc<Context>, adapter_id: usize, node_id: NodeId) -> Self {
+    pub(crate) fn new(context: Weak<Context>, adapter_id: usize, node_id: NodeId) -> Self {
         Self {
-            context: Arc::downgrade(context),
+            context,
             adapter_id,
             node_id,
         }

--- a/platforms/unix/src/util.rs
+++ b/platforms/unix/src/util.rs
@@ -39,7 +39,7 @@ pub(crate) fn block_on<F: std::future::Future>(future: F) -> F::Output {
     TOKIO_RT.block_on(future)
 }
 
-#[derive(Default)]
+#[derive(Clone, Copy, Default)]
 pub(crate) struct WindowBounds {
     pub(crate) outer: Rect,
     pub(crate) inner: Rect,

--- a/platforms/unix/src/util.rs
+++ b/platforms/unix/src/util.rs
@@ -46,6 +46,10 @@ pub(crate) struct WindowBounds {
 }
 
 impl WindowBounds {
+    pub(crate) fn new(outer: Rect, inner: Rect) -> Self {
+        Self { outer, inner }
+    }
+
     pub(crate) fn top_left(&self, coord_type: CoordType, is_root: bool) -> Point {
         match coord_type {
             CoordType::Screen if is_root => self.outer.origin(),


### PR DESCRIPTION
Fixes #314 

When a Unix adapter is created, we now start monitoring the D-Bus session bus for property change signals, which indicate if assistive technologies are currently running. If this becomes true, all currently registered adapters will be initialized. If for some reason the AT-SPI bus disappear, tree updates will still happen but nothing will be sent through D-Bus. If the AT-SPI bus is launched again, the connection will be re-established, the D-Bus object server will be populated and signals will be emitted like before.