### PR TITLE
fix: Fix platform adapters to support copy-on-write tree snapshots again

### DIFF
--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, NodeId, Role, TreeUpdate};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler, TreeState};
 use atspi_common::{InterfaceSet, Live, State};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -13,7 +13,7 @@ use std::sync::{
 
 use crate::{
     context::{ActionHandlerNoMut, ActionHandlerWrapper, AppContext, Context},
-    filters::{filter, filter_detached},
+    filters::filter,
     node::{NodeIdOrRoot, NodeWrapper, PlatformNode, PlatformRoot},
     util::WindowBounds,
     AdapterCallback, Event, ObjectEvent, WindowEvent,
@@ -27,7 +27,7 @@ impl AdapterChangeHandler<'_> {
     fn add_node(&mut self, node: &Node) {
         let role = node.role();
         let is_root = node.is_root();
-        let node = NodeWrapper::Node(node);
+        let node = NodeWrapper(node);
         let interfaces = node.interfaces();
         self.adapter.register_interfaces(node.id(), interfaces);
         if is_root && role == Role::Window {
@@ -49,10 +49,10 @@ impl AdapterChangeHandler<'_> {
         }
     }
 
-    fn remove_node(&mut self, node: &DetachedNode) {
+    fn remove_node(&mut self, node: &Node) {
         let role = node.role();
         let is_root = node.is_root();
-        let node = NodeWrapper::DetachedNode(node);
+        let node = NodeWrapper(node);
         if is_root && role == Role::Window {
             self.adapter.window_destroyed(node.id());
         }
@@ -70,8 +70,8 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
-        let filter_old = filter_detached(old_node);
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+        let filter_old = filter(old_node);
         let filter_new = filter(new_node);
         if filter_new != filter_old {
             if filter_new == FilterResult::Include {
@@ -80,8 +80,8 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                 self.remove_node(old_node);
             }
         } else if filter_new == FilterResult::Include {
-            let old_wrapper = NodeWrapper::DetachedNode(old_node);
-            let new_wrapper = NodeWrapper::Node(new_node);
+            let old_wrapper = NodeWrapper(old_node);
+            let new_wrapper = NodeWrapper(new_node);
             let old_interfaces = old_wrapper.interfaces();
             let new_interfaces = new_wrapper.interfaces();
             let kept_interfaces = old_interfaces & new_interfaces;
@@ -94,25 +94,20 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        current_state: &TreeState,
-    ) {
-        if let Some(root_window) = root_window(current_state) {
-            if old_node.is_none() && new_node.is_some() {
-                self.adapter
-                    .window_activated(&NodeWrapper::Node(&root_window));
-            } else if old_node.is_some() && new_node.is_none() {
-                self.adapter
-                    .window_deactivated(&NodeWrapper::Node(&root_window));
+    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>) {
+        if let (None, Some(new_node)) = (old_node, new_node) {
+            if let Some(root_window) = root_window(new_node.tree_state) {
+                self.adapter.window_activated(&NodeWrapper(&root_window));
+            }
+        } else if let (Some(old_node), None) = (old_node, new_node) {
+            if let Some(root_window) = root_window(old_node.tree_state) {
+                self.adapter.window_deactivated(&NodeWrapper(&root_window));
             }
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, _: &TreeState) {
-        if filter_detached(node) == FilterResult::Include {
+    fn node_removed(&mut self, node: &Node) {
+        if filter(node) == FilterResult::Include {
             self.remove_node(node);
         }
     }
@@ -204,7 +199,7 @@ impl Adapter {
         fn add_children(node: Node<'_>, to_add: &mut Vec<(NodeId, InterfaceSet)>) {
             for child in node.filtered_children(&filter) {
                 let child_id = child.id();
-                let wrapper = NodeWrapper::Node(&child);
+                let wrapper = NodeWrapper(&child);
                 let interfaces = wrapper.interfaces();
                 to_add.push((child_id, interfaces));
                 add_children(child, to_add);
@@ -223,7 +218,7 @@ impl Adapter {
             let adapter_index = app_context.adapter_index(self.id).unwrap();
             let root = tree_state.root();
             let root_id = root.id();
-            let wrapper = NodeWrapper::Node(&root);
+            let wrapper = NodeWrapper(&root);
             objects_to_add.push((root_id, wrapper.interfaces()));
             add_children(root, &mut objects_to_add);
             (adapter_index, root_id)

--- a/platforms/atspi-common/src/filters.rs
+++ b/platforms/atspi-common/src/filters.rs
@@ -3,6 +3,4 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-};
+pub(crate) use accesskit_consumer::common_filter as filter;

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -4,17 +4,13 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Live, NodeId, Role};
-use accesskit_consumer::{DetachedNode, FilterResult, Node, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, TreeChangeHandler};
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_app_kit::*;
 use objc2_foundation::{NSMutableDictionary, NSNumber, NSString};
 use std::{collections::HashSet, rc::Rc};
 
-use crate::{
-    context::Context,
-    filters::{filter, filter_detached},
-    node::NodeWrapper,
-};
+use crate::{context::Context, filters::filter, node::NodeWrapper};
 
 // This type is designed to be safe to create on a non-main thread
 // and send to the main thread. This ability isn't yet used though.
@@ -184,21 +180,6 @@ impl EventGenerator {
             self.insert_text_change_if_needed_parent(node);
         }
     }
-
-    fn insert_text_change_if_needed_for_removed_node(
-        &mut self,
-        node: &DetachedNode,
-        current_state: &TreeState,
-    ) {
-        if node.role() != Role::InlineTextBox {
-            return;
-        }
-        if let Some(id) = node.parent_id() {
-            if let Some(node) = current_state.node_by_id(id) {
-                self.insert_text_change_if_needed_parent(node);
-            }
-        }
-    }
 }
 
 impl TreeChangeHandler for EventGenerator {
@@ -213,7 +194,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -221,8 +202,8 @@ impl TreeChangeHandler for EventGenerator {
             return;
         }
         let node_id = new_node.id();
-        let old_wrapper = NodeWrapper::DetachedNode(old_node);
-        let new_wrapper = NodeWrapper::Node(new_node);
+        let old_wrapper = NodeWrapper(old_node);
+        let new_wrapper = NodeWrapper(new_node);
         if old_wrapper.title() != new_wrapper.title() {
             self.events.push(QueuedEvent::Generic {
                 node_id,
@@ -248,19 +229,14 @@ impl TreeChangeHandler for EventGenerator {
             && new_node.live() != Live::Off
             && (new_node.name() != old_node.name()
                 || new_node.live() != old_node.live()
-                || filter_detached(old_node) != FilterResult::Include)
+                || filter(old_node) != FilterResult::Include)
         {
             self.events
                 .push(QueuedEvent::live_region_announcement(new_node));
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        _old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        _current_state: &TreeState,
-    ) {
+    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
         if let Some(new_node) = new_node {
             if filter(new_node) != FilterResult::Include {
                 return;
@@ -269,8 +245,8 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
-        self.insert_text_change_if_needed_for_removed_node(node, current_state);
+    fn node_removed(&mut self, node: &Node) {
+        self.insert_text_change_if_needed(node);
         self.events.push(QueuedEvent::NodeDestroyed(node.id()));
     }
 }

--- a/platforms/macos/src/filters.rs
+++ b/platforms/macos/src/filters.rs
@@ -3,6 +3,4 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-};
+pub(crate) use accesskit_consumer::common_filter as filter;

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -6,7 +6,7 @@
 use accesskit::{
     ActionHandler, ActivationHandler, Live, NodeBuilder, NodeId, Role, Tree as TreeData, TreeUpdate,
 };
-use accesskit_consumer::{DetachedNode, FilterResult, Node, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
 use std::{
     collections::HashSet,
     sync::{atomic::Ordering, Arc},
@@ -18,7 +18,7 @@ use windows::Win32::{
 
 use crate::{
     context::{ActionHandlerNoMut, ActionHandlerWrapper, Context},
-    filters::{filter, filter_detached},
+    filters::filter,
     node::{NodeWrapper, PlatformNode},
     util::QueuedEvent,
 };
@@ -80,21 +80,6 @@ impl AdapterChangeHandler<'_> {
             self.insert_text_change_if_needed_parent(node);
         }
     }
-
-    fn insert_text_change_if_needed_for_removed_node(
-        &mut self,
-        node: &DetachedNode,
-        current_state: &TreeState,
-    ) {
-        if node.role() != Role::InlineTextBox {
-            return;
-        }
-        if let Some(id) = node.parent_id() {
-            if let Some(node) = current_state.node_by_id(id) {
-                self.insert_text_change_if_needed_parent(node);
-            }
-        }
-    }
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
@@ -113,7 +98,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_updated(&mut self, old_node: &DetachedNode, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -122,14 +107,14 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
         let platform_node = PlatformNode::new(self.context, new_node.id());
         let element: IRawElementProviderSimple = platform_node.into();
-        let old_wrapper = NodeWrapper::DetachedNode(old_node);
-        let new_wrapper = NodeWrapper::Node(new_node);
+        let old_wrapper = NodeWrapper(old_node);
+        let new_wrapper = NodeWrapper(new_node);
         new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
         if new_node.name().is_some()
             && new_node.live() != Live::Off
             && (new_node.name() != old_node.name()
                 || new_node.live() != old_node.live()
-                || filter_detached(old_node) != FilterResult::Include)
+                || filter(old_node) != FilterResult::Include)
         {
             self.queue.push(QueuedEvent::Simple {
                 element,
@@ -138,19 +123,14 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(
-        &mut self,
-        _old_node: Option<&DetachedNode>,
-        new_node: Option<&Node>,
-        _current_state: &TreeState,
-    ) {
+    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
         if let Some(new_node) = new_node {
             self.queue.push(focus_event(self.context, new_node.id()));
         }
     }
 
-    fn node_removed(&mut self, node: &DetachedNode, current_state: &TreeState) {
-        self.insert_text_change_if_needed_for_removed_node(node, current_state);
+    fn node_removed(&mut self, node: &Node) {
+        self.insert_text_change_if_needed(node);
     }
 
     // TODO: handle other events (#20)

--- a/platforms/windows/src/filters.rs
+++ b/platforms/windows/src/filters.rs
@@ -4,6 +4,5 @@
 // the LICENSE-MIT file), at your option.
 
 pub(crate) use accesskit_consumer::{
-    common_filter as filter, common_filter_detached as filter_detached,
-    common_filter_with_root_exception as filter_with_root_exception,
+    common_filter as filter, common_filter_with_root_exception as filter_with_root_exception,
 };


### PR DESCRIPTION
This is the other half of #365 