### PR TITLE
fix: Derive `PartialOrd` and `Ord` on `NodeId`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -707,7 +707,7 @@ pub enum TextDecoration {
 pub type NodeIdContent = u64;
 
 /// The stable identity of a [`Node`], unique within the node's tree.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[repr(transparent)]


### PR DESCRIPTION
This simple fix is necessary for the upcoming refactor of `accesskit_consumer` to use `immutable-chunkmap` to bring back full copy-on-write tree snapshots.