### PR TITLE
fix: Don't emit focus events twice on Unix

### DIFF
--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -137,30 +137,6 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                 });
             }
         }
-        if let Some(node) = new_node.map(|node| NodeWrapper::Node {
-            adapter: self.adapter.id,
-            node,
-        }) {
-            self.adapter.emit_object_event(
-                ObjectId::Node {
-                    adapter: self.adapter.id,
-                    node: node.id(),
-                },
-                ObjectEvent::StateChanged(State::Focused, true),
-            );
-        }
-        if let Some(node) = old_node.map(|node| NodeWrapper::DetachedNode {
-            adapter: self.adapter.id,
-            node,
-        }) {
-            self.adapter.emit_object_event(
-                ObjectId::Node {
-                    adapter: self.adapter.id,
-                    node: node.id(),
-                },
-                ObjectEvent::StateChanged(State::Focused, false),
-            );
-        }
     }
 
     fn node_removed(&mut self, node: &DetachedNode, _: &TreeState) {


### PR DESCRIPTION
All state-related events are already taken care of by `PlatformNode::notify_state_changes`. Firing these events twice often make Orca fail to announce when text input nodes get the focus.