### PR TITLE
refactor!: Drop `SortDirection::Unsorted`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -550,7 +550,6 @@ pub enum DefaultActionVerb {
 )]
 #[repr(u8)]
 pub enum SortDirection {
-    Unsorted,
     Ascending,
     Descending,
     Other,


### PR DESCRIPTION
This continues the pattern of eliminating states that don't have a clear meaning. In this case, according to the MDN documentation for `aria-sort`, the default value for that ARIA property is `none`. This means that specifying `aria-sort="none"` is synonymous with not specifying it at all. So, like other AccessKit enums such as `AutoComplete`, I think it's best to not have a `None` value, which is what `SortDirection::Unsorted` really is; instead, the user just shouldn't set the property at all.