### PR TITLE
fix: Decrease minimum Python version to 3.8 for Python bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.8'
 
       - name: restore cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -6,7 +6,7 @@ on:
 name: Publish Python bindings
 
 env:
-  MIN_PYTHON_VERSION: 3.9
+  MIN_PYTHON_VERSION: 3.8
 
 jobs:
   macos-wheels:
@@ -37,12 +37,12 @@ jobs:
           name: wheels
           path: dist
 
-  unix-wheels:
+  linux-wheels:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, x86, aarch64]
+        target: [x86_64, x86, aarch64, armv7]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -115,7 +115,7 @@ jobs:
     permissions:
       id-token: write
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [macos-wheels, unix-wheels, windows-wheels, sdist]
+    needs: [macos-wheels, linux-wheels, windows-wheels, sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
@@ -129,7 +129,7 @@ jobs:
   github-release:
     name: Add to GitHub release
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [macos-wheels, unix-wheels, windows-wheels, sdist]
+    needs: [macos-wheels, linux-wheels, windows-wheels, sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, aarch64]
+        target: [universal2-apple-darwin]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
@@ -27,7 +27,6 @@ jobs:
           args: --release --out dist
           sccache: 'true'
       - name: Test wheel installation
-        if: matrix.target == 'x86_64'
         run: |
           pip install accesskit --no-index --find-links dist --force-reinstall
           python -c "import accesskit"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,7 +18,7 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 accesskit = { version = "0.12.2", path = "../../common", features = ["pyo3"] }
-pyo3 = { version = "0.20", features = ["abi3-py39", "multiple-pymethods"] }
+pyo3 = { version = "0.20", features = ["abi3-py38", "multiple-pymethods"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 accesskit_windows = { version = "0.16.0", path = "../../platforms/windows" }

--- a/bindings/python/examples/pygame/README.md
+++ b/bindings/python/examples/pygame/README.md
@@ -4,7 +4,7 @@ This directory contains a cross-platform application that demonstrates how to in
 
 ## Prerequisites
 
-- Python 3.9 or higher
+- Python 3.8 or higher
 - A virtual environment: `python -m venv .venv` (activating it will vary based on your platform)
 - `pip install -r requirements.txt` 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,18 @@ include = ['bindings/python/*.py']
 
 [project]
 name = "accesskit"
-requires-python = ">= 3.9"
+requires-python = ">= 3.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: User Interfaces"
 ]
 


### PR DESCRIPTION
All these changes are to better align with [kivy](https://github.com/kivy/kivy)'s build matrix. The only missing target is ARMv6L, but it isn't supported by Rust.

We could also build for apple-universal2 instead of x86_64 and aarch64 separately. Cargo doesn't support this but maturin has a special post-linking step for it.

Given the nature of the changes, I don't think accesskit_python's semver should be increased.