### PR TITLE
fix!: Remove `accesskit_winit::Adapter::update`

### DIFF
--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -92,10 +92,6 @@ impl Adapter {
         self.adapter.process_event(window, event);
     }
 
-    pub fn update(&self, update: TreeUpdate) {
-        self.adapter.update(update);
-    }
-
     pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
         self.adapter.update_if_active(updater);
     }

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -39,11 +39,6 @@ impl Adapter {
         Self { adapter }
     }
 
-    pub fn update(&self, update: TreeUpdate) {
-        let events = self.adapter.update(update);
-        events.raise();
-    }
-
     pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
         if let Some(events) = self.adapter.update_if_active(updater) {
             events.raise();

--- a/platforms/winit/src/platform_impl/null.rs
+++ b/platforms/winit/src/platform_impl/null.rs
@@ -18,8 +18,6 @@ impl Adapter {
         Self {}
     }
 
-    pub fn update(&self, _update: TreeUpdate) {}
-
     pub fn update_if_active(&self, _updater: impl FnOnce() -> TreeUpdate) {}
 
     pub fn process_event(&self, _window: &Window, _event: &WindowEvent) {}

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -28,12 +28,6 @@ impl Adapter {
         }
     }
 
-    pub fn update(&self, update: TreeUpdate) {
-        if let Some(adapter) = &self.adapter {
-            adapter.update(update);
-        }
-    }
-
     pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
         if let Some(adapter) = &self.adapter {
             adapter.update(updater());

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -39,10 +39,6 @@ impl Adapter {
         Self { adapter }
     }
 
-    pub fn update(&self, update: TreeUpdate) {
-        self.adapter.update(update).raise();
-    }
-
     pub fn update_if_active(&self, updater: impl FnOnce() -> TreeUpdate) {
         if let Some(events) = self.adapter.update_if_active(updater) {
             events.raise();


### PR DESCRIPTION
As discussed in #324, the `update` method on the winit `Adapter` isn't really used anymore. Since upcoming changes to the Unix adapter will render this method useless on this platform, this PR removes it.

`update_if_active` is now the only way to push tree updates.

Note that I haven't removed `update` methods from the various subclassing adapters, but they might be useless as well now.