### PR TITLE
fix!: Update winit to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ version = "0.12.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "objc2 0.5.1",
+ "objc2",
  "objc2-app-kit",
  "objc2-foundation",
  "once_cell",
@@ -143,9 +143,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052ad56e336bcc615a214bffbeca6c181ee9550acec193f0327e0b103b033a4d"
+checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
  "bitflags 2.4.1",
@@ -440,31 +440,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92"
-dependencies = [
- "objc-sys",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ff7d91d3c1d568065b06c899777d1e48dcf76103a672a0adbc238a7f247f1e"
 dependencies = [
- "objc2 0.5.1",
+ "objc2",
 ]
 
 [[package]]
@@ -554,9 +535,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
 
 [[package]]
 name = "combine"
@@ -685,7 +666,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -693,6 +674,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "dpi"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "dyn-clone"
@@ -921,12 +908,12 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
- "winapi",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -969,17 +956,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
-]
 
 [[package]]
 name = "indexmap"
@@ -1086,6 +1062,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.3",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.4.1",
  "jni-sys",
@@ -1205,9 +1202,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -1264,22 +1261,12 @@ checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
 
 [[package]]
 name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys",
- "objc2-encode 3.0.0",
-]
-
-[[package]]
-name = "objc2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
 dependencies = [
  "objc-sys",
- "objc2-encode 4.0.1",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -1288,8 +1275,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb79768a710a9a1798848179edb186d1af7e8a8679f369e4b8d201dd2a034047"
 dependencies = [
- "block2 0.5.0",
- "objc2 0.5.1",
+ "block2",
+ "objc2",
  "objc2-core-data",
  "objc2-foundation",
 ]
@@ -1300,16 +1287,10 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e092bc42eaf30a08844e6a076938c60751225ec81431ab89f5d1ccd9f958d6c"
 dependencies = [
- "block2 0.5.0",
- "objc2 0.5.1",
+ "block2",
+ "objc2",
  "objc2-foundation",
 ]
-
-[[package]]
-name = "objc2-encode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc2-encode"
@@ -1323,8 +1304,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfaefe14254871ea16c7d88968c0ff14ba554712a20d76421eec52f0a7fb8904"
 dependencies = [
- "block2 0.5.0",
- "objc2 0.5.1",
+ "block2",
+ "dispatch",
+ "objc2",
 ]
 
 [[package]]
@@ -1338,20 +1320,17 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "orbclient"
-version = "0.3.43"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974465c5e83cf9df05c1e4137b271d29035c902e39e5ad4c1939837e22160af8"
+checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "cfg-if",
- "redox_syscall 0.2.16",
- "wasm-bindgen",
- "web-sys",
+ "libredox",
 ]
 
 [[package]]
@@ -1413,6 +1392,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1628,6 +1627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,9 +1752,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729a30a469de249c6effc17ec8d039b0aa29b3af79b819b7f51cb6ab8046a90"
+checksum = "7de61fa7334ee8ee1f5c3c58dcc414fb9361e7e8f5bff9d45f4d69eeb89a7169"
 dependencies = [
  "ab_glyph",
  "log",
@@ -2064,11 +2072,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2076,20 +2083,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -2349,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57099a701fb3a8043f993e8228dc24229c7b942e2b009a1b962e54489ba1d3bf"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2378,15 +2385,6 @@ name = "winapi-util"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winapi-wsapoll"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e"
 dependencies = [
  "winapi",
 ]
@@ -2481,6 +2479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -2656,9 +2663,9 @@ checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winit"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161598019a9da35ab6c34dc46cd13546cba9dbf9816475d4dd9a639455016563"
+checksum = "ea9e6d5d66cbf702e0dd820302144f51b69a95acdc495dd98ca280ff206562b1"
 dependencies = [
  "ahash",
  "android-activity",
@@ -2667,27 +2674,29 @@ dependencies = [
  "bytemuck",
  "calloop",
  "cfg_aliases",
+ "concurrent-queue",
  "core-foundation",
  "core-graphics",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
  "memmap2",
  "ndk",
- "ndk-sys",
- "objc2 0.4.1",
- "once_cell",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "orbclient",
  "percent-encoding",
+ "pin-project",
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.0",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix 0.38.21",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2697,7 +2706,7 @@ dependencies = [
  "wayland-protocols-plasma",
  "web-sys",
  "web-time",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
@@ -2725,29 +2734,24 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a"
+checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading",
- "nix",
+ "libloading 0.8.3",
  "once_cell",
- "winapi",
- "winapi-wsapoll",
+ "rustix 0.38.21",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc"
-dependencies = [
- "nix",
-]
+checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xcursor"
@@ -2770,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "xkbcommon-dl"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
  "bitflags 2.4.1",
  "dlib",

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -35,5 +35,5 @@ features = [
 [dev-dependencies]
 once_cell = "1.13.0"
 scopeguard = "1.1.0"
-winit = "0.29"
+winit = "0.30"
 

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -23,7 +23,7 @@ tokio = ["accesskit_unix/tokio"]
 
 [dependencies]
 accesskit = { version = "0.13.0", path = "../../common" }
-winit = { version = "0.29", default-features = false }
+winit = { version = "0.30", default-features = false }
 rwh_05 = { package = "raw-window-handle", version = "0.5", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 
@@ -37,7 +37,7 @@ accesskit_macos = { version = "0.12.0", path = "../macos" }
 accesskit_unix = { version = "0.8.0", path = "../unix", optional = true, default-features = false }
 
 [dev-dependencies.winit]
-version = "0.29"
+version = "0.30"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -1,9 +1,12 @@
 use accesskit::{
-    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder, NodeId, Rect, Role, Tree,
-    TreeUpdate,
+    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder, NodeId,
+    Rect, Role, Tree, TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
-use std::{error::Error, sync::{Arc, Mutex}};
+use std::{
+    error::Error,
+    sync::{Arc, Mutex},
+};
 use winit::{
     application::ApplicationHandler,
     event::{ElementState, KeyEvent, WindowEvent},
@@ -179,7 +182,11 @@ impl Application {
         let activation_handler = TearoffActivationHandler {
             state: Arc::clone(&ui),
         };
-        let adapter = Adapter::with_mixed_handlers(&window, activation_handler, self.event_loop_proxy.clone());
+        let adapter = Adapter::with_mixed_handlers(
+            &window,
+            activation_handler,
+            self.event_loop_proxy.clone(),
+        );
         window.set_visible(true);
 
         self.window = Some(WindowState::new(window, adapter, ui));
@@ -259,7 +266,8 @@ impl ApplicationHandler<AccessKitEvent> for Application {
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        self.create_window(event_loop).expect("failed to create initial window");
+        self.create_window(event_loop)
+            .expect("failed to create initial window");
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -144,7 +144,7 @@ impl ActivationHandler for TearoffActivationHandler {
 }
 
 struct WindowState {
-    window: Arc<Window>,
+    window: Window,
     adapter: Adapter,
     ui: Arc<Mutex<UiState>>,
 }
@@ -152,7 +152,7 @@ struct WindowState {
 impl WindowState {
     fn new(window: Window, adapter: Adapter, ui: Arc<Mutex<UiState>>) -> Self {
         Self {
-            window: Arc::new(window),
+            window,
             adapter,
             ui,
         }

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -1,14 +1,15 @@
 use accesskit::{
-    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder, NodeId,
-    Rect, Role, Tree, TreeUpdate,
+    Action, ActionRequest, ActivationHandler, DefaultActionVerb, Live, Node, NodeBuilder, NodeId, Rect, Role, Tree,
+    TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
-use std::sync::{Arc, Mutex};
+use std::{error::Error, sync::{Arc, Mutex}};
 use winit::{
-    event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoopBuilder},
+    application::ApplicationHandler,
+    event::{ElementState, KeyEvent, WindowEvent},
+    event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy},
     keyboard::Key,
-    window::WindowBuilder,
+    window::{Window, WindowId},
 };
 
 const WINDOW_TITLE: &str = "Hello world";
@@ -55,12 +56,12 @@ fn build_announcement(text: &str) -> Node {
     builder.build()
 }
 
-struct State {
+struct UiState {
     focus: NodeId,
     announcement: Option<String>,
 }
 
-impl State {
+impl UiState {
     fn new() -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             focus: INITIAL_FOCUS,
@@ -130,7 +131,7 @@ impl State {
 }
 
 struct TearoffActivationHandler {
-    state: Arc<Mutex<State>>,
+    state: Arc<Mutex<UiState>>,
 }
 
 impl ActivationHandler for TearoffActivationHandler {
@@ -139,7 +140,136 @@ impl ActivationHandler for TearoffActivationHandler {
     }
 }
 
-fn main() -> Result<(), impl std::error::Error> {
+struct WindowState {
+    window: Arc<Window>,
+    adapter: Adapter,
+    ui: Arc<Mutex<UiState>>,
+}
+
+impl WindowState {
+    fn new(window: Window, adapter: Adapter, ui: Arc<Mutex<UiState>>) -> Self {
+        Self {
+            window: Arc::new(window),
+            adapter,
+            ui,
+        }
+    }
+}
+
+struct Application {
+    event_loop_proxy: EventLoopProxy<AccessKitEvent>,
+    window: Option<WindowState>,
+}
+
+impl Application {
+    fn new(event_loop_proxy: EventLoopProxy<AccessKitEvent>) -> Self {
+        Self {
+            event_loop_proxy,
+            window: None,
+        }
+    }
+
+    fn create_window(&mut self, event_loop: &ActiveEventLoop) -> Result<(), Box<dyn Error>> {
+        let window_attributes = Window::default_attributes()
+            .with_title(WINDOW_TITLE)
+            .with_visible(false);
+
+        let window = event_loop.create_window(window_attributes)?;
+        let ui = UiState::new();
+        let activation_handler = TearoffActivationHandler {
+            state: Arc::clone(&ui),
+        };
+        let adapter = Adapter::with_mixed_handlers(&window, activation_handler, self.event_loop_proxy.clone());
+        window.set_visible(true);
+
+        self.window = Some(WindowState::new(window, adapter, ui));
+        Ok(())
+    }
+}
+
+impl ApplicationHandler<AccessKitEvent> for Application {
+    fn window_event(&mut self, _: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
+        let window = match &mut self.window {
+            Some(window) => window,
+            None => return,
+        };
+        let adapter = &mut window.adapter;
+        let state = &mut window.ui;
+
+        adapter.process_event(&window.window, &event);
+        match event {
+            WindowEvent::CloseRequested => {
+                self.window = None;
+            }
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key: virtual_code,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } => match virtual_code {
+                Key::Named(winit::keyboard::NamedKey::Tab) => {
+                    let mut state = state.lock().unwrap();
+                    let new_focus = if state.focus == BUTTON_1_ID {
+                        BUTTON_2_ID
+                    } else {
+                        BUTTON_1_ID
+                    };
+                    state.set_focus(adapter, new_focus);
+                }
+                Key::Named(winit::keyboard::NamedKey::Space) => {
+                    let mut state = state.lock().unwrap();
+                    let id = state.focus;
+                    state.press_button(adapter, id);
+                }
+                _ => (),
+            },
+            _ => (),
+        }
+    }
+
+    fn user_event(&mut self, _: &ActiveEventLoop, user_event: AccessKitEvent) {
+        let window = match &mut self.window {
+            Some(window) => window,
+            None => return,
+        };
+        let adapter = &mut window.adapter;
+        let state = &mut window.ui;
+
+        match user_event.window_event {
+            AccessKitWindowEvent::InitialTreeRequested => unreachable!(),
+            AccessKitWindowEvent::ActionRequested(ActionRequest { action, target, .. }) => {
+                if target == BUTTON_1_ID || target == BUTTON_2_ID {
+                    let mut state = state.lock().unwrap();
+                    match action {
+                        Action::Focus => {
+                            state.set_focus(adapter, target);
+                        }
+                        Action::Default => {
+                            state.press_button(adapter, target);
+                        }
+                        _ => (),
+                    }
+                }
+            }
+            AccessKitWindowEvent::AccessibilityDeactivated => (),
+        }
+    }
+
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.create_window(event_loop).expect("failed to create initial window");
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_none() {
+            event_loop.exit();
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
     println!("This example has no visible GUI, and a keyboard interface:");
     println!("- [Tab] switches focus between two logical buttons.");
     println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
@@ -157,76 +287,7 @@ fn main() -> Result<(), impl std::error::Error> {
     ))]
     println!("Enable Orca with [Super]+[Alt]+[S].");
 
-    let event_loop = EventLoopBuilder::with_user_event().build()?;
-    let state = State::new();
-    let window = WindowBuilder::new()
-        .with_title(WINDOW_TITLE)
-        .with_visible(false)
-        .build(&event_loop)?;
-    let activation_handler = TearoffActivationHandler {
-        state: Arc::clone(&state),
-    };
-    let mut adapter =
-        Adapter::with_mixed_handlers(&window, activation_handler, event_loop.create_proxy());
-    window.set_visible(true);
-
-    event_loop.run(move |event, event_loop| {
-        event_loop.set_control_flow(ControlFlow::Wait);
-
-        match event {
-            Event::WindowEvent { event, .. } => {
-                adapter.process_event(&window, &event);
-                match event {
-                    WindowEvent::CloseRequested => {
-                        event_loop.exit();
-                    }
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: virtual_code,
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    } => match virtual_code {
-                        Key::Named(winit::keyboard::NamedKey::Tab) => {
-                            let mut state = state.lock().unwrap();
-                            let new_focus = if state.focus == BUTTON_1_ID {
-                                BUTTON_2_ID
-                            } else {
-                                BUTTON_1_ID
-                            };
-                            state.set_focus(&mut adapter, new_focus);
-                        }
-                        Key::Named(winit::keyboard::NamedKey::Space) => {
-                            let mut state = state.lock().unwrap();
-                            let id = state.focus;
-                            state.press_button(&mut adapter, id);
-                        }
-                        _ => (),
-                    },
-                    _ => (),
-                }
-            }
-            Event::UserEvent(AccessKitEvent { window_event, .. }) => match window_event {
-                AccessKitWindowEvent::InitialTreeRequested => unreachable!(),
-                AccessKitWindowEvent::ActionRequested(ActionRequest { action, target, .. }) => {
-                    if target == BUTTON_1_ID || target == BUTTON_2_ID {
-                        let mut state = state.lock().unwrap();
-                        match action {
-                            Action::Focus => {
-                                state.set_focus(&mut adapter, target);
-                            }
-                            Action::Default => {
-                                state.press_button(&mut adapter, target);
-                            }
-                            _ => (),
-                        }
-                    }
-                }
-                AccessKitWindowEvent::AccessibilityDeactivated => (),
-            },
-            _ => (),
-        }
-    })
+    let event_loop = EventLoop::with_user_event().build()?;
+    let mut state = Application::new(event_loop.create_proxy());
+    event_loop.run_app(&mut state).map_err(Into::into)
 }

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -244,7 +244,8 @@ impl ApplicationHandler<AccessKitEvent> for Application {
     }
 
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        self.create_window(event_loop).expect("failed to create initial window");
+        self.create_window(event_loop)
+            .expect("failed to create initial window");
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -3,7 +3,7 @@ use accesskit::{
     TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 use winit::{
     application::ApplicationHandler,
     event::{ElementState, KeyEvent, WindowEvent},
@@ -131,7 +131,7 @@ impl UiState {
 }
 
 struct WindowState {
-    window: Arc<Window>,
+    window: Window,
     adapter: Adapter,
     ui: UiState,
 }
@@ -139,7 +139,7 @@ struct WindowState {
 impl WindowState {
     fn new(window: Window, adapter: Adapter, ui: UiState) -> Self {
         Self {
-            window: Arc::new(window),
+            window,
             adapter,
             ui,
         }

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -131,7 +131,7 @@ pub struct Adapter {
 impl Adapter {
     /// Creates a new AccessKit adapter for a winit window. This must be done
     /// before the window is shown for the first time. This means that you must
-    /// use [`winit::window::WindowBuilder::with_visible`] to make the window
+    /// use [`winit::window::WindowAttributes::with_visible`] to make the window
     /// initially invisible, then create the adapter, then show the window.
     ///
     /// This constructor uses a winit event loop proxy to deliver AccessKit
@@ -166,7 +166,7 @@ impl Adapter {
 
     /// Creates a new AccessKit adapter for a winit window. This must be done
     /// before the window is shown for the first time. This means that you must
-    /// use [`winit::window::WindowBuilder::with_visible`] to make the window
+    /// use [`winit::window::WindowAttributes::with_visible`] to make the window
     /// initially invisible, then create the adapter, then show the window.
     ///
     /// Use this if you want to provide your own AccessKit handler callbacks
@@ -194,7 +194,7 @@ impl Adapter {
 
     /// Creates a new AccessKit adapter for a winit window. This must be done
     /// before the window is shown for the first time. This means that you must
-    /// use [`winit::window::WindowBuilder::with_visible`] to make the window
+    /// use [`winit::window::WindowAttributes::with_visible`] to make the window
     /// initially invisible, then create the adapter, then show the window.
     ///
     /// This constructor provides a mix of the approaches used by


### PR DESCRIPTION
Examples now use the new `ApplicationHandler` trait, which led to significant changes.

This is a breaking change to `accesskit_winit`, as described in the [changelog](https://docs.rs/winit/latest/winit/changelog/index.html).