### PR TITLE
fix: Make the transition from placeholder to real tree more robust

### DIFF
--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -5,7 +5,7 @@
 
 use accesskit::{ActionHandler, ActionRequest, Point};
 use accesskit_consumer::Tree;
-use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
+use std::sync::{atomic::AtomicBool, Arc, Mutex, RwLock, RwLockReadGuard};
 use windows::Win32::Foundation::*;
 
 use crate::util::*;
@@ -32,6 +32,7 @@ pub(crate) struct Context {
     pub(crate) hwnd: HWND,
     pub(crate) tree: RwLock<Tree>,
     pub(crate) action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
+    pub(crate) is_placeholder: AtomicBool,
 }
 
 impl Context {
@@ -39,11 +40,13 @@ impl Context {
         hwnd: HWND,
         tree: Tree,
         action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
+        is_placeholder: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
             hwnd,
             tree: RwLock::new(tree),
             action_handler,
+            is_placeholder: AtomicBool::new(is_placeholder),
         })
     }
 

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -474,7 +474,7 @@ impl ITextRangeProvider_Impl for PlatformRange {
             // Revisit this if we eventually support embedded objects.
             Ok(PlatformNode {
                 context: self.context.clone(),
-                node_id: node.id(),
+                node_id: Some(node.id()),
             }
             .into())
         })


### PR DESCRIPTION
On Windows, when running the winit simple example, which uses the placeholder tree, I noticed that with both NVDA and Narrator, the screen reader would sometimes not announce the new window, and if you queried the current focus, it would announce whatever had focus before. The cause seems to be that when transitioning from the placeholder tree to the real tree, a new context is created, and the placeholder context is discarded. That means that if the screen reader previously had a reference to the root node in the placeholder tree, that object would start returning `UIA_E_ELEMENTNOTAVAILABLE`.

I had thought that using a completely separate context for the placeholder tree was the cleanest solution. After all, we don't know what the root node ID of the real tree would be. So I figured, we might end up invalidating the root anyway, so, leaving nothing to chance, we should always invalidate the root when transitioning from the placeholder to the real tree. But I was wrong. It turns out that the screen readers, or UIA itself, didn't handle this situation as gracefully as I had hoped, even though we immediately send a focus event from the real tree.

So now, we update the context in place rather than creating a new one. To avoid the complication of updating the action handler in place, the placeholder context now uses the real action handler, but a new `is_placeholder` flag prevents the action handler from being run while the adapter is in the placeholder state.

The tricky part is that now `PlatformNode` needs to have a new configuration where it always refers to the root node, even if the ID of the root node changes when we go from the placeholder tree to the real tree. To accomplish this, I made the `node_id` field of `PlatformNode` an `Option`.

Also, I decided that while the adapter is in the placeholder state, the tree should reflect the real window focus state, rather than having its focus state always set to false. This is a precaution in case a mismatch between the actual window focus state and the UIA focus state of the window is ever a problem. I had thought that by not telling UIA that the window had focus until we had the real tree, we could prevent the AT from seeing the placeholder tree. But now I think it's not so bad if the AT initially sees an empty tree with just the window object. Assuming something within the window has focus, we do immediately raise a UIA focus event when we switch to the real tree.