### PR TITLE
fix: Update `windows` to `0.54`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,9 +2377,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
 dependencies = [
  "windows-core",
  "windows-implement",
@@ -2389,18 +2389,19 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
+ "windows-result",
  "windows-targets 0.52.3",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2409,13 +2410,22 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.32",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd19df78e5168dfb0aedc343d1d1b8d422ab2db6756d2dc3fef75035402a3f64"
+dependencies = [
+ "windows-targets 0.52.3",
 ]
 
 [[package]]

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -19,7 +19,7 @@ paste = "1.0"
 static_assertions = "1.1.0"
 
 [dependencies.windows]
-version = "0.52"
+version = "0.54"
 features = [
     "implement",
     "Win32_Foundation",

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -296,8 +296,8 @@ impl QueuedEvents {
                         UiaRaiseAutomationPropertyChangedEvent(
                             &element,
                             property_id,
-                            old_value,
-                            new_value,
+                            &old_value,
+                            &new_value,
                         )
                     }
                     .unwrap();

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -18,11 +18,7 @@ use paste::paste;
 use std::sync::{Arc, Weak};
 use windows::{
     core::*,
-    Win32::{
-        Foundation::*,
-        System::{Com::*, Variant::*},
-        UI::Accessibility::*,
-    },
+    Win32::{Foundation::*, System::Com::*, UI::Accessibility::*},
 };
 
 use crate::{
@@ -461,8 +457,8 @@ impl<'a> NodeWrapper<'a> {
         queue: &mut Vec<QueuedEvent>,
         element: &IRawElementProviderSimple,
         property_id: UIA_PROPERTY_ID,
-        old_value: VariantFactory,
-        new_value: VariantFactory,
+        old_value: Variant,
+        new_value: Variant,
     ) {
         let old_value: VARIANT = old_value.into();
         let new_value: VARIANT = new_value.into();
@@ -650,7 +646,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode {
             if self.node_id == state.root_id() {
                 unsafe { UiaHostProviderFromHwnd(context.hwnd) }
             } else {
-                Err(Error::OK)
+                Err(Error::empty())
             }
         })
     }
@@ -672,7 +668,7 @@ impl IRawElementProviderFragment_Impl for PlatformNode {
             };
             match result {
                 Some(result) => Ok(self.relative(result.id()).into()),
-                None => Err(Error::OK),
+                None => Err(Error::empty()),
             }
         })
     }
@@ -730,7 +726,7 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
             let point = Point::new(x - client_top_left.x, y - client_top_left.y);
             let point = node.transform().inverse() * point;
             node.node_at_point(point, &filter).map_or_else(
-                || Err(Error::OK),
+                || Err(Error::empty()),
                 |node| Ok(self.relative(node.id()).into()),
             )
         })
@@ -743,7 +739,7 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
                     return Ok(self.relative(id).into());
                 }
             }
-            Err(Error::OK)
+            Err(Error::empty())
         })
     }
 }
@@ -751,12 +747,12 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode {
 macro_rules! properties {
     ($(($base_id:ident, $m:ident)),+) => {
         impl NodeWrapper<'_> {
-            fn get_property_value(&self, property_id: UIA_PROPERTY_ID) -> VariantFactory {
+            fn get_property_value(&self, property_id: UIA_PROPERTY_ID) -> Variant {
                 match property_id {
                     $(paste! { [< UIA_ $base_id PropertyId>] } => {
                         self.$m().into()
                     })*
-                    _ => VariantFactory::empty()
+                    _ => Variant::empty()
                 }
             }
             fn enqueue_simple_property_changes(
@@ -804,7 +800,7 @@ macro_rules! patterns {
                         })*
                         _ => (),
                     }
-                    Err(Error::OK)
+                    Err(Error::empty())
                 })
             }
         }
@@ -926,7 +922,7 @@ patterns! {
             // TODO: implement when we work on list boxes (#23)
             // We return E_FAIL here because that's what Chromium does
             // if it can't find a container.
-            Err(Error::new(E_FAIL, "".into()))
+            Err(E_FAIL.into())
         }
     )),
     (Text, is_text_pattern_supported, (), (

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -158,10 +158,10 @@ fn navigation() -> Result<()> {
         assert!(equal);
 
         let wrapped_child = unsafe { walker.GetFirstChildElement(&button_1_forward) };
-        assert_eq!(Err(Error::OK), wrapped_child);
+        assert_eq!(Err(Error::empty()), wrapped_child);
 
         let wrapped_child = unsafe { walker.GetLastChildElement(&button_1_forward) };
-        assert_eq!(Err(Error::OK), wrapped_child);
+        assert_eq!(Err(Error::empty()), wrapped_child);
 
         Ok(())
     })

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -12,11 +12,7 @@ use accesskit_consumer::{
 use std::sync::{Arc, RwLock, Weak};
 use windows::{
     core::*,
-    Win32::{
-        Foundation::*,
-        System::{Com::*, Variant::*},
-        UI::Accessibility::*,
-    },
+    Win32::{Foundation::*, System::Com::*, UI::Accessibility::*},
 };
 
 use crate::{context::Context, node::PlatformNode, util::*};
@@ -411,7 +407,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
     ) -> Result<ITextRangeProvider> {
         // TODO: implement when we support variable formatting (part of rich text)
         // Justification: JUCE doesn't implement this.
-        Err(Error::OK)
+        Err(Error::empty())
     }
 
     fn FindText(
@@ -423,7 +419,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
         // TODO: implement when there's a real-world use case that requires it
         // Justification: Quorum doesn't implement this and is being used
         // by blind students.
-        Err(Error::OK)
+        Err(Error::empty())
     }
 
     fn GetAttributeValue(&self, id: UIA_TEXTATTRIBUTE_ID) -> Result<VARIANT> {
@@ -432,7 +428,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
                 // TBD: do we ever want to support mixed read-only/editable text?
                 self.with_node(|node| {
                     let value = node.is_read_only();
-                    Ok(VariantFactory::from(value).into())
+                    Ok(value.into())
                 })
             }
             UIA_CaretPositionAttributeId => self.read(|range| {
@@ -445,12 +441,12 @@ impl ITextRangeProvider_Impl for PlatformRange {
                         value = CaretPosition_EndOfLine;
                     }
                 }
-                Ok(VariantFactory::from(value).into())
+                Ok(value.0.into())
             }),
             // TODO: implement more attributes
             _ => {
                 let value = unsafe { UiaGetReservedNotSupportedValue() }.unwrap();
-                Ok(VariantFactory::from(value).into())
+                Ok(value.into())
             }
         }
     }

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -165,11 +165,11 @@ pub(crate) fn required_param<T>(param: Option<&T>) -> Result<&T> {
 }
 
 pub(crate) fn element_not_available() -> Error {
-    HRESULT::from_win32(UIA_E_ELEMENTNOTAVAILABLE).into()
+    HRESULT(UIA_E_ELEMENTNOTAVAILABLE as _).into()
 }
 
 pub(crate) fn invalid_operation() -> Error {
-    HRESULT::from_win32(UIA_E_INVALIDOPERATION).into()
+    HRESULT(UIA_E_INVALIDOPERATION as _).into()
 }
 
 pub(crate) fn client_top_left(hwnd: HWND) -> Point {


### PR DESCRIPTION
The major highlight of this PR is that `VariantFactory` is replaced by a simpler `Variant` newtype. The `VARIANT` type from the `windows` crate is used directly whenever possible.
