### PR TITLE
feat: Add the `owns` relation

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -564,6 +564,7 @@ node_id_vec_property_methods! {
     (described_by, set_described_by, push_described_by, clear_described_by),
     (flow_to, set_flow_to, push_flow_to, clear_flow_to),
     (labelled_by, set_labelled_by, push_labelled_by, clear_labelled_by),
+    (owns, set_owns, push_owned, clear_owns),
     (radio_group, set_radio_group, push_to_radio_group, clear_radio_group)
 }
 

--- a/bindings/python/src/common.rs
+++ b/bindings/python/src/common.rs
@@ -480,6 +480,7 @@ node_id_vec_property_methods! {
     (described_by, set_described_by, push_described_by, clear_described_by),
     (flow_to, set_flow_to, push_flow_to, clear_flow_to),
     (labelled_by, set_labelled_by, push_labelled_by, clear_labelled_by),
+    (owns, set_owns, push_owned, clear_owns),
     (radio_group, set_radio_group, push_to_radio_group, clear_radio_group)
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -847,6 +847,7 @@ enum PropertyId {
     DescribedBy,
     FlowTo,
     LabelledBy,
+    Owns,
     RadioGroup,
 
     // NodeId
@@ -1512,6 +1513,7 @@ node_id_vec_property_methods! {
     (DescribedBy, described_by, set_described_by, push_described_by, clear_described_by),
     (FlowTo, flow_to, set_flow_to, push_flow_to, clear_flow_to),
     (LabelledBy, labelled_by, set_labelled_by, push_labelled_by, clear_labelled_by),
+    (Owns, owns, set_owns, push_owned, clear_owns),
     /// On radio buttons this should be set to a list of all of the buttons
     /// in the same group as this one, including this radio button itself.
     (RadioGroup, radio_group, set_radio_group, push_to_radio_group, clear_radio_group)
@@ -1945,6 +1947,7 @@ impl<'de> Visitor<'de> for NodeVisitor {
                             DescribedBy,
                             FlowTo,
                             LabelledBy,
+                            Owns,
                             RadioGroup
                         },
                         NodeId {
@@ -2131,6 +2134,7 @@ impl JsonSchema for Node {
                 DescribedBy,
                 FlowTo,
                 LabelledBy,
+                Owns,
                 RadioGroup
             },
             NodeId {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1513,6 +1513,11 @@ node_id_vec_property_methods! {
     (DescribedBy, described_by, set_described_by, push_described_by, clear_described_by),
     (FlowTo, flow_to, set_flow_to, push_flow_to, clear_flow_to),
     (LabelledBy, labelled_by, set_labelled_by, push_labelled_by, clear_labelled_by),
+    /// As with the `aria-owns` property in ARIA, this property should be set
+    /// only if the nodes referenced in the property are not descendants
+    /// of the owning node in the AccessKit tree. In the common case, where the
+    /// owned nodes are direct children or indirect descendants, this property
+    /// is unnecessary.
     (Owns, owns, set_owns, push_owned, clear_owns),
     /// On radio buttons this should be set to a list of all of the buttons
     /// in the same group as this one, including this radio button itself.


### PR DESCRIPTION
This is a standard ARIA relation, so I'm surprised we didn't already inherit it from Chromium; I doubt I would have deliberately left it out or removed it. Anyway, I noticed it while going through the relations in GTK.