### PR TITLE
chore: Move `debug` and `panic` settings to C binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,5 @@ default-members = [
 
 [profile.release]
 lto = true
-panic = "abort"
-debug = true
 opt-level = "z"
 codegen-units = 1

--- a/bindings/c/.cargo/config.toml
+++ b/bindings/c/.cargo/config.toml
@@ -7,3 +7,7 @@ rustflags = [
 rustflags = [
   "-C", "link-arg=-Wl,-install_name,@rpath/libaccesskit.dylib",
 ]
+
+[profile.release]
+panic = "abort"
+debug = true


### PR DESCRIPTION
I've decided that the `debug` and `panic` settings in the Cargo release profile need to be decided on a per-binding basis. I think we're in agreement that these settings should remain as they are for the C binding. But for the Python binding, I think we want `debug = false` and `panic = "unwind"`. Whether by accident or design, it seems to be standard practice to not ship full debug info with Python wheels, but to leave the shared libraries unstripped on non-Windows platforms. The default setting of `debug = false` accomplishes this. As for the `panic` setting, PyO3 can convert a Rust panic into a Python exception as long as we leave the `panic` setting at its default. That does increase binary size somewhat, but I think it's more important for the Python binding to behave as Python users expect, raising an exception with a Python traceback.

Note that, due to an issue discussed in the PR for the Python binding, a `bindings/python/.cargo/config` file, if present, is ignored when building the Python binding with maturin. So it's lucky that, once the Python binding branch is rebased on this PR, the workspace-wide profile settings will be what we want for the Python binding.

I'm doing this as a separate PR so that when we merge the Python binding, it won't trigger a new release of the C binding.