### PR TITLE
feat: Expose the `placeholder` property

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -511,6 +511,12 @@ impl<'a> Node<'a> {
             .map(|description| description.to_string())
     }
 
+    pub fn placeholder(&self) -> Option<String> {
+        self.data()
+            .placeholder()
+            .map(|placeholder| placeholder.to_string())
+    }
+
     pub fn value(&self) -> Option<String> {
         if let Some(value) = &self.data().value() {
             Some(value.to_string())

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -18,6 +18,7 @@ use atspi_common::{
     StateSet,
 };
 use std::{
+    collections::HashMap,
     hash::{Hash, Hasher},
     iter::FusedIterator,
     sync::{Arc, RwLock, RwLockReadGuard, Weak},
@@ -335,6 +336,14 @@ impl<'a> NodeWrapper<'a> {
         }
 
         atspi_state
+    }
+
+    fn attributes(&self) -> HashMap<&'static str, String> {
+        let mut attributes = HashMap::new();
+        if let Some(placeholder) = self.0.placeholder() {
+            attributes.insert("placeholder-text", placeholder);
+        }
+        attributes
     }
 
     fn is_root(&self) -> bool {
@@ -728,6 +737,13 @@ impl PlatformNode {
             Ok(wrapper.state(context.read_tree().state().focus_id().is_some()))
         })
         .unwrap_or(State::Defunct.into())
+    }
+
+    pub fn attributes(&self) -> Result<HashMap<&'static str, String>> {
+        self.resolve(|node| {
+            let wrapper = NodeWrapper(&node);
+            Ok(wrapper.attributes())
+        })
     }
 
     pub fn supports_action(&self) -> Result<bool> {

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -7,6 +7,8 @@
 //! intended to be used by bindings to languages with less rich
 //! type systems.
 
+use std::collections::HashMap;
+
 use crate::{
     Adapter, Event as EventEnum, NodeIdOrRoot, ObjectEvent, PlatformNode, PlatformRoot, Property,
     WindowEvent,
@@ -53,6 +55,13 @@ impl Accessible {
         match self {
             Self::Node(node) => node.state(),
             Self::Root(_) => StateSet::empty(),
+        }
+    }
+
+    pub fn attributes(&self) -> Result<HashMap<&'static str, String>> {
+        match self {
+            Self::Node(node) => node.attributes(),
+            Self::Root(_) => Ok(HashMap::new()),
         }
     }
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -420,7 +420,7 @@ declare_class!(
         #[method_id(accessibilityPlaceholderValue)]
         fn placeholder(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
-                let wrapper = NodeWrapper::Node(node);
+                let wrapper = NodeWrapper(node);
                 wrapper.placeholder().map(|placeholder| NSString::from_str(&placeholder))
             })
             .flatten()

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -278,6 +278,10 @@ impl<'a> NodeWrapper<'a> {
         self.0.description()
     }
 
+    pub(crate) fn placeholder(&self) -> Option<String> {
+        self.0.placeholder()
+    }
+
     pub(crate) fn value(&self) -> Option<Value> {
         let state = self.0;
         if let Some(toggled) = state.toggled() {
@@ -409,6 +413,15 @@ declare_class!(
             self.resolve(|node| {
                 let wrapper = NodeWrapper(node);
                 wrapper.description().map(|description| NSString::from_str(&description))
+            })
+            .flatten()
+        }
+
+        #[method_id(accessibilityPlaceholderValue)]
+        fn placeholder(&self) -> Option<Id<NSString>> {
+            self.resolve(|node| {
+                let wrapper = NodeWrapper::Node(node);
+                wrapper.placeholder().map(|placeholder| NSString::from_str(&placeholder))
             })
             .flatten()
         }
@@ -752,6 +765,7 @@ declare_class!(
                     || selector == sel!(accessibilityRoleDescription)
                     || selector == sel!(accessibilityTitle)
                     || selector == sel!(accessibilityHelp)
+                    || selector == sel!(accessibilityPlaceholderValue)
                     || selector == sel!(accessibilityValue)
                     || selector == sel!(accessibilityMinValue)
                     || selector == sel!(accessibilityMaxValue)

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -3,6 +3,8 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
+use std::collections::HashMap;
+
 use accesskit_atspi_common::{NodeIdOrRoot, PlatformNode, PlatformRoot};
 use atspi::{Interface, InterfaceSet, Role, StateSet};
 use zbus::{fdo, names::OwnedUniqueName};
@@ -107,6 +109,10 @@ impl NodeAccessibleInterface {
 
     fn get_state(&self) -> StateSet {
         self.node.state()
+    }
+
+    fn get_attributes(&self) -> fdo::Result<HashMap<&str, String>> {
+        self.node.attributes().map_err(self.map_error())
     }
 
     fn get_application(&self) -> (OwnedObjectAddress,) {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -265,6 +265,10 @@ impl<'a> NodeWrapper<'a> {
         self.0.description()
     }
 
+    fn placeholder(&self) -> Option<String> {
+        self.0.placeholder()
+    }
+
     fn is_content_element(&self) -> bool {
         filter(self.0) == FilterResult::Include
     }
@@ -852,6 +856,7 @@ properties! {
     (LocalizedControlType, localized_control_type),
     (Name, name),
     (FullDescription, description),
+    (HelpText, placeholder),
     (IsContentElement, is_content_element),
     (IsControlElement, is_content_element),
     (IsEnabled, is_enabled),


### PR DESCRIPTION
The only notable difference with the Chromium implementation is the name of the attribute holding the value on Unix. Chromium uses `placeholder` as it is common with IAccessible2. I chose to use `placeholder-text` as that is what Orca checks first, and that is also what GTK uses.

Also worth mentioning that the AT-SPI "specification" says that we should fire `attribute-changed` events, but Chromium doesn't do it and I think it would be costly to rebuild the hashmap everytime once we'll start adding more attributes.

These changes were tested on all platforms with the example below:

<details><summary>platforms/winit/examples/placeholder.rs</summary>
<p>

```rust
use accesskit::{
    Action, DefaultActionVerb, Node, NodeBuilder, NodeId, Rect, Role, Tree, TreeUpdate,
};
use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
use std::error::Error;
use winit::{
    application::ApplicationHandler,
    event::WindowEvent,
    event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy},
    window::{Window, WindowId},
};

const WINDOW_TITLE: &str = "Placeholder test";

const WINDOW_ID: NodeId = NodeId(0);
const TEXT_ENTRY_ID: NodeId = NodeId(1);
const INITIAL_FOCUS: NodeId = TEXT_ENTRY_ID;

const TEXT_ENTRY_RECT: Rect = Rect {
    x0: 20.0,
    y0: 20.0,
    x1: 200.0,
    y1: 60.0,
};

fn build_text_entry(name: &str, placeholder: &str) -> Node {
    let mut builder = NodeBuilder::new(Role::TextInput);
    builder.set_bounds(TEXT_ENTRY_RECT);
    builder.set_name(name);
    builder.set_placeholder(placeholder);
    builder.add_action(Action::Focus);
    builder.set_default_action_verb(DefaultActionVerb::Click);
    builder.build()
}

struct UiState {
    focus: NodeId,
}

impl UiState {
    fn new() -> Self {
        Self {
            focus: INITIAL_FOCUS,
        }
    }

    fn build_root(&mut self) -> Node {
        let mut builder = NodeBuilder::new(Role::Window);
        builder.push_child(TEXT_ENTRY_ID);
        builder.set_name(WINDOW_TITLE);
        builder.build()
    }

    fn build_initial_tree(&mut self) -> TreeUpdate {
        let root = self.build_root();
        let text_entry = build_text_entry("Enter your name:", "John Smith");
        let mut tree = Tree::new(WINDOW_ID);
        tree.app_name = Some("placeholder_example".to_string());
        TreeUpdate {
            nodes: vec![(WINDOW_ID, root), (TEXT_ENTRY_ID, text_entry)],
            tree: Some(tree),
            focus: self.focus,
        }
    }
}

struct WindowState {
    window: Window,
    adapter: Adapter,
    ui: UiState,
}

impl WindowState {
    fn new(window: Window, adapter: Adapter, ui: UiState) -> Self {
        Self {
            window,
            adapter,
            ui,
        }
    }
}

struct Application {
    event_loop_proxy: EventLoopProxy<AccessKitEvent>,
    window: Option<WindowState>,
}

impl Application {
    fn new(event_loop_proxy: EventLoopProxy<AccessKitEvent>) -> Self {
        Self {
            event_loop_proxy,
            window: None,
        }
    }

    fn create_window(&mut self, event_loop: &ActiveEventLoop) -> Result<(), Box<dyn Error>> {
        let window_attributes = Window::default_attributes()
            .with_title(WINDOW_TITLE)
            .with_visible(false);

        let window = event_loop.create_window(window_attributes)?;
        let adapter = Adapter::with_event_loop_proxy(&window, self.event_loop_proxy.clone());
        window.set_visible(true);

        self.window = Some(WindowState::new(window, adapter, UiState::new()));
        Ok(())
    }
}

impl ApplicationHandler<AccessKitEvent> for Application {
    fn window_event(&mut self, _: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;

        adapter.process_event(&window.window, &event);
        match event {
            WindowEvent::CloseRequested => {
                self.window = None;
            }
            _ => (),
        }
    }

    fn user_event(&mut self, _: &ActiveEventLoop, user_event: AccessKitEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;
        let state = &mut window.ui;

        match user_event.window_event {
            AccessKitWindowEvent::InitialTreeRequested => {
                adapter.update_if_active(|| state.build_initial_tree());
            }
            _ => (),
        }
    }

    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
        self.create_window(event_loop)
            .expect("failed to create initial window");
    }

    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
        if self.window.is_none() {
            event_loop.exit();
        }
    }
}

fn main() -> Result<(), Box<dyn Error>> {
    let event_loop = EventLoop::with_user_event().build()?;
    let mut state = Application::new(event_loop.create_proxy());
    event_loop.run_app(&mut state).map_err(Into::into)
}
```

</p>
</details> 