### PR TITLE
chore: Use the `workspace.package` table for keys which apply to all of our crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,13 @@ default-members = [
     "bindings/python",
 ]
 
+[workspace.package]
+categories = ["gui"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/AccessKit/accesskit"
+rust-version = "1.68.2"
+
 [profile.release]
 lto = true
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
+authors = ["The AccessKit contributors"]
 categories = ["gui"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_c"
 version = "0.7.1"
-authors = ["Arnold Loubriat <datatriny@gmail.com>"]
+authors.workspace = true
 license.workspace = true
 publish = false
 edition.workspace = true

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -2,9 +2,9 @@
 name = "accesskit_c"
 version = "0.7.1"
 authors = ["Arnold Loubriat <datatriny@gmail.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 publish = false
-edition = "2021"
+edition.workspace = true
 
 [lib]
 name = "accesskit"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,11 +2,11 @@
 name = "accesskit_python"
 version = "0.1.2"
 authors = ["Arnold Loubriat <datatriny@gmail.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Python bindings to the AccessKit library"
 readme = "README.md"
 publish = false
-edition = "2021"
+edition.workspace = true
 
 [lib]
 name = "accesskit"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_python"
 version = "0.1.2"
-authors = ["Arnold Loubriat <datatriny@gmail.com>"]
+authors.workspace = true
 license.workspace = true
 description = "Python bindings to the AccessKit library"
 readme = "README.md"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit"
 version = "0.12.2"
-authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+authors.workspace = true
 license.workspace = true
 description = "UI accessibility infrastructure across platforms"
 categories.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,13 +2,14 @@
 name = "accesskit"
 version = "0.12.2"
 authors = ["Matt Campbell <mattcampbell@pobox.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "UI accessibility infrastructure across platforms"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["schemars", "serde"]

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_consumer"
 version = "0.17.0"
-authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+authors.workspace = true
 license.workspace = true
 description = "AccessKit consumer library (internal)"
 categories.workspace = true

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -2,13 +2,14 @@
 name = "accesskit_consumer"
 version = "0.17.0"
 authors = ["Matt Campbell <mattcampbell@pobox.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "AccessKit consumer library (internal)"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 accesskit = { version = "0.12.2", path = "../common" }

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -2,13 +2,14 @@
 name = "accesskit_macos"
 version = "0.11.0"
 authors = ["Matt Campbell <mattcampbell@pobox.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "AccessKit UI accessibility infrastructure: macOS adapter"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_macos"
 version = "0.11.0"
-authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+authors.workspace = true
 license.workspace = true
 description = "AccessKit UI accessibility infrastructure: macOS adapter"
 categories.workspace = true

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_unix"
 version = "0.7.1"
-authors = ["Arnold Loubriat <datatriny@gmail.com>"]
+authors.workspace = true
 license.workspace = true
 description = "AccessKit UI accessibility infrastructure: Linux adapter"
 categories.workspace = true

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -2,13 +2,14 @@
 name = "accesskit_unix"
 version = "0.7.1"
 authors = ["Arnold Loubriat <datatriny@gmail.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "AccessKit UI accessibility infrastructure: Linux adapter"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["async-io"]

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_windows"
 version = "0.16.0"
-authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+authors.workspace = true
 license.workspace = true
 description = "AccessKit UI accessibility infrastructure: Windows adapter"
 categories.workspace = true

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -2,13 +2,14 @@
 name = "accesskit_windows"
 version = "0.16.0"
 authors = ["Matt Campbell <mattcampbell@pobox.com>"]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "AccessKit UI accessibility infrastructure: Windows adapter"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 accesskit = { version = "0.12.2", path = "../../common" }

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accesskit_winit"
 version = "0.18.1"
-authors = ["Matt Campbell <mattcampbell@pobox.com>"]
+authors.workspace = true
 license = "Apache-2.0"
 description = "AccessKit UI accessibility infrastructure: winit adapter"
 categories.workspace = true

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -4,11 +4,12 @@ version = "0.18.1"
 authors = ["Matt Campbell <mattcampbell@pobox.com>"]
 license = "Apache-2.0"
 description = "AccessKit UI accessibility infrastructure: winit adapter"
-categories = ["gui"]
+categories.workspace = true
 keywords = ["gui", "ui", "accessibility", "winit"]
-repository = "https://github.com/AccessKit/accesskit"
+repository.workspace = true
 readme = "README.md"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["winit/rwh_06", "winit/x11", "winit/wayland"]


### PR DESCRIPTION
- The `authors` key has been sort of deprecated for a while now, but I kept this change in a separate commit so we can easily revert it if we don't agree.
- I have everything ready to enforce our MSRV, but `1.68.2` isn't the correct value at this time:
  - We read the `CARGO_BIN_NAME` environment variables in some examples, which is only supported since `1.69`.
  - We allow the `unnecessary_literal_unwrap` in `platforms/windows/src/subclass.rs` yet this clippy lint was introduced in `1.72`.

So we need to decide whether to replace the offending lines, or to bump our MSRV to `1.72`.