### PR TITLE
chore: Don't read environment variables inside the examples anymore

### DIFF
--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -105,7 +105,7 @@ impl InnerWindowState {
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
+        tree.app_name = Some("hello_world".to_string());
 
         let mut result = TreeUpdate {
             nodes: vec![

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -85,7 +85,7 @@ impl State {
         let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
         let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
         let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some(env!("CARGO_BIN_NAME").to_string());
+        tree.app_name = Some("simple".to_string());
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),


### PR DESCRIPTION
The `CARGO_BIN_NAME` environment variable is passed to example binaries starting from Rust `1.69`. By getting rid of these we can still compile on `1.68.2` (which is the lowest version we can compile the rest of the workspace with).