### PR TITLE
refactor!: Drop `NodeClassSet`

### DIFF
--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -25,8 +25,7 @@ const accesskit_rect BUTTON_2_RECT = {20.0, 60.0, 100.0, 100.0};
 const Sint32 SET_FOCUS_MSG = 0;
 const Sint32 DO_DEFAULT_ACTION_MSG = 1;
 
-accesskit_node *build_button(accesskit_node_id id, const char *name,
-                             accesskit_node_class_set *classes) {
+accesskit_node *build_button(accesskit_node_id id, const char *name) {
   accesskit_rect rect;
   if (id == BUTTON_1_ID) {
     rect = BUTTON_1_RECT;
@@ -41,16 +40,15 @@ accesskit_node *build_button(accesskit_node_id id, const char *name,
   accesskit_node_builder_add_action(builder, ACCESSKIT_ACTION_FOCUS);
   accesskit_node_builder_set_default_action_verb(
       builder, ACCESSKIT_DEFAULT_ACTION_VERB_CLICK);
-  return accesskit_node_builder_build(builder, classes);
+  return accesskit_node_builder_build(builder);
 }
 
-accesskit_node *build_announcement(const char *text,
-                                   accesskit_node_class_set *classes) {
+accesskit_node *build_announcement(const char *text) {
   accesskit_node_builder *builder =
       accesskit_node_builder_new(ACCESSKIT_ROLE_STATIC_TEXT);
   accesskit_node_builder_set_name(builder, text);
   accesskit_node_builder_set_live(builder, ACCESSKIT_LIVE_POLITE);
-  return accesskit_node_builder_build(builder, classes);
+  return accesskit_node_builder_build(builder);
 }
 
 struct accesskit_sdl_adapter {
@@ -165,19 +163,16 @@ void accesskit_sdl_adapter_update_root_window_bounds(
 struct window_state {
   accesskit_node_id focus;
   const char *announcement;
-  accesskit_node_class_set *node_classes;
   SDL_mutex *mutex;
 };
 
 void window_state_init(struct window_state *state) {
   state->focus = INITIAL_FOCUS;
   state->announcement = NULL;
-  state->node_classes = accesskit_node_class_set_new();
   state->mutex = SDL_CreateMutex();
 }
 
 void window_state_destroy(struct window_state *state) {
-  accesskit_node_class_set_free(state->node_classes);
   SDL_DestroyMutex(state->mutex);
 }
 
@@ -198,16 +193,14 @@ accesskit_node *window_state_build_root(const struct window_state *state) {
     accesskit_node_builder_push_child(builder, ANNOUNCEMENT_ID);
   }
   accesskit_node_builder_set_name(builder, WINDOW_TITLE);
-  return accesskit_node_builder_build(builder, state->node_classes);
+  return accesskit_node_builder_build(builder);
 }
 
 accesskit_tree_update *window_state_build_initial_tree(
     const struct window_state *state) {
   accesskit_node *root = window_state_build_root(state);
-  accesskit_node *button_1 =
-      build_button(BUTTON_1_ID, "Button 1", state->node_classes);
-  accesskit_node *button_2 =
-      build_button(BUTTON_2_ID, "Button 2", state->node_classes);
+  accesskit_node *button_1 = build_button(BUTTON_1_ID, "Button 1");
+  accesskit_node *button_2 = build_button(BUTTON_2_ID, "Button 2");
   accesskit_tree_update *result = accesskit_tree_update_with_capacity_and_focus(
       (state->announcement != NULL) ? 4 : 3, state->focus);
   accesskit_tree *tree = accesskit_tree_new(WINDOW_ID);
@@ -217,8 +210,7 @@ accesskit_tree_update *window_state_build_initial_tree(
   accesskit_tree_update_push_node(result, BUTTON_1_ID, button_1);
   accesskit_tree_update_push_node(result, BUTTON_2_ID, button_2);
   if (state->announcement != NULL) {
-    accesskit_node *announcement =
-        build_announcement(state->announcement, state->node_classes);
+    accesskit_node *announcement = build_announcement(state->announcement);
     accesskit_tree_update_push_node(result, ANNOUNCEMENT_ID, announcement);
   }
   return result;
@@ -226,8 +218,7 @@ accesskit_tree_update *window_state_build_initial_tree(
 
 accesskit_tree_update *build_tree_update_for_button_press(void *userdata) {
   struct window_state *state = userdata;
-  accesskit_node *announcement =
-      build_announcement(state->announcement, state->node_classes);
+  accesskit_node *announcement = build_announcement(state->announcement);
   accesskit_node *root = window_state_build_root(state);
   accesskit_tree_update *update =
       accesskit_tree_update_with_capacity_and_focus(2, state->focus);

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -13,29 +13,6 @@ use std::{
     ptr, slice,
 };
 
-pub struct node_class_set {
-    _private: [u8; 0],
-}
-
-impl CastPtr for node_class_set {
-    type RustType = NodeClassSet;
-}
-
-impl BoxCastPtr for node_class_set {}
-
-impl node_class_set {
-    #[no_mangle]
-    pub extern "C" fn accesskit_node_class_set_new() -> *mut node_class_set {
-        let set = NodeClassSet::new();
-        BoxCastPtr::to_mut_ptr(set)
-    }
-
-    #[no_mangle]
-    pub extern "C" fn accesskit_node_class_set_free(set: *mut node_class_set) {
-        drop(box_from_ptr(set));
-    }
-}
-
 pub struct node {
     _private: [u8; 0],
 }
@@ -832,13 +809,9 @@ impl node_builder {
 
     /// Converts an `accesskit_node_builder` to an `accesskit_node`, freeing the memory in the process.
     #[no_mangle]
-    pub extern "C" fn accesskit_node_builder_build(
-        builder: *mut node_builder,
-        classes: *mut node_class_set,
-    ) -> *mut node {
+    pub extern "C" fn accesskit_node_builder_build(builder: *mut node_builder) -> *mut node {
         let builder = box_from_ptr(builder);
-        let classes = mut_from_ptr(classes);
-        let node = builder.build(classes);
+        let node = builder.build();
         BoxCastPtr::to_mut_ptr(node)
     }
 

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -46,8 +46,8 @@ pub use unix::*;
 #[cfg(any(target_os = "windows", feature = "cbindgen"))]
 pub use windows::*;
 
-/// `CastPtr` represents the relationship between a snake case type (like `node_class_set`)
-/// and the corresponding Rust type (like `NodeClassSet`). For each matched pair of types, there
+/// `CastPtr` represents the relationship between a snake case type (like `node_builder`)
+/// and the corresponding Rust type (like `NodeBuilder`). For each matched pair of types, there
 /// should be an `impl CastPtr for foo_bar { RustType = FooBar }`.
 ///
 /// This allows us to avoid using `as` in most places, and ensure that when we cast, we're

--- a/bindings/python/examples/pygame/hello_world.py
+++ b/bindings/python/examples/pygame/hello_world.py
@@ -24,20 +24,20 @@ SET_FOCUS_MSG = 0
 DO_DEFAULT_ACTION_MSG = 1
 
 
-def build_button(id, name, classes):
+def build_button(id, name):
     builder = accesskit.NodeBuilder(accesskit.Role.BUTTON)
     builder.set_bounds(BUTTON_1_RECT if id == BUTTON_1_ID else BUTTON_2_RECT)
     builder.set_name(name)
     builder.add_action(accesskit.Action.FOCUS)
     builder.set_default_action_verb(accesskit.DefaultActionVerb.CLICK)
-    return builder.build(classes)
+    return builder.build()
 
 
-def build_announcement(text, classes):
+def build_announcement(text):
     builder = accesskit.NodeBuilder(accesskit.Role.STATIC_TEXT)
     builder.set_name(text)
     builder.set_live(accesskit.Live.POLITE)
-    return builder.build(classes)
+    return builder.build()
 
 
 class PygameAdapter:
@@ -76,7 +76,6 @@ class WindowState:
     def __init__(self):
         self.focus = INITIAL_FOCUS
         self.announcement = None
-        self.node_classes = accesskit.NodeClassSet()
 
     def build_root(self):
         builder = accesskit.NodeBuilder(accesskit.Role.WINDOW)
@@ -84,12 +83,12 @@ class WindowState:
         if self.announcement is not None:
             builder.push_child(ANNOUNCEMENT_ID)
         builder.set_name(WINDOW_TITLE)
-        return builder.build(self.node_classes)
+        return builder.build()
 
     def build_initial_tree(self):
         root = self.build_root()
-        button_1 = build_button(BUTTON_1_ID, "Button 1", self.node_classes)
-        button_2 = build_button(BUTTON_2_ID, "Button 2", self.node_classes)
+        button_1 = build_button(BUTTON_1_ID, "Button 1")
+        button_2 = build_button(BUTTON_2_ID, "Button 2")
         result = accesskit.TreeUpdate(self.focus)
         tree = accesskit.Tree(WINDOW_ID)
         tree.app_name = "Hello world"
@@ -101,7 +100,7 @@ class WindowState:
             result.nodes.append(
                 (
                     ANNOUNCEMENT_ID,
-                    build_announcement(self.announcement, self.node_classes),
+                    build_announcement(self.announcement),
                 )
             )
         return result
@@ -114,9 +113,7 @@ class WindowState:
 
     def build_tree_update_for_button_press(self):
         update = accesskit.TreeUpdate(self.focus)
-        update.nodes.append(
-            (ANNOUNCEMENT_ID, build_announcement(self.announcement, self.node_classes))
-        )
+        update.nodes.append((ANNOUNCEMENT_ID, build_announcement(self.announcement)))
         update.nodes.append((WINDOW_ID, self.build_root()))
         return update
 

--- a/bindings/python/src/common.rs
+++ b/bindings/python/src/common.rs
@@ -6,17 +6,6 @@
 use crate::{Point, Rect};
 use pyo3::{prelude::*, types::PyList};
 
-#[pyclass(module = "accesskit")]
-pub struct NodeClassSet(accesskit::NodeClassSet);
-
-#[pymethods]
-impl NodeClassSet {
-    #[new]
-    pub fn __new__() -> Self {
-        Self(accesskit::NodeClassSet::new())
-    }
-}
-
 #[derive(Clone)]
 #[pyclass(module = "accesskit")]
 pub struct Node(accesskit::Node);
@@ -68,9 +57,9 @@ impl NodeBuilder {
         Self(Some(accesskit::NodeBuilder::new(role)))
     }
 
-    pub fn build(&mut self, classes: &mut NodeClassSet) -> Node {
+    pub fn build(&mut self) -> Node {
         let builder = self.0.take().unwrap();
-        Node(builder.build(&mut classes.0))
+        Node(builder.build())
     }
 
     #[getter]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -41,7 +41,6 @@ fn accesskit(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<::accesskit::TextAlign>()?;
     m.add_class::<::accesskit::VerticalOffset>()?;
     m.add_class::<::accesskit::TextDecoration>()?;
-    m.add_class::<NodeClassSet>()?;
     m.add_class::<Node>()?;
     m.add_class::<NodeBuilder>()?;
     m.add_class::<Tree>()?;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -22,7 +22,6 @@ use serde::{
     ser::{SerializeMap, SerializeSeq, Serializer},
     Deserialize, Serialize,
 };
-use std::sync::Arc;
 #[cfg(feature = "serde")]
 use std::{fmt, mem::size_of_val};
 
@@ -980,7 +979,7 @@ struct NodeClass {
 pub struct Node {
     class: NodeClass,
     flags: u32,
-    props: Arc<[PropertyValue]>,
+    props: Box<[PropertyValue]>,
 }
 
 /// Builds a [`Node`].
@@ -1333,7 +1332,7 @@ impl NodeBuilder {
         Node {
             class: self.class,
             flags: self.flags,
-            props: self.props.into(),
+            props: self.props.into_boxed_slice(),
         }
     }
 }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -24,9 +24,7 @@ pub use text::{
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{
-        Affine, NodeBuilder, NodeClassSet, NodeId, Rect, Role, Tree, TreeUpdate, Vec2,
-    };
+    use accesskit::{Affine, NodeBuilder, NodeId, Rect, Role, Tree, TreeUpdate, Vec2};
 
     use crate::FilterResult;
 
@@ -45,7 +43,6 @@ mod tests {
     pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId = NodeId(12);
 
     pub fn test_tree() -> crate::tree::Tree {
-        let mut classes = NodeClassSet::new();
         let root = {
             let mut builder = NodeBuilder::new(Role::RootWebArea);
             builder.set_children(vec![
@@ -54,17 +51,17 @@ mod tests {
                 PARAGRAPH_2_ID,
                 PARAGRAPH_3_IGNORED_ID,
             ]);
-            builder.build(&mut classes)
+            builder.build()
         };
         let paragraph_0 = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
             builder.set_children(vec![STATIC_TEXT_0_0_IGNORED_ID]);
-            builder.build(&mut classes)
+            builder.build()
         };
         let static_text_0_0_ignored = {
             let mut builder = NodeBuilder::new(Role::StaticText);
             builder.set_name("static_text_0_0_ignored");
-            builder.build(&mut classes)
+            builder.build()
         };
         let paragraph_1_ignored = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
@@ -76,7 +73,7 @@ mod tests {
                 y1: 40.0,
             });
             builder.set_children(vec![STATIC_TEXT_1_0_ID]);
-            builder.build(&mut classes)
+            builder.build()
         };
         let static_text_1_0 = {
             let mut builder = NodeBuilder::new(Role::StaticText);
@@ -87,17 +84,17 @@ mod tests {
                 y1: 30.0,
             });
             builder.set_name("static_text_1_0");
-            builder.build(&mut classes)
+            builder.build()
         };
         let paragraph_2 = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
             builder.set_children(vec![STATIC_TEXT_2_0_ID]);
-            builder.build(&mut classes)
+            builder.build()
         };
         let static_text_2_0 = {
             let mut builder = NodeBuilder::new(Role::StaticText);
             builder.set_name("static_text_2_0");
-            builder.build(&mut classes)
+            builder.build()
         };
         let paragraph_3_ignored = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
@@ -107,28 +104,26 @@ mod tests {
                 BUTTON_3_2_ID,
                 EMPTY_CONTAINER_3_3_IGNORED_ID,
             ]);
-            builder.build(&mut classes)
+            builder.build()
         };
-        let empty_container_3_0_ignored =
-            NodeBuilder::new(Role::GenericContainer).build(&mut classes);
+        let empty_container_3_0_ignored = NodeBuilder::new(Role::GenericContainer).build();
         let link_3_1_ignored = {
             let mut builder = NodeBuilder::new(Role::Link);
             builder.set_children(vec![STATIC_TEXT_3_1_0_ID]);
             builder.set_linked();
-            builder.build(&mut classes)
+            builder.build()
         };
         let static_text_3_1_0 = {
             let mut builder = NodeBuilder::new(Role::StaticText);
             builder.set_name("static_text_3_1_0");
-            builder.build(&mut classes)
+            builder.build()
         };
         let button_3_2 = {
             let mut builder = NodeBuilder::new(Role::Button);
             builder.set_name("button_3_2");
-            builder.build(&mut classes)
+            builder.build()
         };
-        let empty_container_3_3_ignored =
-            NodeBuilder::new(Role::GenericContainer).build(&mut classes);
+        let empty_container_3_3_ignored = NodeBuilder::new(Role::GenericContainer).build();
         let initial_update = TreeUpdate {
             nodes: vec![
                 (ROOT_ID, root),

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use std::{iter::FusedIterator, ops::Deref};
+use std::{iter::FusedIterator, ops::Deref, sync::Arc};
 
 use accesskit::{
     Action, Affine, DefaultActionVerb, Live, Node as NodeData, NodeId, Point, Rect, Role,
@@ -29,7 +29,7 @@ pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);
 pub struct NodeState {
     pub(crate) id: NodeId,
     pub(crate) parent_and_index: Option<ParentAndIndex>,
-    pub(crate) data: NodeData,
+    pub(crate) data: Arc<NodeData>,
 }
 
 #[derive(Copy, Clone)]

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -756,7 +756,7 @@ impl Deref for DetachedNode {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{NodeBuilder, NodeClassSet, NodeId, Point, Rect, Role, Tree, TreeUpdate};
+    use accesskit::{NodeBuilder, NodeId, Point, Rect, Role, Tree, TreeUpdate};
 
     use crate::tests::*;
 
@@ -1019,18 +1019,14 @@ mod tests {
 
     #[test]
     fn no_name_or_labelled_by() {
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
-                (
-                    NodeId(1),
-                    NodeBuilder::new(Role::Button).build(&mut classes),
-                ),
+                (NodeId(1), NodeBuilder::new(Role::Button).build()),
             ],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
@@ -1046,33 +1042,32 @@ mod tests {
         const LABEL_1: &str = "Check email every";
         const LABEL_2: &str = "minutes";
 
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1), NodeId(2), NodeId(3), NodeId(4)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(1), {
                     let mut builder = NodeBuilder::new(Role::CheckBox);
                     builder.set_labelled_by(vec![NodeId(2), NodeId(4)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(2), {
                     let mut builder = NodeBuilder::new(Role::StaticText);
                     builder.set_name(LABEL_1);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(3), {
                     let mut builder = NodeBuilder::new(Role::TextInput);
                     builder.push_labelled_by(NodeId(4));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(4), {
                     let mut builder = NodeBuilder::new(Role::StaticText);
                     builder.set_name(LABEL_2);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
@@ -1094,38 +1089,37 @@ mod tests {
         const BUTTON_LABEL: &str = "Play";
         const LINK_LABEL: &str = "Watch in browser";
 
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1), NodeId(3)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(1), {
                     let mut builder = NodeBuilder::new(Role::Button);
                     builder.push_child(NodeId(2));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(2), {
                     let mut builder = NodeBuilder::new(Role::Image);
                     builder.set_name(BUTTON_LABEL);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(3), {
                     let mut builder = NodeBuilder::new(Role::Link);
                     builder.push_child(NodeId(4));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(4), {
                     let mut builder = NodeBuilder::new(Role::GenericContainer);
                     builder.push_child(NodeId(5));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(5), {
                     let mut builder = NodeBuilder::new(Role::StaticText);
                     builder.set_name(LINK_LABEL);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -1031,18 +1031,15 @@ mod tests {
 
     // This is based on an actual tree produced by egui.
     fn main_multiline_tree(selection: Option<TextSelection>) -> crate::Tree {
-        use accesskit::{
-            Action, Affine, NodeBuilder, NodeClassSet, Role, TextDirection, Tree, TreeUpdate,
-        };
+        use accesskit::{Action, Affine, NodeBuilder, Role, TextDirection, Tree, TreeUpdate};
 
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_transform(Affine::scale(1.5));
                     builder.set_children(vec![NodeId(1)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(1), {
                     let mut builder = NodeBuilder::new(Role::MultilineTextInput);
@@ -1064,7 +1061,7 @@ mod tests {
                     if let Some(selection) = selection {
                         builder.set_text_selection(selection);
                     }
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(2), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1099,7 +1096,7 @@ mod tests {
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                     ]);
                     builder.set_word_lengths([5, 10, 3, 5, 7, 3, 5]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(3), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1124,7 +1121,7 @@ mod tests {
                         0.0,
                     ]);
                     builder.set_word_lengths([3, 8, 6]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(4), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1150,7 +1147,7 @@ mod tests {
                         7.58557, 7.58557, 0.0,
                     ]);
                     builder.set_word_lengths([8, 11]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(5), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1166,7 +1163,7 @@ mod tests {
                     builder.set_character_positions([0.0]);
                     builder.set_character_widths([0.0]);
                     builder.set_word_lengths([1]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(6), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1196,7 +1193,7 @@ mod tests {
                         7.58557, 7.58557, 7.58557, 7.58557, 0.0,
                     ]);
                     builder.set_word_lengths([5, 4, 6, 6]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(7), {
                     let mut builder = NodeBuilder::new(Role::InlineTextBox);
@@ -1212,7 +1209,7 @@ mod tests {
                     builder.set_character_positions([]);
                     builder.set_character_widths([]);
                     builder.set_word_lengths([0]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -390,16 +390,12 @@ impl Tree {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree, TreeUpdate};
+    use accesskit::{NodeBuilder, NodeId, Role, Tree, TreeUpdate};
 
     #[test]
     fn init_tree_with_root_node() {
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
-            nodes: vec![(
-                NodeId(0),
-                NodeBuilder::new(Role::Window).build(&mut classes),
-            )],
+            nodes: vec![(NodeId(0), NodeBuilder::new(Role::Window).build())],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
         };
@@ -411,22 +407,15 @@ mod tests {
 
     #[test]
     fn root_node_has_children() {
-        let mut classes = NodeClassSet::new();
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1), NodeId(2)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
-                (
-                    NodeId(1),
-                    NodeBuilder::new(Role::Button).build(&mut classes),
-                ),
-                (
-                    NodeId(2),
-                    NodeBuilder::new(Role::Button).build(&mut classes),
-                ),
+                (NodeId(1), NodeBuilder::new(Role::Button).build()),
+                (NodeId(2), NodeBuilder::new(Role::Button).build()),
             ],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
@@ -446,10 +435,9 @@ mod tests {
 
     #[test]
     fn add_child_to_root_node() {
-        let mut classes = NodeClassSet::new();
         let root_builder = NodeBuilder::new(Role::Window);
         let first_update = TreeUpdate {
-            nodes: vec![(NodeId(0), root_builder.clone().build(&mut classes))],
+            nodes: vec![(NodeId(0), root_builder.clone().build())],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
         };
@@ -460,12 +448,9 @@ mod tests {
                 (NodeId(0), {
                     let mut builder = root_builder;
                     builder.push_child(NodeId(1));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
-                (
-                    NodeId(1),
-                    NodeBuilder::new(Role::RootWebArea).build(&mut classes),
-                ),
+                (NodeId(1), NodeBuilder::new(Role::RootWebArea).build()),
             ],
             tree: None,
             focus: NodeId(0),
@@ -529,19 +514,15 @@ mod tests {
 
     #[test]
     fn remove_child_from_root_node() {
-        let mut classes = NodeClassSet::new();
         let root_builder = NodeBuilder::new(Role::Window);
         let first_update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = root_builder.clone();
                     builder.push_child(NodeId(1));
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
-                (
-                    NodeId(1),
-                    NodeBuilder::new(Role::RootWebArea).build(&mut classes),
-                ),
+                (NodeId(1), NodeBuilder::new(Role::RootWebArea).build()),
             ],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
@@ -549,7 +530,7 @@ mod tests {
         let mut tree = super::Tree::new(first_update, false);
         assert_eq!(1, tree.state().root().children().count());
         let second_update = TreeUpdate {
-            nodes: vec![(NodeId(0), root_builder.build(&mut classes))],
+            nodes: vec![(NodeId(0), root_builder.build())],
             tree: None,
             focus: NodeId(0),
         };
@@ -607,22 +588,15 @@ mod tests {
 
     #[test]
     fn move_focus_between_siblings() {
-        let mut classes = NodeClassSet::new();
         let first_update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1), NodeId(2)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
-                (
-                    NodeId(1),
-                    NodeBuilder::new(Role::Button).build(&mut classes),
-                ),
-                (
-                    NodeId(2),
-                    NodeBuilder::new(Role::Button).build(&mut classes),
-                ),
+                (NodeId(1), NodeBuilder::new(Role::Button).build()),
+                (NodeId(2), NodeBuilder::new(Role::Button).build()),
             ],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(1),
@@ -702,19 +676,18 @@ mod tests {
 
     #[test]
     fn update_node() {
-        let mut classes = NodeClassSet::new();
         let child_builder = NodeBuilder::new(Role::Button);
         let first_update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
                     let mut builder = NodeBuilder::new(Role::Window);
                     builder.set_children(vec![NodeId(1)]);
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
                 (NodeId(1), {
                     let mut builder = child_builder.clone();
                     builder.set_name("foo");
-                    builder.build(&mut classes)
+                    builder.build()
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
@@ -729,7 +702,7 @@ mod tests {
             nodes: vec![(NodeId(1), {
                 let mut builder = child_builder;
                 builder.set_name("bar");
-                builder.build(&mut classes)
+                builder.build()
             })],
             tree: None,
             focus: NodeId(0),

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,7 +4,10 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Live, Node as NodeData, NodeId, Tree as TreeData, TreeUpdate};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::node::{DetachedNode, Node, NodeState, ParentAndIndex};
 
@@ -77,7 +80,7 @@ impl State {
             let state = NodeState {
                 id,
                 parent_and_index,
-                data,
+                data: Arc::new(data),
             };
             nodes.insert(id, state);
             if let Some(changes) = changes {
@@ -120,7 +123,7 @@ impl State {
                         orphans.insert(*child_id);
                     }
                 }
-                node_state.data = node_data;
+                node_state.data = Arc::new(node_data);
             } else if let Some(parent_and_index) = pending_children.remove(&node_id) {
                 add_node(
                     &mut self.nodes,
@@ -216,7 +219,7 @@ impl State {
 
         fn traverse(state: &State, nodes: &mut Vec<(NodeId, NodeData)>, id: NodeId) {
             let node = state.nodes.get(&id).unwrap();
-            nodes.push((id, node.data.clone()));
+            nodes.push((id, (*node.data).clone()));
 
             for child_id in node.data.children().iter() {
                 traverse(state, nodes, *child_id);

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -165,10 +165,7 @@ impl Adapter {
                 }
                 None => {
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(
-                            PLACEHOLDER_ROOT_ID,
-                            NodeBuilder::new(Role::Window).build(&mut Default::default()),
-                        )],
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeBuilder::new(Role::Window).build())],
                         tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -339,10 +339,7 @@ impl Adapter {
                 None => {
                     let hwnd = *hwnd;
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(
-                            PLACEHOLDER_ROOT_ID,
-                            NodeBuilder::new(Role::Window).build(&mut Default::default()),
-                        )],
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeBuilder::new(Role::Window).build())],
                         tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -4,8 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeClassSet,
-    NodeId, Role, Tree, TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeId, Role, Tree,
+    TreeUpdate,
 };
 use windows::{core::*, Win32::UI::Accessibility::*};
 
@@ -17,22 +17,21 @@ const WINDOW_ID: NodeId = NodeId(0);
 const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
-fn make_button(name: &str, classes: &mut NodeClassSet) -> Node {
+fn make_button(name: &str) -> Node {
     let mut builder = NodeBuilder::new(Role::Button);
     builder.set_name(name);
     builder.add_action(Action::Focus);
-    builder.build(classes)
+    builder.build()
 }
 
 fn get_initial_state() -> TreeUpdate {
-    let mut classes = NodeClassSet::new();
     let root = {
         let mut builder = NodeBuilder::new(Role::Window);
         builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
-        builder.build(&mut classes)
+        builder.build()
     };
-    let button_1 = make_button("Button 1", &mut classes);
-    let button_2 = make_button("Button 2", &mut classes);
+    let button_1 = make_button("Button 1");
+    let button_2 = make_button("Button 2");
     TreeUpdate {
         nodes: vec![
             (WINDOW_ID, root),

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -4,8 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeClassSet,
-    NodeId, Role, Tree, TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeId, Role, Tree,
+    TreeUpdate,
 };
 use windows::Win32::{Foundation::*, UI::Accessibility::*};
 use winit::{
@@ -24,23 +24,22 @@ const WINDOW_ID: NodeId = NodeId(0);
 const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
-fn make_button(name: &str, classes: &mut NodeClassSet) -> Node {
+fn make_button(name: &str) -> Node {
     let mut builder = NodeBuilder::new(Role::Button);
     builder.set_name(name);
     builder.add_action(Action::Focus);
-    builder.build(classes)
+    builder.build()
 }
 
 fn get_initial_state() -> TreeUpdate {
-    let mut classes = NodeClassSet::new();
     let root = {
         let mut builder = NodeBuilder::new(Role::Window);
         builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
         builder.set_name(WINDOW_TITLE);
-        builder.build(&mut classes)
+        builder.build()
     };
-    let button_1 = make_button("Button 1", &mut classes);
-    let button_2 = make_button("Button 2", &mut classes);
+    let button_1 = make_button("Button 1");
+    let button_2 = make_button("Button 2");
     TreeUpdate {
         nodes: vec![
             (WINDOW_ID, root),

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -1,6 +1,6 @@
 use accesskit::{
-    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder,
-    NodeClassSet, NodeId, Rect, Role, Tree, TreeUpdate,
+    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder, NodeId,
+    Rect, Role, Tree, TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use std::sync::{Arc, Mutex};
@@ -33,7 +33,7 @@ const BUTTON_2_RECT: Rect = Rect {
     y1: 100.0,
 };
 
-fn build_button(id: NodeId, name: &str, classes: &mut NodeClassSet) -> Node {
+fn build_button(id: NodeId, name: &str) -> Node {
     let rect = match id {
         BUTTON_1_ID => BUTTON_1_RECT,
         BUTTON_2_ID => BUTTON_2_RECT,
@@ -45,20 +45,19 @@ fn build_button(id: NodeId, name: &str, classes: &mut NodeClassSet) -> Node {
     builder.set_name(name);
     builder.add_action(Action::Focus);
     builder.set_default_action_verb(DefaultActionVerb::Click);
-    builder.build(classes)
+    builder.build()
 }
 
-fn build_announcement(text: &str, classes: &mut NodeClassSet) -> Node {
+fn build_announcement(text: &str) -> Node {
     let mut builder = NodeBuilder::new(Role::StaticText);
     builder.set_name(text);
     builder.set_live(Live::Polite);
-    builder.build(classes)
+    builder.build()
 }
 
 struct State {
     focus: NodeId,
     announcement: Option<String>,
-    node_classes: NodeClassSet,
 }
 
 impl State {
@@ -66,7 +65,6 @@ impl State {
         Arc::new(Mutex::new(Self {
             focus: INITIAL_FOCUS,
             announcement: None,
-            node_classes: NodeClassSet::new(),
         }))
     }
 
@@ -77,13 +75,13 @@ impl State {
             builder.push_child(ANNOUNCEMENT_ID);
         }
         builder.set_name(WINDOW_TITLE);
-        builder.build(&mut self.node_classes)
+        builder.build()
     }
 
     fn build_initial_tree(&mut self) -> TreeUpdate {
         let root = self.build_root();
-        let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
-        let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
+        let button_1 = build_button(BUTTON_1_ID, "Button 1");
+        let button_2 = build_button(BUTTON_2_ID, "Button 2");
         let mut tree = Tree::new(WINDOW_ID);
         tree.app_name = Some("simple".to_string());
         let mut result = TreeUpdate {
@@ -96,10 +94,9 @@ impl State {
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {
-            result.nodes.push((
-                ANNOUNCEMENT_ID,
-                build_announcement(announcement, &mut self.node_classes),
-            ));
+            result
+                .nodes
+                .push((ANNOUNCEMENT_ID, build_announcement(announcement)));
         }
         result
     }
@@ -121,7 +118,7 @@ impl State {
         };
         self.announcement = Some(text.into());
         adapter.update_if_active(|| {
-            let announcement = build_announcement(text, &mut self.node_classes);
+            let announcement = build_announcement(text);
             let root = self.build_root();
             TreeUpdate {
                 nodes: vec![(ANNOUNCEMENT_ID, announcement), (WINDOW_ID, root)],

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -1,6 +1,6 @@
 use accesskit::{
-    Action, ActionRequest, DefaultActionVerb, Live, Node, NodeBuilder, NodeClassSet, NodeId, Rect,
-    Role, Tree, TreeUpdate,
+    Action, ActionRequest, DefaultActionVerb, Live, Node, NodeBuilder, NodeId, Rect, Role, Tree,
+    TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use winit::{
@@ -32,7 +32,7 @@ const BUTTON_2_RECT: Rect = Rect {
     y1: 100.0,
 };
 
-fn build_button(id: NodeId, name: &str, classes: &mut NodeClassSet) -> Node {
+fn build_button(id: NodeId, name: &str) -> Node {
     let rect = match id {
         BUTTON_1_ID => BUTTON_1_RECT,
         BUTTON_2_ID => BUTTON_2_RECT,
@@ -44,20 +44,19 @@ fn build_button(id: NodeId, name: &str, classes: &mut NodeClassSet) -> Node {
     builder.set_name(name);
     builder.add_action(Action::Focus);
     builder.set_default_action_verb(DefaultActionVerb::Click);
-    builder.build(classes)
+    builder.build()
 }
 
-fn build_announcement(text: &str, classes: &mut NodeClassSet) -> Node {
+fn build_announcement(text: &str) -> Node {
     let mut builder = NodeBuilder::new(Role::StaticText);
     builder.set_name(text);
     builder.set_live(Live::Polite);
-    builder.build(classes)
+    builder.build()
 }
 
 struct State {
     focus: NodeId,
     announcement: Option<String>,
-    node_classes: NodeClassSet,
 }
 
 impl State {
@@ -65,7 +64,6 @@ impl State {
         Self {
             focus: INITIAL_FOCUS,
             announcement: None,
-            node_classes: NodeClassSet::new(),
         }
     }
 
@@ -76,13 +74,13 @@ impl State {
             builder.push_child(ANNOUNCEMENT_ID);
         }
         builder.set_name(WINDOW_TITLE);
-        builder.build(&mut self.node_classes)
+        builder.build()
     }
 
     fn build_initial_tree(&mut self) -> TreeUpdate {
         let root = self.build_root();
-        let button_1 = build_button(BUTTON_1_ID, "Button 1", &mut self.node_classes);
-        let button_2 = build_button(BUTTON_2_ID, "Button 2", &mut self.node_classes);
+        let button_1 = build_button(BUTTON_1_ID, "Button 1");
+        let button_2 = build_button(BUTTON_2_ID, "Button 2");
         let mut tree = Tree::new(WINDOW_ID);
         tree.app_name = Some("simple".to_string());
         let mut result = TreeUpdate {
@@ -95,10 +93,9 @@ impl State {
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {
-            result.nodes.push((
-                ANNOUNCEMENT_ID,
-                build_announcement(announcement, &mut self.node_classes),
-            ));
+            result
+                .nodes
+                .push((ANNOUNCEMENT_ID, build_announcement(announcement)));
         }
         result
     }
@@ -120,7 +117,7 @@ impl State {
         };
         self.announcement = Some(text.into());
         adapter.update_if_active(|| {
-            let announcement = build_announcement(text, &mut self.node_classes);
+            let announcement = build_announcement(text);
             let root = self.build_root();
             TreeUpdate {
                 nodes: vec![(ANNOUNCEMENT_ID, announcement), (WINDOW_ID, root)],


### PR DESCRIPTION
I now believe that this was a bad API design decision on my part. The original rationale was explained in a [blog post on optimizing node size](https://accesskit.dev/dramatically-reducing-accesskits-memory-usage/), but I now think I went too far. It's not at all clear from real-world measurements that this approach to minimizing node size at the cost of speed and API complexity is worth it. I mention speed because, of course, it takes time to determine whether the node class can be shared, by comparing the new node class with existing entries in the `BTreeSet`, and this is done every time `NodeBuilder::build` is called. And even if we eventually gather data showing that the size versus speed tradeoff is worthwhile, I think it was a mistake on my part to expose this complexity in the API. I now think it would be better to have a global `NodeClassSet` behind a mutex, as we already had to do for serde support, than to expose this implementation detail to the users; we already know that it caused confusion for at least one potential user.

This change does increase the size of `Node` from 32 to 112 bytes, a difference of 80 bytes. I think this is completely acceptable; I remember from chat room discussion during my work on `Node` size optimization last year that people were happy when I got the size down to 128 bytes.

Looking at it another way, I would rather ship 1.0 without the API complexity of `NodeClassSet`, and figure out how to re-add the optimization in a backward-compatible way later if it's truly necessary, than ship with this API complexity and be stuck with it forever. My work on integrating AccessKit into GTK has led me to refocus on making AccessKit as simple and easy as possible for our users, the toolkits, and that's the primary purpose of this PR.