### PR TITLE
fix: Return to handling focus events directly, after generic node changes

### DIFF
--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -104,6 +104,14 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                 self.adapter.window_deactivated(&NodeWrapper(&root_window));
             }
         }
+        if let Some(node) = new_node {
+            self.adapter
+                .emit_object_event(node.id(), ObjectEvent::StateChanged(State::Focused, true));
+        }
+        if let Some(node) = old_node {
+            self.adapter
+                .emit_object_event(node.id(), ObjectEvent::StateChanged(State::Focused, false));
+        }
     }
 
     fn node_removed(&mut self, node: &Node) {

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -455,6 +455,10 @@ impl<'a> NodeWrapper<'a> {
         let new_state = self.state(true);
         let changed_states = old_state ^ new_state;
         for state in changed_states.iter() {
+            if state == State::Focused {
+                // This is handled specially in `focus_moved`.
+                continue;
+            }
             adapter.emit_object_event(
                 self.id(),
                 ObjectEvent::StateChanged(state, new_state.contains(state)),


### PR DESCRIPTION
I now believe that #354 was a mistake. So I've re-added the code in `focus_moved` to emit focus change events. But now, we specifically skip the focused state when looking for generic state changes. Reasons to do it this way:

1. If a node has just been added, whether actually added to the tree or just newly visible in the filtered tree, we don't generally want to emit state change events for that node, but if it's the focused node, we do have to emit a focus event.
2. If a node has other state changes at the same time that it receives focus, we want to emit the other state change events before the focus event. If we do it the other way around, as might happen depending on the order of the states, then Orca might read some states twice, once when presenting the newly focused node, and again in response to the state change event that was emitted after the focus change. I heard this happen; when leaving a menu and returning focus to the menu button, Orca would say something like, "Primary Menu, toggle button, not pressed. Not pressed."
3. Also on the topic of event order, we should emit the activation event for the window before emitting the focus event for the node within the window. This change makes sure that it happens in that order.