### PR TITLE
fix: Set INTERFACE_INCLUDE_DIRECTORIES in CMake config

### DIFF
--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -16,12 +16,6 @@ You can then require AccessKit as a dependency by adding this to your `CMakeList
 find_package(ACCESSKIT REQUIRED)
 ```
 
-The headers can be added like so:
-
-```cmake
-include_directories(YourProject ${ACCESSKIT_INCLUDE_DIR})
-```
-
 Finally, link the library to your executable:
 
 ```cmake

--- a/bindings/c/accesskit-config.cmake
+++ b/bindings/c/accesskit-config.cmake
@@ -8,6 +8,10 @@ set_property(
     TARGET accesskit-static
     PROPERTY IMPORTED_LOCATION "${_accesskit_static_lib}"
 )
+set_property(
+    TARGET accesskit-static
+    PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${ACCESSKIT_INCLUDE_DIR}"
+)
 if (_accesskit_os STREQUAL "macos")
     target_link_libraries(accesskit-static INTERFACE "-framework AppKit" "-framework Foundation" "-framework CoreFoundation" objc c++)
 elseif (_accesskit_os STREQUAL "linux")
@@ -34,6 +38,10 @@ endif()
 set_property(
     TARGET accesskit-shared
     PROPERTY IMPORTED_LOCATION "${ACCESSKIT_LIBRARIES_DIR}/shared/${_accesskit_shared_lib}"
+)
+set_property(
+    TARGET accesskit-shared
+    PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${ACCESSKIT_INCLUDE_DIR}"
 )
 
 if (BUILD_SHARED_LIBS)

--- a/bindings/c/examples/sdl/CMakeLists.txt
+++ b/bindings/c/examples/sdl/CMakeLists.txt
@@ -5,7 +5,6 @@ project(sdl_example)
 find_package(SDL2 REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS})
 find_package(ACCESSKIT REQUIRED)
-include_directories(windows_example ${ACCESSKIT_INCLUDE_DIR})
 
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PUBLIC ${SDL2_LIBRARIES})

--- a/bindings/c/examples/windows/CMakeLists.txt
+++ b/bindings/c/examples/windows/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.20)
 project(windows_example)
 
 find_package(ACCESSKIT REQUIRED)
-include_directories(windows_example ${ACCESSKIT_INCLUDE_DIR})
 
 add_executable(hello_world hello_world.c)
 target_link_libraries(hello_world PUBLIC accesskit)


### PR DESCRIPTION
The Meson build system needs this in order to find the header file. I encountered this problem while working on integrating AccessKit into GTK. Our current build system may not work for distro packagers, but this fix at least lets me make progress on that project, and may also help other users.