### PR TITLE
fix: Fix new compiler warning in Rust 1.77

### DIFF
--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -33,7 +33,7 @@ static SUBCLASSES: SyncLazy<Mutex<HashMap<&'static AnyClass, &'static AnyClass>>
 static mut ASSOCIATED_OBJECT_KEY: u8 = 0;
 
 fn associated_object_key() -> *const c_void {
-    unsafe { &ASSOCIATED_OBJECT_KEY as *const u8 as *const _ }
+    unsafe { std::ptr::addr_of_mut!(ASSOCIATED_OBJECT_KEY) as *const u8 as *const _ }
 }
 
 type LazyAdapter = Lazy<Adapter, Box<dyn FnOnce() -> Adapter>>;

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -33,7 +33,7 @@ static SUBCLASSES: SyncLazy<Mutex<HashMap<&'static AnyClass, &'static AnyClass>>
 static mut ASSOCIATED_OBJECT_KEY: u8 = 0;
 
 fn associated_object_key() -> *const c_void {
-    unsafe { std::ptr::addr_of_mut!(ASSOCIATED_OBJECT_KEY) as *const u8 as *const _ }
+    unsafe { std::ptr::addr_of!(ASSOCIATED_OBJECT_KEY).cast() }
 }
 
 type LazyAdapter = Lazy<Adapter, Box<dyn FnOnce() -> Adapter>>;

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -32,7 +32,7 @@ static SUBCLASSES: SyncLazy<Mutex<HashMap<&'static AnyClass, &'static AnyClass>>
 static ASSOCIATED_OBJECT_KEY: u8 = 0;
 
 fn associated_object_key() -> *const c_void {
-    std::ptr::addr_of!(ASSOCIATED_OBJECT_KEY).cast()
+    (&ASSOCIATED_OBJECT_KEY as *const u8).cast()
 }
 
 type LazyAdapter = Lazy<Adapter, Box<dyn FnOnce() -> Adapter>>;

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -29,11 +29,10 @@ use crate::{event::QueuedEvents, Adapter};
 static SUBCLASSES: SyncLazy<Mutex<HashMap<&'static AnyClass, &'static AnyClass>>> =
     SyncLazy::new(|| Mutex::new(HashMap::new()));
 
-// Declare as mutable to ensure the address is unique.
-static mut ASSOCIATED_OBJECT_KEY: u8 = 0;
+static ASSOCIATED_OBJECT_KEY: u8 = 0;
 
 fn associated_object_key() -> *const c_void {
-    unsafe { std::ptr::addr_of!(ASSOCIATED_OBJECT_KEY).cast() }
+    std::ptr::addr_of!(ASSOCIATED_OBJECT_KEY).cast()
 }
 
 type LazyAdapter = Lazy<Adapter, Box<dyn FnOnce() -> Adapter>>;


### PR DESCRIPTION
The compiler is now issuing a warning about taking a reference to a mutable static; this will become a hard error in the 2024 edition.