### PR TITLE
fix: Fix dead code warning on Unix platforms

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -95,6 +95,9 @@ pub(crate) trait BoxCastPtr: CastPtr + Sized {
         Box::into_raw(Box::new(src)) as *mut _
     }
 
+    // The following exception is needed because this function is only
+    // used in the bindings for some platform adapters.
+    #[allow(dead_code)]
     fn to_nullable_mut_ptr(src: Option<Self::RustType>) -> *mut Self {
         src.map_or_else(std::ptr::null_mut, Self::to_mut_ptr)
     }

--- a/bindings/python/src/common.rs
+++ b/bindings/python/src/common.rs
@@ -715,6 +715,9 @@ impl From<accesskit::ActionRequest> for ActionRequest {
     }
 }
 
+// The following exception is needed because this struct is only used
+// in the bindings for some platform adapters.
+#[allow(dead_code)]
 pub(crate) struct LocalPythonActivationHandler<'a> {
     pub(crate) py: Python<'a>,
     pub(crate) handler: Py<PyAny>,


### PR DESCRIPTION
This is causing CI to fail in another PR, now that Rust 1.78 has added a new dead code warning for trait associated functions.