### PR TITLE
fix: Fix a logic error that sometimes caused filtered traversal to stop prematurely

### DIFF
--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -191,6 +191,7 @@ fn next_filtered_sibling<'a>(
             if result == FilterResult::Include {
                 return next;
             }
+            consider_children = result == FilterResult::ExcludeNode;
         } else if let Some(sibling) = current.following_siblings().next() {
             let result = filter(&sibling);
             next = Some(sibling);
@@ -229,6 +230,7 @@ fn previous_filtered_sibling<'a>(
             if result == FilterResult::Include {
                 return previous;
             }
+            consider_children = result == FilterResult::ExcludeNode;
         } else if let Some(sibling) = current.preceding_siblings().next() {
             let result = filter(&sibling);
             previous = Some(sibling);
@@ -629,7 +631,7 @@ mod tests {
             .is_none());
         assert_eq!(
             [
-                STATIC_TEXT_1_0_ID,
+                STATIC_TEXT_1_1_ID,
                 PARAGRAPH_2_ID,
                 STATIC_TEXT_3_1_0_ID,
                 BUTTON_3_2_ID
@@ -673,7 +675,7 @@ mod tests {
                 BUTTON_3_2_ID,
                 STATIC_TEXT_3_1_0_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_1_0_ID
+                STATIC_TEXT_1_1_ID
             ],
             tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
@@ -712,7 +714,7 @@ mod tests {
             .next()
             .is_none());
         assert_eq!(
-            [PARAGRAPH_2_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_0_ID],
+            [PARAGRAPH_2_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_0_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -721,7 +723,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
-            [PARAGRAPH_2_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_0_ID],
+            [PARAGRAPH_2_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_0_ID],
             tree.state()
                 .node_by_id(STATIC_TEXT_3_1_0_ID)
                 .unwrap()
@@ -748,7 +750,7 @@ mod tests {
             .next_back()
             .is_none());
         assert_eq!(
-            [PARAGRAPH_0_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_2_ID],
+            [PARAGRAPH_0_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_2_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -758,7 +760,7 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
-            [PARAGRAPH_0_ID, STATIC_TEXT_1_0_ID, PARAGRAPH_2_ID],
+            [PARAGRAPH_0_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_2_ID],
             tree.state()
                 .node_by_id(STATIC_TEXT_3_1_0_ID)
                 .unwrap()
@@ -782,7 +784,7 @@ mod tests {
         assert_eq!(
             [
                 PARAGRAPH_0_ID,
-                STATIC_TEXT_1_0_ID,
+                STATIC_TEXT_1_1_ID,
                 PARAGRAPH_2_ID,
                 STATIC_TEXT_3_1_0_ID,
                 BUTTON_3_2_ID
@@ -817,7 +819,7 @@ mod tests {
                 BUTTON_3_2_ID,
                 STATIC_TEXT_3_1_0_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_1_0_ID,
+                STATIC_TEXT_1_1_ID,
                 PARAGRAPH_0_ID
             ],
             tree.state()

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -30,15 +30,19 @@ mod tests {
     pub const PARAGRAPH_0_ID: NodeId = NodeId(1);
     pub const STATIC_TEXT_0_0_IGNORED_ID: NodeId = NodeId(2);
     pub const PARAGRAPH_1_IGNORED_ID: NodeId = NodeId(3);
-    pub const STATIC_TEXT_1_0_ID: NodeId = NodeId(4);
-    pub const PARAGRAPH_2_ID: NodeId = NodeId(5);
-    pub const STATIC_TEXT_2_0_ID: NodeId = NodeId(6);
-    pub const PARAGRAPH_3_IGNORED_ID: NodeId = NodeId(7);
-    pub const EMPTY_CONTAINER_3_0_IGNORED_ID: NodeId = NodeId(8);
-    pub const LINK_3_1_IGNORED_ID: NodeId = NodeId(9);
-    pub const STATIC_TEXT_3_1_0_ID: NodeId = NodeId(10);
-    pub const BUTTON_3_2_ID: NodeId = NodeId(11);
-    pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId = NodeId(12);
+    pub const BUTTON_1_0_HIDDEN_ID: NodeId = NodeId(4);
+    pub const CONTAINER_1_0_0_HIDDEN_ID: NodeId = NodeId(5);
+    pub const STATIC_TEXT_1_1_ID: NodeId = NodeId(6);
+    pub const BUTTON_1_2_HIDDEN_ID: NodeId = NodeId(7);
+    pub const CONTAINER_1_2_0_HIDDEN_ID: NodeId = NodeId(8);
+    pub const PARAGRAPH_2_ID: NodeId = NodeId(9);
+    pub const STATIC_TEXT_2_0_ID: NodeId = NodeId(10);
+    pub const PARAGRAPH_3_IGNORED_ID: NodeId = NodeId(11);
+    pub const EMPTY_CONTAINER_3_0_IGNORED_ID: NodeId = NodeId(12);
+    pub const LINK_3_1_IGNORED_ID: NodeId = NodeId(13);
+    pub const STATIC_TEXT_3_1_0_ID: NodeId = NodeId(14);
+    pub const BUTTON_3_2_ID: NodeId = NodeId(15);
+    pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId = NodeId(16);
 
     pub fn test_tree() -> crate::tree::Tree {
         let root = {
@@ -70,10 +74,26 @@ mod tests {
                 x1: 800.0,
                 y1: 40.0,
             });
-            builder.set_children(vec![STATIC_TEXT_1_0_ID]);
+            builder.set_children(vec![
+                BUTTON_1_0_HIDDEN_ID,
+                STATIC_TEXT_1_1_ID,
+                BUTTON_1_2_HIDDEN_ID,
+            ]);
             builder.build()
         };
-        let static_text_1_0 = {
+        let button_1_0_hidden = {
+            let mut builder = NodeBuilder::new(Role::Button);
+            builder.set_name("button_1_0_hidden");
+            builder.set_hidden();
+            builder.set_children(vec![CONTAINER_1_0_0_HIDDEN_ID]);
+            builder.build()
+        };
+        let container_1_0_0_hidden = {
+            let mut builder = NodeBuilder::new(Role::GenericContainer);
+            builder.set_hidden();
+            builder.build()
+        };
+        let static_text_1_1 = {
             let mut builder = NodeBuilder::new(Role::StaticText);
             builder.set_bounds(Rect {
                 x0: 10.0,
@@ -81,7 +101,19 @@ mod tests {
                 x1: 90.0,
                 y1: 30.0,
             });
-            builder.set_name("static_text_1_0");
+            builder.set_name("static_text_1_1");
+            builder.build()
+        };
+        let button_1_2_hidden = {
+            let mut builder = NodeBuilder::new(Role::Button);
+            builder.set_name("button_1_2_hidden");
+            builder.set_hidden();
+            builder.set_children(vec![CONTAINER_1_2_0_HIDDEN_ID]);
+            builder.build()
+        };
+        let container_1_2_0_hidden = {
+            let mut builder = NodeBuilder::new(Role::GenericContainer);
+            builder.set_hidden();
             builder.build()
         };
         let paragraph_2 = {
@@ -128,7 +160,11 @@ mod tests {
                 (PARAGRAPH_0_ID, paragraph_0),
                 (STATIC_TEXT_0_0_IGNORED_ID, static_text_0_0_ignored),
                 (PARAGRAPH_1_IGNORED_ID, paragraph_1_ignored),
-                (STATIC_TEXT_1_0_ID, static_text_1_0),
+                (BUTTON_1_0_HIDDEN_ID, button_1_0_hidden),
+                (CONTAINER_1_0_0_HIDDEN_ID, container_1_0_0_hidden),
+                (STATIC_TEXT_1_1_ID, static_text_1_1),
+                (BUTTON_1_2_HIDDEN_ID, button_1_2_hidden),
+                (CONTAINER_1_2_0_HIDDEN_ID, container_1_2_0_hidden),
                 (PARAGRAPH_2_ID, paragraph_2),
                 (STATIC_TEXT_2_0_ID, static_text_2_0),
                 (PARAGRAPH_3_IGNORED_ID, paragraph_3_ignored),
@@ -146,7 +182,9 @@ mod tests {
 
     pub fn test_tree_filter(node: &crate::Node) -> FilterResult {
         let id = node.id();
-        if id == STATIC_TEXT_0_0_IGNORED_ID
+        if node.is_hidden() {
+            FilterResult::ExcludeSubtree
+        } else if id == STATIC_TEXT_0_0_IGNORED_ID
             || id == PARAGRAPH_1_IGNORED_ID
             || id == PARAGRAPH_3_IGNORED_ID
             || id == EMPTY_CONTAINER_3_0_IGNORED_ID

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(
             ROOT_ID,
             tree.state()
-                .node_by_id(STATIC_TEXT_1_0_ID)
+                .node_by_id(STATIC_TEXT_1_1_ID)
                 .unwrap()
                 .filtered_parent(&test_tree_filter)
                 .unwrap()
@@ -871,7 +871,7 @@ mod tests {
                 y1: 70.0,
             }),
             tree.state()
-                .node_by_id(STATIC_TEXT_1_0_ID)
+                .node_by_id(STATIC_TEXT_1_1_ID)
                 .unwrap()
                 .bounding_box()
         );
@@ -886,14 +886,14 @@ mod tests {
             .node_at_point(Point::new(10.0, 40.0), &test_tree_filter)
             .is_none());
         assert_eq!(
-            Some(STATIC_TEXT_1_0_ID),
+            Some(STATIC_TEXT_1_1_ID),
             tree.state()
                 .root()
                 .node_at_point(Point::new(20.0, 50.0), &test_tree_filter)
                 .map(|node| node.id())
         );
         assert_eq!(
-            Some(STATIC_TEXT_1_0_ID),
+            Some(STATIC_TEXT_1_1_ID),
             tree.state()
                 .root()
                 .node_at_point(Point::new(50.0, 60.0), &test_tree_filter)


### PR DESCRIPTION
I came across this while testing my GTK AccessKit implementation with a real GNOME app. We forgot to reset `consider_children` in the case where the filter result for the child is `ExcludeSubtree`. The new nodes I added to the test tree follow the same pattern as the nodes in the real app tree that triggered this bug.