### PR TITLE
refactor!: Restore full copy-on-write tree snapshots, now using `immutable-chunkmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ name = "accesskit_consumer"
 version = "0.17.0"
 dependencies = [
  "accesskit",
+ "immutable-chunkmap",
 ]
 
 [[package]]
@@ -429,6 +430,18 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -844,6 +857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1009,17 @@ checksum = "e286f4b975ac6c054971a0600a9b76438b332edace54bff79c71c9d3adfc9772"
 dependencies = [
  "block2 0.4.0",
  "objc2 0.5.0",
+]
+
+[[package]]
+name = "immutable-chunkmap"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374b75d1b5a9df2c4d9392f21a9e821113543ffc49571b3428d8e161802f8cc7"
+dependencies = [
+ "arrayvec",
+ "packed_struct",
+ "packed_struct_codegen",
 ]
 
 [[package]]
@@ -1353,6 +1383,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec",
+ "packed_struct_codegen",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1596,12 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1919,6 +1976,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -2679,6 +2742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -13,4 +13,4 @@ rust-version.workspace = true
 
 [dependencies]
 accesskit = { version = "0.12.2", path = "../common" }
-
+immutable-chunkmap = "2.0.4"

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -5,7 +5,7 @@
 
 use accesskit::Role;
 
-use crate::node::{DetachedNode, Node, NodeState};
+use crate::node::Node;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FilterResult {
@@ -14,7 +14,11 @@ pub enum FilterResult {
     ExcludeSubtree,
 }
 
-fn common_filter_base(node: &NodeState) -> FilterResult {
+pub fn common_filter(node: &Node) -> FilterResult {
+    if node.is_focused() {
+        return FilterResult::Include;
+    }
+
     if node.is_hidden() {
         return FilterResult::ExcludeSubtree;
     }
@@ -25,20 +29,6 @@ fn common_filter_base(node: &NodeState) -> FilterResult {
     }
 
     FilterResult::Include
-}
-
-pub fn common_filter(node: &Node) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-    common_filter_base(node.state())
-}
-
-pub fn common_filter_detached(node: &DetachedNode) -> FilterResult {
-    if node.is_focused() {
-        return FilterResult::Include;
-    }
-    common_filter_base(node.state())
 }
 
 pub fn common_filter_with_root_exception(node: &Node) -> FilterResult {

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -7,12 +7,10 @@ pub(crate) mod tree;
 pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
 
 pub(crate) mod node;
-pub use node::{DetachedNode, Node, NodeState};
+pub use node::Node;
 
 pub(crate) mod filters;
-pub use filters::{
-    common_filter, common_filter_detached, common_filter_with_root_exception, FilterResult,
-};
+pub use filters::{common_filter, common_filter_with_root_exception, FilterResult};
 
 pub(crate) mod iterators;
 

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use std::{iter::FusedIterator, ops::Deref};
+use std::iter::FusedIterator;
 
 use accesskit::{
     Action, Affine, Checked, DefaultActionVerb, Live, Node as NodeData, NodeId, Point, Rect, Role,
@@ -26,8 +26,7 @@ use crate::tree::State as TreeState;
 pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);
 
 #[derive(Clone)]
-pub struct NodeState {
-    pub(crate) id: NodeId,
+pub(crate) struct NodeState {
     pub(crate) parent_and_index: Option<ParentAndIndex>,
     pub(crate) data: NodeData,
 }
@@ -35,56 +34,36 @@ pub struct NodeState {
 #[derive(Copy, Clone)]
 pub struct Node<'a> {
     pub tree_state: &'a TreeState,
+    pub(crate) id: NodeId,
     pub(crate) state: &'a NodeState,
 }
 
-impl NodeState {
-    pub(crate) fn data(&self) -> &NodeData {
-        &self.data
-    }
-}
-
 impl<'a> Node<'a> {
-    pub fn detached(&self) -> DetachedNode {
-        DetachedNode {
-            state: self.state.clone(),
-            is_focused: self.is_focused(),
-            is_root: self.is_root(),
-            name: self.name(),
-            value: self.value(),
-            live: self.live(),
-            supports_text_ranges: self.supports_text_ranges(),
-        }
+    pub(crate) fn data(&self) -> &NodeData {
+        &self.state.data
     }
 
     pub fn is_focused(&self) -> bool {
         self.tree_state.focus_id() == Some(self.id())
     }
-}
 
-impl NodeState {
     pub fn is_focusable(&self) -> bool {
         self.supports_action(Action::Focus)
     }
-}
 
-impl<'a> Node<'a> {
     pub fn is_root(&self) -> bool {
         // Don't check for absence of a parent node, in case a non-root node
         // somehow gets detached from the tree.
         self.id() == self.tree_state.root_id()
     }
-}
 
-impl NodeState {
     pub fn parent_id(&self) -> Option<NodeId> {
-        self.parent_and_index
+        self.state
+            .parent_and_index
             .as_ref()
             .map(|ParentAndIndex(id, _)| *id)
     }
-}
 
-impl<'a> Node<'a> {
     pub fn parent(&self) -> Option<Node<'a>> {
         self.parent_id()
             .map(|id| self.tree_state.node_by_id(id).unwrap())
@@ -108,21 +87,17 @@ impl<'a> Node<'a> {
                 (self.tree_state.node_by_id(*parent).unwrap(), *index)
             })
     }
-}
 
-impl NodeState {
     pub fn child_ids(
         &self,
     ) -> impl DoubleEndedIterator<Item = NodeId>
            + ExactSizeIterator<Item = NodeId>
            + FusedIterator<Item = NodeId>
            + '_ {
-        let data = &self.data;
+        let data = &self.state.data;
         data.children().iter().copied()
     }
-}
 
-impl<'a> Node<'a> {
     pub fn children(
         &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
@@ -130,9 +105,10 @@ impl<'a> Node<'a> {
            + FusedIterator<Item = Node<'a>>
            + 'a {
         let state = self.tree_state;
-        self.state
-            .child_ids()
-            .map(move |id| state.node_by_id(id).unwrap())
+        let data = &self.state.data;
+        data.children()
+            .iter()
+            .map(move |id| state.node_by_id(*id).unwrap())
     }
 
     pub fn filtered_children(
@@ -243,9 +219,7 @@ impl<'a> Node<'a> {
         }
         false
     }
-}
 
-impl NodeState {
     /// Returns the transform defined directly on this node, or the identity
     /// transform, without taking into account transforms on ancestors.
     pub fn direct_transform(&self) -> Affine {
@@ -253,9 +227,7 @@ impl NodeState {
             .transform()
             .map_or(Affine::IDENTITY, |value| *value)
     }
-}
 
-impl<'a> Node<'a> {
     /// Returns the combined affine transform of this node and its ancestors,
     /// up to and including the root of this node's tree.
     pub fn transform(&self) -> Affine {
@@ -276,31 +248,25 @@ impl<'a> Node<'a> {
         };
         parent_transform * self.direct_transform()
     }
-}
 
-impl NodeState {
     pub fn raw_bounds(&self) -> Option<Rect> {
         self.data().bounds()
     }
-}
 
-impl<'a> Node<'a> {
     pub fn has_bounds(&self) -> bool {
-        self.state.raw_bounds().is_some()
+        self.raw_bounds().is_some()
     }
 
     /// Returns the node's transformed bounding box relative to the tree's
     /// container (e.g. window).
     pub fn bounding_box(&self) -> Option<Rect> {
-        self.state
-            .raw_bounds()
+        self.raw_bounds()
             .as_ref()
             .map(|rect| self.transform().transform_rect_bbox(*rect))
     }
 
     pub(crate) fn bounding_box_in_coordinate_space(&self, other: &Node) -> Option<Rect> {
-        self.state
-            .raw_bounds()
+        self.raw_bounds()
             .as_ref()
             .map(|rect| self.relative_transform(other).transform_rect_bbox(*rect))
     }
@@ -324,7 +290,7 @@ impl<'a> Node<'a> {
         }
 
         if filter_result == FilterResult::Include {
-            if let Some(rect) = &self.state.raw_bounds() {
+            if let Some(rect) = &self.raw_bounds() {
                 if rect.contains(point) {
                     return Some((*self, point));
                 }
@@ -343,9 +309,7 @@ impl<'a> Node<'a> {
     ) -> Option<Node<'a>> {
         self.hit_test(point, filter).map(|(node, _)| node)
     }
-}
 
-impl NodeState {
     pub fn id(&self) -> NodeId {
         self.id
     }
@@ -554,9 +518,7 @@ impl<'a> Node<'a> {
     pub fn has_value(&self) -> bool {
         self.data().value().is_some() || (self.supports_text_ranges() && !self.is_multiline())
     }
-}
 
-impl NodeState {
     pub fn is_read_only_supported(&self) -> bool {
         self.is_text_input()
             || matches!(
@@ -600,17 +562,13 @@ impl NodeState {
                 | Role::Tooltip
         )
     }
-}
 
-impl<'a> Node<'a> {
     pub fn live(&self) -> Live {
         self.data()
             .live()
             .unwrap_or_else(|| self.parent().map_or(Live::Off, |parent| parent.live()))
     }
-}
 
-impl NodeState {
     pub fn is_selected(&self) -> Option<bool> {
         self.data().is_selected()
     }
@@ -622,9 +580,7 @@ impl NodeState {
     pub fn raw_value(&self) -> Option<&str> {
         self.data().value()
     }
-}
 
-impl<'a> Node<'a> {
     pub fn index_path(&self) -> Vec<usize> {
         self.relative_index_path(self.tree_state.root_id())
     }
@@ -675,71 +631,6 @@ impl<'a> Node<'a> {
             }
         }
         None
-    }
-
-    pub fn state(&self) -> &'a NodeState {
-        self.state
-    }
-}
-
-impl<'a> Deref for Node<'a> {
-    type Target = NodeState;
-
-    fn deref(&self) -> &NodeState {
-        self.state
-    }
-}
-
-#[derive(Clone)]
-pub struct DetachedNode {
-    pub(crate) state: NodeState,
-    pub(crate) is_focused: bool,
-    pub(crate) is_root: bool,
-    pub(crate) name: Option<String>,
-    pub(crate) value: Option<String>,
-    pub(crate) live: Live,
-    pub(crate) supports_text_ranges: bool,
-}
-
-impl DetachedNode {
-    pub fn is_focused(&self) -> bool {
-        self.is_focused
-    }
-
-    pub fn is_root(&self) -> bool {
-        self.is_root
-    }
-
-    pub fn name(&self) -> Option<String> {
-        self.name.clone()
-    }
-
-    pub fn value(&self) -> Option<String> {
-        self.value.clone()
-    }
-
-    pub fn has_value(&self) -> bool {
-        self.value.is_some()
-    }
-
-    pub fn live(&self) -> Live {
-        self.live
-    }
-
-    pub fn supports_text_ranges(&self) -> bool {
-        self.supports_text_ranges
-    }
-
-    pub fn state(&self) -> &NodeState {
-        &self.state
-    }
-}
-
-impl Deref for DetachedNode {
-    type Target = NodeState;
-
-    fn deref(&self) -> &NodeState {
-        &self.state
     }
 }
 

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,36 +3,31 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{Live, Node as NodeData, NodeId, Tree as TreeData, TreeUpdate};
+use accesskit::{Node as NodeData, NodeId, Tree as TreeData, TreeUpdate};
+use immutable_chunkmap::map::MapM as ChunkMap;
 use std::collections::{HashMap, HashSet};
 
-use crate::node::{DetachedNode, Node, NodeState, ParentAndIndex};
+use crate::node::{Node, NodeState, ParentAndIndex};
 
 #[derive(Clone)]
 pub struct State {
-    pub(crate) nodes: HashMap<NodeId, NodeState>,
+    pub(crate) nodes: ChunkMap<NodeId, NodeState>,
     pub(crate) data: TreeData,
     focus: NodeId,
     is_host_focused: bool,
 }
 
-struct InternalFocusChange {
-    old_focus: Option<DetachedNode>,
-    new_focus_old_node: Option<DetachedNode>,
-}
-
 #[derive(Default)]
 struct InternalChanges {
     added_node_ids: HashSet<NodeId>,
-    updated_nodes: HashMap<NodeId, DetachedNode>,
-    focus_change: Option<InternalFocusChange>,
-    removed_nodes: HashMap<NodeId, DetachedNode>,
+    updated_node_ids: HashSet<NodeId>,
+    removed_node_ids: HashSet<NodeId>,
 }
 
 impl State {
     fn validate_global(&self) {
-        assert!(self.nodes.contains_key(&self.data.root));
-        assert!(self.nodes.contains_key(&self.focus));
+        assert!(self.nodes.get(&self.data.root).is_some());
+        assert!(self.nodes.get(&self.focus).is_some());
     }
 
     fn update(
@@ -41,20 +36,17 @@ impl State {
         is_host_focused: bool,
         mut changes: Option<&mut InternalChanges>,
     ) {
-        // First, if we're collecting changes, get the accurate state
-        // of any updated nodes.
+        // First, if we're collecting changes, collect the IDS of any nodes
+        // in the update that were in the previous state.
         if let Some(changes) = &mut changes {
             for (node_id, _) in &update.nodes {
-                if let Some(old_node) = self.node_by_id(*node_id) {
-                    let old_node = old_node.detached();
-                    changes.updated_nodes.insert(*node_id, old_node);
+                if self.nodes.get(node_id).is_some() {
+                    changes.updated_node_ids.insert(*node_id);
                 }
             }
         }
 
         let mut orphans = HashSet::new();
-        let old_focus_id = self.is_host_focused.then_some(self.focus);
-        let old_root_id = self.data.root;
 
         if let Some(tree) = update.tree {
             if tree.root != self.data.root {
@@ -68,18 +60,17 @@ impl State {
         let mut pending_children = HashMap::new();
 
         fn add_node(
-            nodes: &mut HashMap<NodeId, NodeState>,
+            nodes: &mut ChunkMap<NodeId, NodeState>,
             changes: &mut Option<&mut InternalChanges>,
             parent_and_index: Option<ParentAndIndex>,
             id: NodeId,
             data: NodeData,
         ) {
             let state = NodeState {
-                id,
                 parent_and_index,
                 data,
             };
-            nodes.insert(id, state);
+            nodes.insert_cow(id, state);
             if let Some(changes) = changes {
                 changes.added_node_ids.insert(id);
             }
@@ -93,7 +84,7 @@ impl State {
                 assert!(!seen_child_ids.contains(child_id));
                 orphans.remove(child_id);
                 let parent_and_index = ParentAndIndex(node_id, child_index);
-                if let Some(child_state) = self.nodes.get_mut(child_id) {
+                if let Some(child_state) = self.nodes.get_mut_cow(child_id) {
                     if child_state.parent_and_index != Some(parent_and_index) {
                         child_state.parent_and_index = Some(parent_and_index);
                     }
@@ -111,7 +102,7 @@ impl State {
                 seen_child_ids.insert(child_id);
             }
 
-            if let Some(node_state) = self.nodes.get_mut(&node_id) {
+            if let Some(node_state) = self.nodes.get_mut_cow(&node_id) {
                 if node_id == root {
                     node_state.parent_and_index = None;
                 }
@@ -139,29 +130,14 @@ impl State {
         assert_eq!(pending_nodes.len(), 0);
         assert_eq!(pending_children.len(), 0);
 
-        if update.focus != self.focus || is_host_focused != self.is_host_focused {
-            let old_focus = old_focus_id.map(|id| self.node_by_id(id).unwrap().detached());
-            let new_focus = is_host_focused.then_some(update.focus);
-            if let Some(changes) = &mut changes {
-                changes.focus_change = Some(InternalFocusChange {
-                    old_focus,
-                    new_focus_old_node: new_focus
-                        .and_then(|id| {
-                            (!changes.updated_nodes.contains_key(&id))
-                                .then(|| self.node_by_id(id).map(|node| node.detached()))
-                        })
-                        .flatten(),
-                });
-            }
-            self.focus = update.focus;
-            self.is_host_focused = is_host_focused;
-        }
+        self.focus = update.focus;
+        self.is_host_focused = is_host_focused;
 
         if !orphans.is_empty() {
             let mut to_remove = HashSet::new();
 
             fn traverse_orphan(
-                nodes: &HashMap<NodeId, NodeState>,
+                nodes: &ChunkMap<NodeId, NodeState>,
                 to_remove: &mut HashSet<NodeId>,
                 id: NodeId,
             ) {
@@ -177,18 +153,9 @@ impl State {
             }
 
             for id in to_remove {
-                if let Some(old_node_state) = self.nodes.remove(&id) {
+                if self.nodes.remove_cow(&id).is_some() {
                     if let Some(changes) = &mut changes {
-                        let old_node = DetachedNode {
-                            state: old_node_state,
-                            is_focused: old_focus_id == Some(id),
-                            is_root: old_root_id == id,
-                            name: None,
-                            value: None,
-                            live: Live::Off,
-                            supports_text_ranges: false,
-                        };
-                        changes.removed_nodes.insert(id, old_node);
+                        changes.removed_node_ids.insert(id);
                     }
                 }
             }
@@ -233,12 +200,13 @@ impl State {
     }
 
     pub fn has_node(&self, id: NodeId) -> bool {
-        self.nodes.contains_key(&id)
+        self.nodes.get(&id).is_some()
     }
 
     pub fn node_by_id(&self, id: NodeId) -> Option<Node<'_>> {
         self.nodes.get(&id).map(|node_state| Node {
             tree_state: self,
+            id,
             state: node_state,
         })
     }
@@ -274,21 +242,9 @@ impl State {
 
 pub trait ChangeHandler {
     fn node_added(&mut self, node: &Node);
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node);
-    fn focus_moved(
-        &mut self,
-        old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        current_state: &State,
-    );
-    /// The tree update process doesn't currently collect all possible information
-    /// about removed nodes. The following methods don't accurately reflect
-    /// the full state of the old node:
-    ///
-    /// * [`DetachedNode::name`]
-    /// * [`DetachedNode::live`]
-    /// * [`DetachedNode::supports_text_ranges`]
-    fn node_removed(&mut self, node: &DetachedNode, current_state: &State);
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node);
+    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>);
+    fn node_removed(&mut self, node: &Node);
 }
 
 pub struct Tree {
@@ -298,7 +254,7 @@ pub struct Tree {
 impl Tree {
     pub fn new(mut initial_state: TreeUpdate, is_host_focused: bool) -> Self {
         let mut state = State {
-            nodes: HashMap::new(),
+            nodes: ChunkMap::new(),
             data: initial_state.tree.take().unwrap(),
             focus: initial_state.focus,
             is_host_focused,
@@ -317,9 +273,10 @@ impl Tree {
         handler: &mut impl ChangeHandler,
     ) {
         let mut changes = InternalChanges::default();
+        let old_state = self.state.clone();
         self.state
             .update(update, self.state.is_host_focused, Some(&mut changes));
-        self.process_changes(changes, handler);
+        self.process_changes(old_state, changes, handler);
     }
 
     pub fn update_host_focus_state(&mut self, is_host_focused: bool) {
@@ -332,25 +289,33 @@ impl Tree {
         handler: &mut impl ChangeHandler,
     ) {
         let mut changes = InternalChanges::default();
+        let old_state = self.state.clone();
         self.state
             .update_host_focus_state(is_host_focused, Some(&mut changes));
-        self.process_changes(changes, handler);
+        self.process_changes(old_state, changes, handler);
     }
 
-    fn process_changes(&self, changes: InternalChanges, handler: &mut impl ChangeHandler) {
+    fn process_changes(
+        &self,
+        old_state: State,
+        changes: InternalChanges,
+        handler: &mut impl ChangeHandler,
+    ) {
         for id in &changes.added_node_ids {
             let node = self.state.node_by_id(*id).unwrap();
             handler.node_added(&node);
         }
-        for (id, old_node) in &changes.updated_nodes {
+        for id in &changes.updated_node_ids {
+            let old_node = old_state.node_by_id(*id).unwrap();
             let new_node = self.state.node_by_id(*id).unwrap();
-            handler.node_updated(old_node, &new_node);
+            handler.node_updated(&old_node, &new_node);
         }
-        if let Some(focus_change) = changes.focus_change {
-            if let Some(old_node) = &focus_change.old_focus {
+        if old_state.focus_id() != self.state.focus_id() {
+            let old_node = old_state.focus();
+            if let Some(old_node) = &old_node {
                 let id = old_node.id();
-                if !changes.updated_nodes.contains_key(&id)
-                    && !changes.removed_nodes.contains_key(&id)
+                if !changes.updated_node_ids.contains(&id)
+                    && !changes.removed_node_ids.contains(&id)
                 {
                     if let Some(old_node_new_version) = self.state.node_by_id(id) {
                         handler.node_updated(old_node, &old_node_new_version);
@@ -358,23 +323,20 @@ impl Tree {
                 }
             }
             let new_node = self.state.focus();
-            if let Some(new_node) = new_node {
+            if let Some(new_node) = &new_node {
                 let id = new_node.id();
-                if !changes.added_node_ids.contains(&id) && !changes.updated_nodes.contains_key(&id)
+                if !changes.added_node_ids.contains(&id) && !changes.updated_node_ids.contains(&id)
                 {
-                    if let Some(new_node_old_version) = focus_change.new_focus_old_node {
-                        handler.node_updated(&new_node_old_version, &new_node);
+                    if let Some(new_node_old_version) = old_state.node_by_id(id) {
+                        handler.node_updated(&new_node_old_version, new_node);
                     }
                 }
             }
-            handler.focus_moved(
-                focus_change.old_focus.as_ref(),
-                new_node.as_ref(),
-                &self.state,
-            );
+            handler.focus_moved(old_node.as_ref(), new_node.as_ref());
         }
-        for node in changes.removed_nodes.values() {
-            handler.node_removed(node, &self.state);
+        for id in &changes.removed_node_ids {
+            let node = old_state.node_by_id(*id).unwrap();
+            handler.node_removed(&node);
         }
     }
 
@@ -480,7 +442,7 @@ mod tests {
                 }
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::DetachedNode, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NodeId(0)
                     && old_node.data().children().is_empty()
                     && new_node.data().children() == [NodeId(1)]
@@ -492,17 +454,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::DetachedNode>,
+                _old_node: Option<&crate::Node>,
                 _new_node: Option<&crate::Node>,
-                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }
-            fn node_removed(
-                &mut self,
-                _node: &crate::DetachedNode,
-                _current_state: &crate::TreeState,
-            ) {
+            fn node_removed(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
         }
@@ -559,7 +516,7 @@ mod tests {
             fn node_added(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::DetachedNode, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NodeId(0)
                     && old_node.data().children() == [NodeId(1)]
                     && new_node.data().children().is_empty()
@@ -571,17 +528,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::DetachedNode>,
+                _old_node: Option<&crate::Node>,
                 _new_node: Option<&crate::Node>,
-                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }
-            fn node_removed(
-                &mut self,
-                node: &crate::DetachedNode,
-                _current_state: &crate::TreeState,
-            ) {
+            fn node_removed(&mut self, node: &crate::Node) {
                 if node.id() == NodeId(1) {
                     self.got_removed_child_node = true;
                     return;
@@ -641,7 +593,7 @@ mod tests {
             fn node_added(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::DetachedNode, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if old_node.id() == NodeId(1)
                     && new_node.id() == NodeId(1)
                     && old_node.is_focused()
@@ -662,9 +614,8 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                old_node: Option<&crate::DetachedNode>,
+                old_node: Option<&crate::Node>,
                 new_node: Option<&crate::Node>,
-                _current_state: &crate::TreeState,
             ) {
                 if let (Some(old_node), Some(new_node)) = (old_node, new_node) {
                     if old_node.id() == NodeId(1) && new_node.id() == NodeId(2) {
@@ -674,11 +625,7 @@ mod tests {
                 }
                 unexpected_change();
             }
-            fn node_removed(
-                &mut self,
-                _node: &crate::DetachedNode,
-                _current_state: &crate::TreeState,
-            ) {
+            fn node_removed(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
         }
@@ -739,7 +686,7 @@ mod tests {
             fn node_added(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::DetachedNode, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
                 if new_node.id() == NodeId(1)
                     && old_node.name() == Some("foo".into())
                     && new_node.name() == Some("bar".into())
@@ -751,17 +698,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::DetachedNode>,
+                _old_node: Option<&crate::Node>,
                 _new_node: Option<&crate::Node>,
-                _current_state: &crate::TreeState,
             ) {
                 unexpected_change();
             }
-            fn node_removed(
-                &mut self,
-                _node: &crate::DetachedNode,
-                _current_state: &crate::TreeState,
-            ) {
+            fn node_removed(&mut self, _node: &crate::Node) {
                 unexpected_change();
             }
         }

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, NodeId, Role, TreeUpdate};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler, TreeState};
 use atspi_common::{InterfaceSet, Live, State};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -13,7 +13,7 @@ use std::sync::{
 
 use crate::{
     context::{AppContext, Context},
-    filters::{filter, filter_detached},
+    filters::filter,
     node::{NodeIdOrRoot, NodeWrapper, PlatformNode, PlatformRoot},
     util::WindowBounds,
     AdapterCallback, Event, ObjectEvent, WindowEvent,
@@ -27,7 +27,7 @@ impl AdapterChangeHandler<'_> {
     fn add_node(&mut self, node: &Node) {
         let role = node.role();
         let is_root = node.is_root();
-        let node = NodeWrapper::Node(node);
+        let node = NodeWrapper(node);
         let interfaces = node.interfaces();
         self.adapter.register_interfaces(node.id(), interfaces);
         if is_root && role == Role::Window {
@@ -49,10 +49,10 @@ impl AdapterChangeHandler<'_> {
         }
     }
 
-    fn remove_node(&mut self, node: &DetachedNode) {
+    fn remove_node(&mut self, node: &Node) {
         let role = node.role();
         let is_root = node.is_root();
-        let node = NodeWrapper::DetachedNode(node);
+        let node = NodeWrapper(node);
         if is_root && role == Role::Window {
             self.adapter.window_destroyed(node.id());
         }
@@ -70,8 +70,8 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
-        let filter_old = filter_detached(old_node);
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+        let filter_old = filter(old_node);
         let filter_new = filter(new_node);
         if filter_new != filter_old {
             if filter_new == FilterResult::Include {
@@ -80,8 +80,8 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                 self.remove_node(old_node);
             }
         } else if filter_new == FilterResult::Include {
-            let old_wrapper = NodeWrapper::DetachedNode(old_node);
-            let new_wrapper = NodeWrapper::Node(new_node);
+            let old_wrapper = NodeWrapper(old_node);
+            let new_wrapper = NodeWrapper(new_node);
             let old_interfaces = old_wrapper.interfaces();
             let new_interfaces = new_wrapper.interfaces();
             let kept_interfaces = old_interfaces & new_interfaces;
@@ -94,25 +94,20 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        current_state: &TreeState,
-    ) {
-        if let Some(root_window) = root_window(current_state) {
-            if old_node.is_none() && new_node.is_some() {
-                self.adapter
-                    .window_activated(&NodeWrapper::Node(&root_window));
-            } else if old_node.is_some() && new_node.is_none() {
-                self.adapter
-                    .window_deactivated(&NodeWrapper::Node(&root_window));
+    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>) {
+        if let (None, Some(new_node)) = (old_node, new_node) {
+            if let Some(root_window) = root_window(new_node.tree_state) {
+                self.adapter.window_activated(&NodeWrapper(&root_window));
+            }
+        } else if let (Some(old_node), None) = (old_node, new_node) {
+            if let Some(root_window) = root_window(old_node.tree_state) {
+                self.adapter.window_deactivated(&NodeWrapper(&root_window));
             }
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, _: &TreeState) {
-        if filter_detached(node) == FilterResult::Include {
+    fn node_removed(&mut self, node: &Node) {
+        if filter(node) == FilterResult::Include {
             self.remove_node(node);
         }
     }
@@ -186,7 +181,7 @@ impl Adapter {
         fn add_children(node: Node<'_>, to_add: &mut Vec<(NodeId, InterfaceSet)>) {
             for child in node.filtered_children(&filter) {
                 let child_id = child.id();
-                let wrapper = NodeWrapper::Node(&child);
+                let wrapper = NodeWrapper(&child);
                 let interfaces = wrapper.interfaces();
                 to_add.push((child_id, interfaces));
                 add_children(child, to_add);
@@ -205,7 +200,7 @@ impl Adapter {
             let adapter_index = app_context.adapter_index(self.id).unwrap();
             let root = tree_state.root();
             let root_id = root.id();
-            let wrapper = NodeWrapper::Node(&root);
+            let wrapper = NodeWrapper(&root);
             objects_to_add.push((root_id, wrapper.interfaces()));
             add_children(root, &mut objects_to_add);
             (adapter_index, root_id)

--- a/platforms/atspi-common/src/filters.rs
+++ b/platforms/atspi-common/src/filters.rs
@@ -3,6 +3,4 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-};
+pub(crate) use accesskit_consumer::common_filter as filter;

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -12,7 +12,7 @@ use accesskit::{
     Action, ActionData, ActionRequest, Affine, Checked, DefaultActionVerb, Live, NodeId, Point,
     Rect, Role,
 };
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
+use accesskit_consumer::{FilterResult, Node, TreeState};
 use atspi_common::{
     CoordType, Interface, InterfaceSet, Layer, Live as AtspiLive, Role as AtspiRole, State,
     StateSet,
@@ -26,29 +26,16 @@ use std::{
 use crate::{
     adapter::Adapter,
     context::{AppContext, Context},
-    filters::{filter, filter_detached},
+    filters::filter,
     util::WindowBounds,
     Action as AtspiAction, Error, ObjectEvent, Property, Rect as AtspiRect, Result,
 };
 
-pub(crate) enum NodeWrapper<'a> {
-    Node(&'a Node<'a>),
-    DetachedNode(&'a DetachedNode),
-}
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
 
 impl<'a> NodeWrapper<'a> {
-    fn node_state(&self) -> &NodeState {
-        match self {
-            Self::Node(node) => node.state(),
-            Self::DetachedNode(node) => node.state(),
-        }
-    }
-
     pub fn name(&self) -> Option<String> {
-        match self {
-            Self::Node(node) => node.name(),
-            Self::DetachedNode(node) => node.name(),
-        }
+        self.0.name()
     }
 
     pub fn description(&self) -> String {
@@ -56,11 +43,11 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub fn parent_id(&self) -> Option<NodeId> {
-        self.node_state().parent_id()
+        self.0.parent_id()
     }
 
     pub fn id(&self) -> NodeId {
-        self.node_state().id()
+        self.0.id()
     }
 
     fn child_ids(
@@ -69,24 +56,21 @@ impl<'a> NodeWrapper<'a> {
            + ExactSizeIterator<Item = NodeId>
            + FusedIterator<Item = NodeId>
            + '_ {
-        self.node_state().child_ids()
+        self.0.child_ids()
     }
 
     fn filtered_child_ids(
         &self,
     ) -> impl DoubleEndedIterator<Item = NodeId> + FusedIterator<Item = NodeId> + '_ {
-        match self {
-            Self::Node(node) => node.filtered_children(&filter).map(|child| child.id()),
-            _ => unreachable!(),
-        }
+        self.0.filtered_children(&filter).map(|child| child.id())
     }
 
     pub fn role(&self) -> AtspiRole {
-        if self.node_state().has_role_description() {
+        if self.0.has_role_description() {
             return AtspiRole::Extended;
         }
 
-        match self.node_state().role() {
+        match self.0.role() {
             Role::Alert => AtspiRole::Notification,
             Role::AlertDialog => AtspiRole::Alert,
             Role::Comment | Role::Suggestion => AtspiRole::Section,
@@ -200,7 +184,6 @@ impl<'a> NodeWrapper<'a> {
             // only if it still has non-ignored descendants, which happens only when =>
             // - The list marker itself is ignored but the descendants are not
             // - Or the list marker contains images
-            // TODO: How to check for unignored children when the node is detached?
             Role::ListMarker => AtspiRole::Static,
             Role::Log => AtspiRole::Log,
             Role::Main => AtspiRole::Landmark,
@@ -297,14 +280,11 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn is_focused(&self) -> bool {
-        match self {
-            Self::Node(node) => node.is_focused(),
-            Self::DetachedNode(node) => node.is_focused(),
-        }
+        self.0.is_focused()
     }
 
     pub fn state(&self, is_window_focused: bool) -> StateSet {
-        let state = self.node_state();
+        let state = self.0;
         let atspi_role = self.role();
         let mut atspi_state = StateSet::empty();
         if state.parent_id().is_none() && state.role() == Role::Window && is_window_focused {
@@ -314,10 +294,7 @@ impl<'a> NodeWrapper<'a> {
         if state.is_focusable() {
             atspi_state.insert(State::Focusable);
         }
-        let filter_result = match self {
-            Self::Node(node) => filter(node),
-            Self::DetachedNode(node) => filter_detached(node),
-        };
+        let filter_result = filter(self.0);
         if filter_result == FilterResult::Include {
             atspi_state.insert(State::Visible | State::Showing);
         }
@@ -369,18 +346,15 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn is_root(&self) -> bool {
-        match self {
-            Self::Node(node) => node.is_root(),
-            Self::DetachedNode(node) => node.is_root(),
-        }
+        self.0.is_root()
     }
 
     fn supports_action(&self) -> bool {
-        self.node_state().default_action_verb().is_some()
+        self.0.default_action_verb().is_some()
     }
 
     fn supports_component(&self) -> bool {
-        self.node_state().raw_bounds().is_some() || self.is_root()
+        self.0.raw_bounds().is_some() || self.is_root()
     }
 
     fn supports_value(&self) -> bool {
@@ -402,10 +376,7 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub(crate) fn live(&self) -> AtspiLive {
-        let live = match self {
-            Self::Node(node) => node.live(),
-            Self::DetachedNode(node) => node.live(),
-        };
+        let live = self.0.live();
         match live {
             Live::Off => AtspiLive::None,
             Live::Polite => AtspiLive::Polite,
@@ -414,7 +385,7 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn n_actions(&self) -> i32 {
-        match self.node_state().default_action_verb() {
+        match self.0.default_action_verb() {
             Some(_) => 1,
             None => 0,
         }
@@ -424,7 +395,7 @@ impl<'a> NodeWrapper<'a> {
         if index != 0 {
             return String::new();
         }
-        String::from(match self.node_state().default_action_verb() {
+        String::from(match self.0.default_action_verb() {
             Some(DefaultActionVerb::Click) => "click",
             Some(DefaultActionVerb::Focus) => "focus",
             Some(DefaultActionVerb::Check) => "check",
@@ -440,7 +411,7 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn raw_bounds_and_transform(&self) -> (Option<Rect>, Affine) {
-        let state = self.node_state();
+        let state = self.0;
         (state.raw_bounds(), state.direct_transform())
     }
 
@@ -448,25 +419,22 @@ impl<'a> NodeWrapper<'a> {
         if self.is_root() {
             return window_bounds.outer.into();
         }
-        match self {
-            Self::Node(node) => node.bounding_box().map_or_else(
-                || AtspiRect::INVALID,
-                |bounds| {
-                    let window_top_left = window_bounds.inner.origin();
-                    let node_origin = bounds.origin();
-                    let new_origin = Point::new(
-                        window_top_left.x + node_origin.x,
-                        window_top_left.y + node_origin.y,
-                    );
-                    bounds.with_origin(new_origin).into()
-                },
-            ),
-            _ => unreachable!(),
-        }
+        self.0.bounding_box().map_or_else(
+            || AtspiRect::INVALID,
+            |bounds| {
+                let window_top_left = window_bounds.inner.origin();
+                let node_origin = bounds.origin();
+                let new_origin = Point::new(
+                    window_top_left.x + node_origin.x,
+                    window_top_left.y + node_origin.y,
+                );
+                bounds.with_origin(new_origin).into()
+            },
+        )
     }
 
     fn current_value(&self) -> Option<f64> {
-        self.node_state().numeric_value()
+        self.0.numeric_value()
     }
 
     pub(crate) fn notify_changes(
@@ -516,11 +484,8 @@ impl<'a> NodeWrapper<'a> {
         }
         let parent_id = self.parent_id();
         if parent_id != old.parent_id() {
-            let node = match self {
-                NodeWrapper::Node(node) => node,
-                _ => unreachable!(),
-            };
-            let parent = node
+            let parent = self
+                .0
                 .filtered_parent(&filter)
                 .map_or(NodeIdOrRoot::Root, |node| NodeIdOrRoot::Node(node.id()));
             adapter.emit_object_event(
@@ -660,14 +625,14 @@ impl PlatformNode {
 
     pub fn name(&self) -> Result<String> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.name().unwrap_or_default())
         })
     }
 
     pub fn description(&self) -> Result<String> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.description())
         })
     }
@@ -750,18 +715,18 @@ impl PlatformNode {
 
     pub fn role(&self) -> Result<AtspiRole> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.role())
         })
     }
 
     pub fn localized_role_name(&self) -> Result<String> {
-        self.resolve(|node| Ok(node.state().role_description().unwrap_or_default()))
+        self.resolve(|node| Ok(node.role_description().unwrap_or_default()))
     }
 
     pub fn state(&self) -> StateSet {
         self.resolve_with_context(|node, context| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.state(context.read_tree().state().focus_id().is_some()))
         })
         .unwrap_or(State::Defunct.into())
@@ -769,49 +734,49 @@ impl PlatformNode {
 
     pub fn supports_action(&self) -> Result<bool> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.supports_action())
         })
     }
 
     pub fn supports_component(&self) -> Result<bool> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.supports_component())
         })
     }
 
     pub fn supports_value(&self) -> Result<bool> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.supports_value())
         })
     }
 
     pub fn interfaces(&self) -> Result<InterfaceSet> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.interfaces())
         })
     }
 
     pub fn n_actions(&self) -> Result<i32> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.n_actions())
         })
     }
 
     pub fn action_name(&self, index: i32) -> Result<String> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.get_action_name(index))
         })
     }
 
     pub fn actions(&self) -> Result<Vec<AtspiAction>> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             let n_actions = wrapper.n_actions() as usize;
             let mut actions = Vec::with_capacity(n_actions);
             for i in 0..n_actions {
@@ -901,7 +866,7 @@ impl PlatformNode {
 
     pub fn layer(&self) -> Result<Layer> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             if wrapper.role() == AtspiRole::Window {
                 Ok(Layer::Window)
             } else {
@@ -935,20 +900,20 @@ impl PlatformNode {
     }
 
     pub fn minimum_value(&self) -> Result<f64> {
-        self.resolve(|node| Ok(node.state().min_numeric_value().unwrap_or(std::f64::MIN)))
+        self.resolve(|node| Ok(node.min_numeric_value().unwrap_or(std::f64::MIN)))
     }
 
     pub fn maximum_value(&self) -> Result<f64> {
-        self.resolve(|node| Ok(node.state().max_numeric_value().unwrap_or(std::f64::MAX)))
+        self.resolve(|node| Ok(node.max_numeric_value().unwrap_or(std::f64::MAX)))
     }
 
     pub fn minimum_increment(&self) -> Result<f64> {
-        self.resolve(|node| Ok(node.state().numeric_value_step().unwrap_or(0.0)))
+        self.resolve(|node| Ok(node.numeric_value_step().unwrap_or(0.0)))
     }
 
     pub fn current_value(&self) -> Result<f64> {
         self.resolve(|node| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             Ok(wrapper.current_value().unwrap_or(0.0))
         })
     }

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Live, NodeId, Role};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, TreeChangeHandler};
 use icrate::{
     AppKit::*,
     Foundation::{NSMutableDictionary, NSNumber, NSString},
@@ -12,11 +12,7 @@ use icrate::{
 use objc2::runtime::{AnyObject, ProtocolObject};
 use std::{collections::HashSet, rc::Rc};
 
-use crate::{
-    context::Context,
-    filters::{filter, filter_detached},
-    node::NodeWrapper,
-};
+use crate::{context::Context, filters::filter, node::NodeWrapper};
 
 // This type is designed to be safe to create on a non-main thread
 // and send to the main thread. This ability isn't yet used though.
@@ -179,18 +175,12 @@ impl EventGenerator {
         }
     }
 
-    fn insert_text_change_if_needed_for_removed_node(
-        &mut self,
-        node: &DetachedNode,
-        current_state: &TreeState,
-    ) {
+    fn insert_text_change_if_needed_for_removed_node(&mut self, node: &Node) {
         if node.role() != Role::InlineTextBox {
             return;
         }
-        if let Some(id) = node.parent_id() {
-            if let Some(node) = current_state.node_by_id(id) {
-                self.insert_text_change_if_needed_parent(node);
-            }
+        if let Some(parent) = node.parent() {
+            self.insert_text_change_if_needed_parent(parent);
         }
     }
 }
@@ -207,7 +197,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -215,8 +205,8 @@ impl TreeChangeHandler for EventGenerator {
             return;
         }
         let node_id = new_node.id();
-        let old_wrapper = NodeWrapper::DetachedNode(old_node);
-        let new_wrapper = NodeWrapper::Node(new_node);
+        let old_wrapper = NodeWrapper(old_node);
+        let new_wrapper = NodeWrapper(new_node);
         if old_wrapper.title() != new_wrapper.title() {
             self.events.push(QueuedEvent::Generic {
                 node_id,
@@ -242,19 +232,14 @@ impl TreeChangeHandler for EventGenerator {
             && new_node.live() != Live::Off
             && (new_node.name() != old_node.name()
                 || new_node.live() != old_node.live()
-                || filter_detached(old_node) != FilterResult::Include)
+                || filter(old_node) != FilterResult::Include)
         {
             self.events
                 .push(QueuedEvent::live_region_announcement(new_node));
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        _old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        _current_state: &TreeState,
-    ) {
+    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
         if let Some(new_node) = new_node {
             if filter(new_node) != FilterResult::Include {
                 return;
@@ -266,8 +251,8 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
-        self.insert_text_change_if_needed_for_removed_node(node, current_state);
+    fn node_removed(&mut self, node: &Node) {
+        self.insert_text_change_if_needed_for_removed_node(node);
         self.events.push(QueuedEvent::NodeDestroyed(node.id()));
     }
 }

--- a/platforms/macos/src/filters.rs
+++ b/platforms/macos/src/filters.rs
@@ -3,6 +3,4 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-};
+pub(crate) use accesskit_consumer::common_filter as filter;

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -11,7 +11,7 @@
 #![allow(non_upper_case_globals)]
 
 use accesskit::{Action, ActionData, ActionRequest, Checked, NodeId, Role, TextSelection};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState};
+use accesskit_consumer::{FilterResult, Node};
 use icrate::{
     AppKit::*,
     Foundation::{
@@ -30,8 +30,8 @@ use std::rc::{Rc, Weak};
 
 use crate::{context::Context, filters::filter, util::*};
 
-fn ns_role(node_state: &NodeState) -> &'static NSAccessibilityRole {
-    let role = node_state.role();
+fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
+    let role = node.role();
     // TODO: Handle special cases.
     unsafe {
         match role {
@@ -239,43 +239,24 @@ pub(crate) enum Value {
     String(String),
 }
 
-pub(crate) enum NodeWrapper<'a> {
-    Node(&'a Node<'a>),
-    DetachedNode(&'a DetachedNode),
-}
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
 
 impl<'a> NodeWrapper<'a> {
-    fn node_state(&self) -> &'a NodeState {
-        match self {
-            Self::Node(node) => node.state(),
-            Self::DetachedNode(node) => node.state(),
-        }
-    }
-
     fn is_root(&self) -> bool {
-        match self {
-            Self::Node(node) => node.is_root(),
-            Self::DetachedNode(node) => node.is_root(),
-        }
+        self.0.is_root()
     }
 
     fn name(&self) -> Option<String> {
-        if self.is_root() && self.node_state().role() == Role::Window {
+        if self.is_root() && self.0.role() == Role::Window {
             // If the group element that we expose for the top-level window
             // includes a title, VoiceOver behavior is broken.
             return None;
         }
-        match self {
-            Self::Node(node) => node.name(),
-            Self::DetachedNode(node) => node.name(),
-        }
+        self.0.name()
     }
 
     fn node_value(&self) -> Option<String> {
-        match self {
-            Self::Node(node) => node.value(),
-            Self::DetachedNode(node) => node.value(),
-        }
+        self.0.value()
     }
 
     // TODO: implement proper logic for title, description, and value;
@@ -283,7 +264,7 @@ impl<'a> NodeWrapper<'a> {
     // and figure out how this is different in the macOS 10.10+ protocol
 
     pub(crate) fn title(&self) -> Option<String> {
-        let state = self.node_state();
+        let state = self.0;
         if state.role() == Role::StaticText && state.raw_value().is_none() {
             // In this case, macOS wants the text to be the value, not title.
             return None;
@@ -292,7 +273,7 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub(crate) fn value(&self) -> Option<Value> {
-        let state = self.node_state();
+        let state = self.0;
         if let Some(checked) = state.checked() {
             return Some(Value::Bool(checked != Checked::False));
         }
@@ -311,14 +292,11 @@ impl<'a> NodeWrapper<'a> {
     }
 
     pub(crate) fn supports_text_ranges(&self) -> bool {
-        match self {
-            Self::Node(node) => node.supports_text_ranges(),
-            Self::DetachedNode(node) => node.supports_text_ranges(),
-        }
+        self.0.supports_text_ranges()
     }
 
     pub(crate) fn raw_text_selection(&self) -> Option<&TextSelection> {
-        self.node_state().raw_text_selection()
+        self.0.raw_text_selection()
     }
 }
 
@@ -394,7 +372,7 @@ declare_class!(
 
         #[method_id(accessibilityRole)]
         fn role(&self) -> Id<NSAccessibilityRole> {
-            self.resolve(|node| ns_role(node.state()))
+            self.resolve(ns_role)
                 .unwrap_or(unsafe { NSAccessibilityUnknownRole })
                 .copy()
         }
@@ -414,7 +392,7 @@ declare_class!(
         #[method_id(accessibilityTitle)]
         fn title(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
-                let wrapper = NodeWrapper::Node(node);
+                let wrapper = NodeWrapper(node);
                 wrapper.title().map(|title| NSString::from_str(&title))
             })
             .flatten()
@@ -423,7 +401,7 @@ declare_class!(
         #[method_id(accessibilityValue)]
         fn value(&self) -> Option<Id<NSObject>> {
             self.resolve(|node| {
-                let wrapper = NodeWrapper::Node(node);
+                let wrapper = NodeWrapper(node);
                 wrapper.value().map(|value| match value {
                     Value::Bool(value) => {
                         Id::into_super(Id::into_super(NSNumber::new_bool(value)))

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, Live, NodeId, Role, TreeUpdate};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
 use std::{collections::HashSet, sync::Arc};
 use windows::Win32::{
     Foundation::*,
@@ -13,7 +13,7 @@ use windows::Win32::{
 
 use crate::{
     context::Context,
-    filters::{filter, filter_detached},
+    filters::filter,
     init::UiaInitMarker,
     node::{NodeWrapper, PlatformNode},
     util::QueuedEvent,
@@ -58,18 +58,12 @@ impl AdapterChangeHandler<'_> {
         }
     }
 
-    fn insert_text_change_if_needed_for_removed_node(
-        &mut self,
-        node: &DetachedNode,
-        current_state: &TreeState,
-    ) {
+    fn insert_text_change_if_needed_for_removed_node(&mut self, node: &Node) {
         if node.role() != Role::InlineTextBox {
             return;
         }
-        if let Some(id) = node.parent_id() {
-            if let Some(node) = current_state.node_by_id(id) {
-                self.insert_text_change_if_needed_parent(node);
-            }
+        if let Some(parent) = node.parent() {
+            self.insert_text_change_if_needed_parent(parent);
         }
     }
 }
@@ -90,7 +84,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -99,14 +93,14 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
         let platform_node = PlatformNode::new(self.context, new_node.id());
         let element: IRawElementProviderSimple = platform_node.into();
-        let old_wrapper = NodeWrapper::DetachedNode(old_node);
-        let new_wrapper = NodeWrapper::Node(new_node);
+        let old_wrapper = NodeWrapper(old_node);
+        let new_wrapper = NodeWrapper(new_node);
         new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
         if new_node.name().is_some()
             && new_node.live() != Live::Off
             && (new_node.name() != old_node.name()
                 || new_node.live() != old_node.live()
-                || filter_detached(old_node) != FilterResult::Include)
+                || filter(old_node) != FilterResult::Include)
         {
             self.queue.push(QueuedEvent::Simple {
                 element,
@@ -115,12 +109,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        _old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        _current_state: &TreeState,
-    ) {
+    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
         if let Some(new_node) = new_node {
             let platform_node = PlatformNode::new(self.context, new_node.id());
             let element: IRawElementProviderSimple = platform_node.into();
@@ -131,8 +120,8 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
-        self.insert_text_change_if_needed_for_removed_node(node, current_state);
+    fn node_removed(&mut self, node: &Node) {
+        self.insert_text_change_if_needed_for_removed_node(node);
     }
 
     // TODO: handle other events (#20)

--- a/platforms/windows/src/filters.rs
+++ b/platforms/windows/src/filters.rs
@@ -4,6 +4,5 @@
 // the LICENSE-MIT file), at your option.
 
 pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-    common_filter_with_root_exception as filter_with_root_exception,
+    common_filter as filter, common_filter_with_root_exception as filter_with_root_exception,
 };

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -13,7 +13,7 @@
 use accesskit::{
     Action, ActionData, ActionRequest, Checked, Live, NodeId, NodeIdContent, Point, Role,
 };
-use accesskit_consumer::{DetachedNode, FilterResult, Node, NodeState, TreeState};
+use accesskit_consumer::{FilterResult, Node, TreeState};
 use paste::paste;
 use std::sync::{Arc, Weak};
 use windows::{
@@ -27,7 +27,7 @@ use windows::{
 
 use crate::{
     context::Context,
-    filters::{filter, filter_detached, filter_with_root_exception},
+    filters::{filter, filter_with_root_exception},
     text::PlatformRange as PlatformTextRange,
     util::*,
 };
@@ -44,21 +44,11 @@ fn runtime_id_from_node_id(id: NodeId) -> [i32; RUNTIME_ID_SIZE] {
     ]
 }
 
-pub(crate) enum NodeWrapper<'a> {
-    Node(&'a Node<'a>),
-    DetachedNode(&'a DetachedNode),
-}
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
 
 impl<'a> NodeWrapper<'a> {
-    fn node_state(&self) -> &'a NodeState {
-        match self {
-            Self::Node(node) => node.state(),
-            Self::DetachedNode(node) => node.state(),
-        }
-    }
-
     fn control_type(&self) -> UIA_CONTROLTYPE_ID {
-        let role = self.node_state().role();
+        let role = self.0.role();
         // TODO: Handle special cases. (#14)
         match role {
             Role::Unknown => UIA_CustomControlTypeId,
@@ -271,44 +261,31 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn localized_control_type(&self) -> Option<String> {
-        self.node_state().role_description()
+        self.0.role_description()
     }
 
     fn name(&self) -> Option<String> {
-        match self {
-            Self::Node(node) => node.name(),
-            Self::DetachedNode(node) => node.name(),
-        }
+        self.0.name()
     }
 
     fn is_content_element(&self) -> bool {
-        let result = match self {
-            Self::Node(node) => filter(node),
-            Self::DetachedNode(node) => filter_detached(node),
-        };
-        result == FilterResult::Include
+        filter(self.0) == FilterResult::Include
     }
 
     fn is_enabled(&self) -> bool {
-        !self.node_state().is_disabled()
+        !self.0.is_disabled()
     }
 
     fn is_focusable(&self) -> bool {
-        self.node_state().is_focusable()
+        self.0.is_focusable()
     }
 
     fn is_focused(&self) -> bool {
-        match self {
-            Self::Node(node) => node.is_focused(),
-            Self::DetachedNode(node) => node.is_focused(),
-        }
+        self.0.is_focused()
     }
 
     fn live_setting(&self) -> LiveSetting {
-        let live = match self {
-            Self::Node(node) => node.live(),
-            Self::DetachedNode(node) => node.live(),
-        };
+        let live = self.0.live();
         match live {
             Live::Off => Off,
             Live::Polite => Polite,
@@ -317,11 +294,11 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn is_toggle_pattern_supported(&self) -> bool {
-        self.node_state().checked().is_some() && !self.is_selection_item_pattern_supported()
+        self.0.checked().is_some() && !self.is_selection_item_pattern_supported()
     }
 
     fn toggle_state(&self) -> ToggleState {
-        match self.node_state().checked().unwrap() {
+        match self.0.checked().unwrap() {
             Checked::False => ToggleState_Off,
             Checked::True => ToggleState_On,
             Checked::Mixed => ToggleState_Indeterminate,
@@ -329,94 +306,82 @@ impl<'a> NodeWrapper<'a> {
     }
 
     fn is_invoke_pattern_supported(&self) -> bool {
-        self.node_state().is_invocable()
+        self.0.is_invocable()
     }
 
     fn is_value_pattern_supported(&self) -> bool {
-        match self {
-            Self::Node(node) => node.has_value(),
-            Self::DetachedNode(node) => node.has_value(),
-        }
+        self.0.has_value()
     }
 
     fn is_range_value_pattern_supported(&self) -> bool {
-        self.node_state().numeric_value().is_some()
+        self.0.numeric_value().is_some()
     }
 
     fn value(&self) -> String {
-        match self {
-            Self::Node(node) => node.value().unwrap(),
-            Self::DetachedNode(node) => node.value().unwrap(),
-        }
+        self.0.value().unwrap()
     }
 
     fn is_read_only(&self) -> bool {
-        self.node_state().is_read_only()
+        self.0.is_read_only()
     }
 
     fn numeric_value(&self) -> f64 {
-        self.node_state().numeric_value().unwrap()
+        self.0.numeric_value().unwrap()
     }
 
     fn min_numeric_value(&self) -> f64 {
-        self.node_state().min_numeric_value().unwrap_or(0.0)
+        self.0.min_numeric_value().unwrap_or(0.0)
     }
 
     fn max_numeric_value(&self) -> f64 {
-        self.node_state().max_numeric_value().unwrap_or(0.0)
+        self.0.max_numeric_value().unwrap_or(0.0)
     }
 
     fn numeric_value_step(&self) -> f64 {
-        self.node_state().numeric_value_step().unwrap_or(0.0)
+        self.0.numeric_value_step().unwrap_or(0.0)
     }
 
     fn numeric_value_jump(&self) -> f64 {
-        self.node_state()
+        self.0
             .numeric_value_jump()
             .unwrap_or_else(|| self.numeric_value_step())
     }
 
     fn is_selection_item_pattern_supported(&self) -> bool {
-        match self.node_state().role() {
+        match self.0.role() {
             // TODO: tables (#29)
             // https://www.w3.org/TR/core-aam-1.1/#mapping_state-property_table
             // SelectionItem.IsSelected is exposed when aria-checked is True or
             // False, for 'radio' and 'menuitemradio' roles.
-            Role::RadioButton | Role::MenuItemRadio => matches!(
-                self.node_state().checked(),
-                Some(Checked::True | Checked::False)
-            ),
+            Role::RadioButton | Role::MenuItemRadio => {
+                matches!(self.0.checked(), Some(Checked::True | Checked::False))
+            }
             // https://www.w3.org/TR/wai-aria-1.1/#aria-selected
             // SelectionItem.IsSelected is exposed when aria-select is True or False.
             Role::ListBoxOption
             | Role::ListItem
             | Role::MenuListOption
             | Role::Tab
-            | Role::TreeItem => self.node_state().is_selected().is_some(),
+            | Role::TreeItem => self.0.is_selected().is_some(),
             _ => false,
         }
     }
 
     fn is_selected(&self) -> bool {
-        match self.node_state().role() {
+        match self.0.role() {
             // https://www.w3.org/TR/core-aam-1.1/#mapping_state-property_table
             // SelectionItem.IsSelected is set according to the True or False
             // value of aria-checked for 'radio' and 'menuitemradio' roles.
-            Role::RadioButton | Role::MenuItemRadio => {
-                self.node_state().checked() == Some(Checked::True)
-            }
+            Role::RadioButton | Role::MenuItemRadio => self.0.checked() == Some(Checked::True),
             // https://www.w3.org/TR/wai-aria-1.1/#aria-selected
             // SelectionItem.IsSelected is set according to the True or False
             // value of aria-selected.
-            _ => self.node_state().is_selected().unwrap_or(false),
+            _ => self.0.is_selected().unwrap_or(false),
         }
     }
 
     fn is_text_pattern_supported(&self) -> bool {
-        match self {
-            Self::Node(node) => node.supports_text_ranges(),
-            Self::DetachedNode(node) => node.supports_text_ranges(),
-        }
+        self.0.supports_text_ranges()
     }
 
     pub(crate) fn enqueue_property_changes(
@@ -447,7 +412,7 @@ impl<'a> NodeWrapper<'a> {
         }
         if self.is_text_pattern_supported()
             && old.is_text_pattern_supported()
-            && self.node_state().raw_text_selection() != old.node_state().raw_text_selection()
+            && self.0.raw_text_selection() != old.0.raw_text_selection()
         {
             queue.push(QueuedEvent::Simple {
                 element: element.clone(),
@@ -619,7 +584,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
 
     fn GetPropertyValue(&self, property_id: UIA_PROPERTY_ID) -> Result<VARIANT> {
         self.resolve_with_tree_state_and_context(|node, state, context| {
-            let wrapper = NodeWrapper::Node(&node);
+            let wrapper = NodeWrapper(&node);
             let mut result = wrapper.get_property_value(property_id);
             if result.is_empty() {
                 if node.is_root() {
@@ -792,7 +757,7 @@ macro_rules! patterns {
         impl PlatformNode {
             fn pattern_provider(&self, pattern_id: UIA_PATTERN_ID) -> Result<IUnknown> {
                 self.resolve(|node| {
-                    let wrapper = NodeWrapper::Node(&node);
+                    let wrapper = NodeWrapper(&node);
                     match pattern_id {
                         $(paste! { [< UIA_ $base_pattern_id PatternId>] } => {
                             if wrapper.$is_supported() {
@@ -837,7 +802,7 @@ macro_rules! patterns {
             impl [< I $base_pattern_id Provider_Impl>] for PlatformNode {
                 $(fn $base_property_id(&self) -> Result<$com_type> {
                     self.resolve(|node| {
-                        let wrapper = NodeWrapper::Node(&node);
+                        let wrapper = NodeWrapper(&node);
                         Ok(wrapper.$getter().into())
                     })
                 })*


### PR DESCRIPTION
To avoid semver-breaking version increases on the adapter crates, I think we'll have to split this into two PRs: one for the changes to `accesskit_consumer`, and the other for the changes to the adapters. This will require us to merge the first PR with broken CI, and briefly break the main branch. But I can't think of a better way.