### PR TITLE
ci: Enforce MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,19 +42,18 @@ jobs:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
 
-  test:
+  clippy:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
-    name: cargo clippy+test
+    name: cargo clippy
     steps:
       - uses: actions/checkout@v4
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy
 
       - name: Setup Python
@@ -67,6 +66,38 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
+
+  find-msrv:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.step2.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: step2
+        run: echo "version=`cat Cargo.toml | sed -n 's/rust-version = "\(.*\)"/\1/p'`" >> "$GITHUB_OUTPUT"
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: find-msrv
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-2019, ubuntu-latest]
+    name: cargo test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ needs.find-msrv.outputs.version }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo test
         run: cargo test


### PR DESCRIPTION
Blocked on #344 

Ensures that AccessKit can compile with the minimum Rust version as advertised in the workspace's `Cargo.toml`.

`cargo clippy` deliberately runs on stable so we can allow/deny lints that are not present on older Rust versions.