### PR TITLE
feat: Expose the class name property

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -622,6 +622,10 @@ impl NodeState {
     pub fn raw_value(&self) -> Option<&str> {
         self.data().value()
     }
+
+    pub fn class_name(&self) -> Option<&str> {
+        self.data().class_name()
+    }
 }
 
 impl<'a> Node<'a> {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -312,6 +312,10 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn class_name(&self) -> Option<&str> {
+        self.node_state().class_name()
+    }
+
     fn is_toggle_pattern_supported(&self) -> bool {
         self.node_state().checked().is_some() && !self.is_selection_item_pattern_supported()
     }
@@ -852,7 +856,8 @@ properties! {
     (IsEnabled, is_enabled),
     (IsKeyboardFocusable, is_focusable),
     (HasKeyboardFocus, is_focused),
-    (LiveSetting, live_setting)
+    (LiveSetting, live_setting),
+    (ClassName, class_name)
 }
 
 patterns! {


### PR DESCRIPTION
As far as I know, only UIA on Windows has such a property. But this simple feature is helping me debug my GTK AccessKit integration, since it makes it easy to find the GTK class of any accessible object, e.g. via NVDA+F1.