### PR TITLE
feat: Add new `AuthorControlledParent` role

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -113,6 +113,16 @@ pub enum Role {
     Application,
     Article,
     Audio,
+    /// This role is for cases where a specialized widget, such as a menu
+    /// button, merely serves as a parent for a more generic widget, such as
+    /// a toggle button, which is the actual focusable widget, but the parent
+    /// widget is the one where the application developer sets the essential
+    /// name and description properties, or their corresponding relations.
+    /// When this role is used, this node is filtered out of the platform
+    /// accessibility tree, but the child inherits this node's name and
+    /// description (or their corresponding relations) if it doesn't
+    /// already have them set.
+    AuthorControlledParent,
     Banner,
     Blockquote,
     Canvas,

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -20,7 +20,10 @@ fn common_filter_base(node: &NodeState) -> FilterResult {
     }
 
     let role = node.role();
-    if role == Role::GenericContainer || role == Role::InlineTextBox {
+    if matches!(
+        role,
+        Role::AuthorControlledParent | Role::GenericContainer | Role::InlineTextBox
+    ) {
         return FilterResult::ExcludeNode;
     }
 

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -167,6 +167,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Form => AtspiRole::Form,
             Role::Figure | Role::Feed => AtspiRole::Panel,
             Role::GenericContainer
+            | Role::AuthorControlledParent
             | Role::FooterAsNonLandmark
             | Role::HeaderAsNonLandmark
             | Role::Ruby => AtspiRole::Section,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -85,6 +85,7 @@ fn ns_role(node_state: &NodeState) -> &'static NSAccessibilityRole {
             Role::Application => NSAccessibilityGroupRole,
             Role::Article => NSAccessibilityGroupRole,
             Role::Audio => NSAccessibilityGroupRole,
+            Role::AuthorControlledParent => NSAccessibilityUnknownRole,
             Role::Banner => NSAccessibilityGroupRole,
             Role::Blockquote => NSAccessibilityGroupRole,
             Role::Canvas => NSAccessibilityImageRole,

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -114,6 +114,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Application => UIA_PaneControlTypeId,
             Role::Article => UIA_GroupControlTypeId,
             Role::Audio => UIA_GroupControlTypeId,
+            Role::AuthorControlledParent => UIA_GroupControlTypeId,
             Role::Banner => UIA_GroupControlTypeId,
             Role::Blockquote => UIA_GroupControlTypeId,
             Role::Canvas => UIA_ImageControlTypeId,


### PR DESCRIPTION
This role, and the associated logic in `accesskit_consumer`, is meant to handle a pattern I'm seeing in GTK, and which is probably common in other object-oriented toolkits with a one-to-one correspondence between widgets and accessibility nodes. In GTK, there are some widget classes like `GtkMenuButton` that are essentially wrappers around a more generic widget like `GtkToggleButton`. In these cases, the more generic widget is the one that's actually focusable, and the wrapper ought to be filtered out of the platform accessibility tree. But the wrapper is the one that's actually created by the application developer, and is the place where they can set properties like the accessibility name and description. GTK's accessibility implementation currently has special-case logic for pulling the name and description from the parent for these specific widgets, but I think this is a general pattern that's worth codifying in AccessKit. I wrote test cases to verify that the logic I had in mind is actually implemented. This does make `accesskit_consumer::Node::labelled_by` more complicated, but in general, I think we should be willing to make the consumer more complicated in order to simplify toolkit implementations.