### PR TITLE
clippy: Fix new legacy-numeric-constants lint.

### DIFF
--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -946,11 +946,11 @@ impl PlatformNode {
     }
 
     pub fn minimum_value(&self) -> Result<f64> {
-        self.resolve(|node| Ok(node.state().min_numeric_value().unwrap_or(std::f64::MIN)))
+        self.resolve(|node| Ok(node.state().min_numeric_value().unwrap_or(f64::MIN)))
     }
 
     pub fn maximum_value(&self) -> Result<f64> {
-        self.resolve(|node| Ok(node.state().max_numeric_value().unwrap_or(std::f64::MAX)))
+        self.resolve(|node| Ok(node.state().max_numeric_value().unwrap_or(f64::MAX)))
     }
 
     pub fn minimum_increment(&self) -> Result<f64> {


### PR DESCRIPTION
It is preferred to use the associated constants as the other forms are expected to be deprecated in the future.