### PR TITLE
fix: Make full use of the tokio ecosystem if the `tokio` feature is enabled on Unix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "once_cell",
  "serde",
  "tokio",
+ "tokio-stream",
  "zbus",
 ]
 
@@ -1990,8 +1991,31 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.4",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -12,19 +12,27 @@ edition = "2021"
 
 [features]
 default = ["async-io"]
-async-io = ["atspi/async-std", "zbus/async-io"]
-tokio = ["dep:tokio", "atspi/tokio", "zbus/tokio"]
+async-io = ["dep:async-channel", "dep:async-lock", "dep:futures-util", "atspi/async-std", "zbus/async-io"]
+tokio = ["dep:tokio", "dep:tokio-stream", "atspi/tokio", "zbus/tokio"]
 
 [dependencies]
 accesskit = { version = "0.12.2", path = "../../common" }
 accesskit_consumer = { version = "0.17.0", path = "../../consumer" }
-async-channel = "2.1.1"
-async-lock = "2.7.0"
 async-once-cell = "0.5.3"
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"
-futures-util = "0.3.27"
 once_cell = "1.17.1"
 serde = "1.0"
-tokio = { version = "1.32.0", optional = true, features = ["rt", "net", "time"] }
 zbus = { version = "3.14", default-features = false }
+
+# async-io support
+async-channel = { version = "2.1.1", optional = true }
+async-lock = { version = "2.7.0", optional = true }
+futures-util = { version = "0.3.27", optional = true }
+
+# tokio support
+tokio-stream = { version = "0.1.14", optional = true }
+[dependencies.tokio]
+version = "1.32.0"
+optional = true
+features = ["macros", "net", "rt", "sync", "time"]


### PR DESCRIPTION
I noticed that we can get rid of a couple of async-related crates when the `tokio` feature is enabled, because tokio ships its own async types.