### PR TITLE
fix!: Rename `accesskit_builder_set_text_selection` to `accesskit_node_builder_set_text_selection`

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -722,7 +722,7 @@ opt_struct! { opt_text_selection, text_selection }
 property_getters! { text_selection, opt_text_selection }
 impl node_builder {
     #[no_mangle]
-    pub extern "C" fn accesskit_builder_set_text_selection(
+    pub extern "C" fn accesskit_node_builder_set_text_selection(
         builder: *mut node_builder,
         value: text_selection,
     ) {


### PR DESCRIPTION
I missed this inconsistency when I originally reviewed the C bindings.