### PR TITLE
chore: Fix a clippy warning in the Unix adapter

### DIFF
--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -421,7 +421,7 @@ impl Adapter {
         })));
         let adapter = Self {
             id,
-            messages: messages.clone(),
+            messages,
             r#impl: r#impl.clone(),
             is_window_focused,
             root_window_bounds,


### PR DESCRIPTION
For some reason it only showed up when I ran clippy for Rust 1.68.2.