### PR TITLE
feat: Implement the `description` property

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -51,6 +51,7 @@ impl<'a> Node<'a> {
             is_focused: self.is_focused(),
             is_root: self.is_root(),
             name: self.name(),
+            description: self.description(),
             value: self.value(),
             live: self.live(),
             supports_text_ranges: self.supports_text_ranges(),
@@ -541,6 +542,12 @@ impl<'a> Node<'a> {
         }
     }
 
+    pub fn description(&self) -> Option<String> {
+        self.data()
+            .description()
+            .map(|description| description.to_string())
+    }
+
     pub fn value(&self) -> Option<String> {
         if let Some(value) = &self.data().value() {
             Some(value.to_string())
@@ -696,6 +703,7 @@ pub struct DetachedNode {
     pub(crate) is_focused: bool,
     pub(crate) is_root: bool,
     pub(crate) name: Option<String>,
+    pub(crate) description: Option<String>,
     pub(crate) value: Option<String>,
     pub(crate) live: Live,
     pub(crate) supports_text_ranges: bool,
@@ -712,6 +720,10 @@ impl DetachedNode {
 
     pub fn name(&self) -> Option<String> {
         self.name.clone()
+    }
+
+    pub fn description(&self) -> Option<String> {
+        self.description.clone()
     }
 
     pub fn value(&self) -> Option<String> {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -184,6 +184,7 @@ impl State {
                             is_focused: old_focus_id == Some(id),
                             is_root: old_root_id == id,
                             name: None,
+                            description: None,
                             value: None,
                             live: Live::Off,
                             supports_text_ranges: false,

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -51,8 +51,11 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
-    pub fn description(&self) -> String {
-        String::new()
+    pub fn description(&self) -> Option<String> {
+        match self {
+            Self::Node(node) => node.description(),
+            Self::DetachedNode(node) => node.description(),
+        }
     }
 
     pub fn parent_id(&self) -> Option<NodeId> {
@@ -511,7 +514,9 @@ impl<'a> NodeWrapper<'a> {
         if description != old.description() {
             adapter.emit_object_event(
                 self.id(),
-                ObjectEvent::PropertyChanged(Property::Description(description)),
+                ObjectEvent::PropertyChanged(Property::Description(
+                    description.unwrap_or_default(),
+                )),
             );
         }
         let parent_id = self.parent_id();
@@ -668,7 +673,7 @@ impl PlatformNode {
     pub fn description(&self) -> Result<String> {
         self.resolve(|node| {
             let wrapper = NodeWrapper::Node(&node);
-            Ok(wrapper.description())
+            Ok(wrapper.description().unwrap_or_default())
         })
     }
 

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -51,7 +51,7 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
-    pub fn description(&self) -> Option<String> {
+    pub(crate) fn description(&self) -> Option<String> {
         match self {
             Self::Node(node) => node.description(),
             Self::DetachedNode(node) => node.description(),

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -278,7 +278,7 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
-    // TODO: implement proper logic for title, description, and value;
+    // TODO: implement proper logic for title and value;
     // see Chromium's content/browser/accessibility/browser_accessibility_cocoa.mm
     // and figure out how this is different in the macOS 10.10+ protocol
 
@@ -289,6 +289,13 @@ impl<'a> NodeWrapper<'a> {
             return None;
         }
         self.name()
+    }
+
+    pub(crate) fn description(&self) -> Option<String> {
+        match self {
+            Self::Node(node) => node.description(),
+            Self::DetachedNode(node) => node.description(),
+        }
     }
 
     pub(crate) fn value(&self) -> Option<Value> {
@@ -416,6 +423,15 @@ declare_class!(
             self.resolve(|node| {
                 let wrapper = NodeWrapper::Node(node);
                 wrapper.title().map(|title| NSString::from_str(&title))
+            })
+            .flatten()
+        }
+
+        #[method_id(accessibilityHelp)]
+        fn description(&self) -> Option<Id<NSString>> {
+            self.resolve(|node| {
+                let wrapper = NodeWrapper::Node(node);
+                wrapper.description().map(|description| NSString::from_str(&description))
             })
             .flatten()
         }
@@ -758,6 +774,7 @@ declare_class!(
                     || selector == sel!(accessibilityRole)
                     || selector == sel!(accessibilityRoleDescription)
                     || selector == sel!(accessibilityTitle)
+                    || selector == sel!(accessibilityHelp)
                     || selector == sel!(accessibilityValue)
                     || selector == sel!(accessibilityMinValue)
                     || selector == sel!(accessibilityMaxValue)

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -277,6 +277,13 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn description(&self) -> Option<String> {
+        match self {
+            Self::Node(node) => node.description(),
+            Self::DetachedNode(node) => node.description(),
+        }
+    }
+
     fn is_content_element(&self) -> bool {
         let result = match self {
             Self::Node(node) => filter(node),
@@ -847,6 +854,7 @@ properties! {
     (ControlType, control_type),
     (LocalizedControlType, localized_control_type),
     (Name, name),
+    (FullDescription, description),
     (IsContentElement, is_content_element),
     (IsControlElement, is_content_element),
     (IsEnabled, is_enabled),


### PR DESCRIPTION
I know at least Slint implements it.

There is apparently no corresponding event to fire on macOS. Also on this platform: Chromium includes it in live region updates, but we don't do that on other platforms so this must be a Chromium specific thing.

Tested on all platforms by modifying the winit example like so:

```rust
fn build_button(id: NodeId, name: &str, classes: &mut NodeClassSet) -> Node {
    let rect = match id {
        BUTTON_1_ID => BUTTON_1_RECT,
        BUTTON_2_ID => BUTTON_2_RECT,
        _ => unreachable!(),
    };

    let mut builder = NodeBuilder::new(Role::Button);
    builder.set_bounds(rect);
    builder.set_name(name);
    builder.set_description("Announces that this button was pressed.");
    builder.add_action(Action::Focus);
    builder.set_default_action_verb(DefaultActionVerb::Click);
    builder.build(classes)
}
```