### PR TITLE
refactor!: Rename `hierarchical_level` to `level`

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -630,7 +630,7 @@ usize_property_methods! {
     (table_cell_column_span, set_table_cell_column_span, clear_table_cell_column_span),
     (table_cell_row_index, set_table_cell_row_index, clear_table_cell_row_index),
     (table_cell_row_span, set_table_cell_row_span, clear_table_cell_row_span),
-    (hierarchical_level, set_hierarchical_level, clear_hierarchical_level),
+    (level, set_level, clear_level),
     (size_of_set, set_size_of_set, clear_size_of_set),
     (position_in_set, set_position_in_set, clear_position_in_set)
 }

--- a/bindings/python/src/common.rs
+++ b/bindings/python/src/common.rs
@@ -539,7 +539,7 @@ usize_property_methods! {
     (table_cell_column_span, set_table_cell_column_span, clear_table_cell_column_span),
     (table_cell_row_index, set_table_cell_row_index, clear_table_cell_row_index),
     (table_cell_row_span, set_table_cell_row_span, clear_table_cell_row_span),
-    (hierarchical_level, set_hierarchical_level, clear_hierarchical_level),
+    (level, set_level, clear_level),
     (size_of_set, set_size_of_set, clear_size_of_set),
     (position_in_set, set_position_in_set, clear_position_in_set)
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -902,7 +902,7 @@ enum PropertyId {
     TableCellColumnSpan,
     TableCellRowIndex,
     TableCellRowSpan,
-    HierarchicalLevel,
+    Level,
     SizeOfSet,
     PositionInSet,
 
@@ -1605,7 +1605,7 @@ usize_property_methods! {
     (TableCellColumnSpan, table_cell_column_span, set_table_cell_column_span, clear_table_cell_column_span),
     (TableCellRowIndex, table_cell_row_index, set_table_cell_row_index, clear_table_cell_row_index),
     (TableCellRowSpan, table_cell_row_span, set_table_cell_row_span, clear_table_cell_row_span),
-    (HierarchicalLevel, hierarchical_level, set_hierarchical_level, clear_hierarchical_level),
+    (Level, level, set_level, clear_level),
     (SizeOfSet, size_of_set, set_size_of_set, clear_size_of_set),
     (PositionInSet, position_in_set, set_position_in_set, clear_position_in_set)
 }
@@ -2000,7 +2000,7 @@ impl<'de> Visitor<'de> for NodeVisitor {
                             TableCellColumnSpan,
                             TableCellRowIndex,
                             TableCellRowSpan,
-                            HierarchicalLevel,
+                            Level,
                             SizeOfSet,
                             PositionInSet
                         },
@@ -2186,7 +2186,7 @@ impl JsonSchema for Node {
                 TableCellColumnSpan,
                 TableCellRowIndex,
                 TableCellRowSpan,
-                HierarchicalLevel,
+                Level,
                 SizeOfSet,
                 PositionInSet
             },


### PR DESCRIPTION
I thoughtlessly copied the original name from Chromium nearly 3 years ago. I can think of no good reason for that long, cumbersome name, and it's an API wart that I definitely don't want to ship in 1.0. The equivalent ARIA property is simply called `aria-level`. If we need to clarify the meaning of "level", the place to do that is in the docs, not the name.