### PR TITLE
fix: Expose root node ID in `accesskit_atspi_common::Adapter`

### DIFF
--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -223,6 +223,10 @@ impl Adapter {
         PlatformNode::new(&self.context, self.id, id)
     }
 
+    pub fn root_id(&self) -> NodeId {
+        self.context.read_tree().state().root_id()
+    }
+
     pub fn platform_root(&self) -> PlatformRoot {
         PlatformRoot::new(&self.context.app_context)
     }


### PR DESCRIPTION
I need this in my `newton_atspi_compat` crate so I can create a `PlatformNode` from the window root outside of the AT-SPI event handler._