### PR TITLE
fix: Add missing README

### DIFF
--- a/platforms/atspi-common/README.md
+++ b/platforms/atspi-common/README.md
@@ -1,0 +1,3 @@
+# AccessKit common AT-SPI translation layer
+
+This crate contains common logic for translating between AccessKit and AT-SPI. It is shared by the AccessKit Unix adapter and the new, experimental GNOME accessibility stack (code-named Newton) which is based on pushing AccessKit tree updates to the assistive technology.


### PR DESCRIPTION
I realized that I can't actually publish `accesskit_atspi_common` to crates.io because I didn't add the README.