### PR TITLE
feat: Expose the `orientation` property

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -11,8 +11,7 @@
 use std::{iter::FusedIterator, sync::Arc};
 
 use accesskit::{
-    Action, Affine, DefaultActionVerb, Live, Node as NodeData, NodeId, Point, Rect, Role,
-    TextSelection, Toggled,
+    Action, Affine, DefaultActionVerb, Live, Node as NodeData, NodeId, Orientation, Point, Rect, Role, TextSelection, Toggled
 };
 
 use crate::filters::FilterResult;
@@ -394,6 +393,10 @@ impl<'a> Node<'a> {
 
     pub fn is_multiline(&self) -> bool {
         self.role() == Role::MultilineTextInput
+    }
+
+    pub fn orientation(&self) -> Option<Orientation> {
+        self.data().orientation()
     }
 
     pub fn default_action_verb(&self) -> Option<DefaultActionVerb> {

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -11,7 +11,8 @@
 use std::{iter::FusedIterator, sync::Arc};
 
 use accesskit::{
-    Action, Affine, DefaultActionVerb, Live, Node as NodeData, NodeId, Orientation, Point, Rect, Role, TextSelection, Toggled
+    Action, Affine, DefaultActionVerb, Live, Node as NodeData, NodeId, Orientation, Point, Rect,
+    Role, TextSelection, Toggled,
 };
 
 use crate::filters::FilterResult;

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -9,8 +9,8 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    Action, ActionData, ActionRequest, Affine, DefaultActionVerb, Live, NodeId, Point, Rect, Role,
-    Toggled,
+    Action, ActionData, ActionRequest, Affine, DefaultActionVerb, Live, NodeId, Orientation, Point,
+    Rect, Role, Toggled,
 };
 use accesskit_consumer::{FilterResult, Node, TreeState};
 use atspi_common::{
@@ -289,6 +289,13 @@ impl<'a> NodeWrapper<'a> {
         // TODO: Focus and selection.
         if state.is_focusable() {
             atspi_state.insert(State::Focusable);
+        }
+        if let Some(orientation) = state.orientation() {
+            atspi_state.insert(if orientation == Orientation::Horizontal {
+                State::Horizontal
+            } else {
+                State::Vertical
+            });
         }
         let filter_result = filter(self.0);
         if filter_result == FilterResult::Include {

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -10,7 +10,9 @@
 
 #![allow(non_upper_case_globals)]
 
-use accesskit::{Action, ActionData, ActionRequest, NodeId, Role, TextSelection, Toggled};
+use accesskit::{
+    Action, ActionData, ActionRequest, NodeId, Orientation, Role, TextSelection, Toggled,
+};
 use accesskit_consumer::{FilterResult, Node};
 use objc2::{
     declare_class, msg_send_id,
@@ -467,6 +469,18 @@ declare_class!(
             .flatten()
         }
 
+        #[method(accessibilityOrientation)]
+        fn orientation(&self) -> NSAccessibilityOrientation {
+            self.resolve(|node| {
+                match node.orientation() {
+                    Some(Orientation::Horizontal) => NSAccessibilityOrientation::Horizontal,
+                    Some(Orientation::Vertical) => NSAccessibilityOrientation::Vertical,
+                    None => NSAccessibilityOrientation::Unknown,
+                }
+            })
+            .unwrap_or(NSAccessibilityOrientation::Unknown)
+        }
+
         #[method(isAccessibilityElement)]
         fn is_accessibility_element(&self) -> bool {
             self.resolve(|node| filter(node) == FilterResult::Include)
@@ -769,6 +783,7 @@ declare_class!(
                     || selector == sel!(accessibilityValue)
                     || selector == sel!(accessibilityMinValue)
                     || selector == sel!(accessibilityMaxValue)
+                    || selector == sel!(accessibilityOrientation)
                     || selector == sel!(isAccessibilityElement)
                     || selector == sel!(isAccessibilityFocused)
                     || selector == sel!(accessibilityNotifiesWhenDestroyed)

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -11,7 +11,8 @@
 #![allow(non_upper_case_globals)]
 
 use accesskit::{
-    Action, ActionData, ActionRequest, Live, NodeId, NodeIdContent, Point, Role, Toggled,
+    Action, ActionData, ActionRequest, Live, NodeId, NodeIdContent, Orientation, Point, Role,
+    Toggled,
 };
 use accesskit_consumer::{FilterResult, Node, TreeState};
 use paste::paste;
@@ -296,6 +297,14 @@ impl<'a> NodeWrapper<'a> {
 
     fn class_name(&self) -> Option<&str> {
         self.0.class_name()
+    }
+
+    fn orientation(&self) -> OrientationType {
+        match self.0.orientation() {
+            Some(Orientation::Horizontal) => OrientationType_Horizontal,
+            Some(Orientation::Vertical) => OrientationType_Vertical,
+            None => OrientationType_None,
+        }
     }
 
     fn is_toggle_pattern_supported(&self) -> bool {
@@ -863,7 +872,8 @@ properties! {
     (IsKeyboardFocusable, is_focusable),
     (HasKeyboardFocus, is_focused),
     (LiveSetting, live_setting),
-    (ClassName, class_name)
+    (ClassName, class_name),
+    (Orientation, orientation)
 }
 
 patterns! {

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -95,6 +95,12 @@ impl From<UIA_CONTROLTYPE_ID> for Variant {
     }
 }
 
+impl From<OrientationType> for Variant {
+    fn from(value: OrientationType) -> Self {
+        Self(value.0.into())
+    }
+}
+
 impl From<bool> for Variant {
     fn from(value: bool) -> Self {
         Self(value.into())


### PR DESCRIPTION
These changes were tested on all platforms with the example below:

<details><summary>platforms/winit/examples/orientation.rs</summary>
<p>

```rust
use accesskit::{
    Action, DefaultActionVerb, Node, NodeBuilder, NodeId, Orientation, Rect, Role, Tree, TreeUpdate,
};
use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
use std::error::Error;
use winit::{
    application::ApplicationHandler,
    event::WindowEvent,
    event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy},
    window::{Window, WindowId},
};

const WINDOW_TITLE: &str = "Orientation test";

const WINDOW_ID: NodeId = NodeId(0);
const HORIZONTAL_SCROLLBAR_ID: NodeId = NodeId(1);
const VERTICAL_SCROLLBAR_ID: NodeId = NodeId(2);
const INITIAL_FOCUS: NodeId = WINDOW_ID;

const HORIZONTAL_SCROLLBAR_RECT: Rect = Rect {
    x0: 0.0,
    y0: 380.0,
    x1: 380.0,
    y1: 400.0,
};

const VERTICAL_SCROLLBAR_RECT: Rect = Rect {
    x0: 380.0,
    y0: 0.0,
    x1: 400.0,
    y1: 380.0,
};

fn build_scrollbar(bounds: Rect, orientation: Orientation, value: f64) -> Node {
    let mut builder = NodeBuilder::new(Role::ScrollBar);
    builder.set_bounds(bounds);
    builder.set_orientation(orientation);
    builder.set_min_numeric_value(0.0);
    builder.set_max_numeric_value(100.0);
    builder.set_numeric_value(value);
    builder.add_action(Action::Focus);
    builder.set_default_action_verb(DefaultActionVerb::Click);
    builder.build()
}

struct UiState;

impl UiState {
    fn new() -> Self {
        Self {}
    }

    fn build_root(&mut self) -> Node {
        let mut builder = NodeBuilder::new(Role::Window);
        builder.set_children(&[HORIZONTAL_SCROLLBAR_ID, VERTICAL_SCROLLBAR_ID]);
        builder.set_name(WINDOW_TITLE);
        builder.build()
    }

    fn build_initial_tree(&mut self) -> TreeUpdate {
        let root = self.build_root();
        let hbar = build_scrollbar(HORIZONTAL_SCROLLBAR_RECT, Orientation::Horizontal, 0.0);
        let vbar = build_scrollbar(VERTICAL_SCROLLBAR_RECT, Orientation::Vertical, 50.0);
        let mut tree = Tree::new(WINDOW_ID);
        tree.app_name = Some("orientation_example".to_string());
        TreeUpdate {
            nodes: vec![
                (WINDOW_ID, root),
                (HORIZONTAL_SCROLLBAR_ID, hbar),
                (VERTICAL_SCROLLBAR_ID, vbar),
            ],
            tree: Some(tree),
            focus: INITIAL_FOCUS,
        }
    }
}

struct WindowState {
    window: Window,
    adapter: Adapter,
    ui: UiState,
}

impl WindowState {
    fn new(window: Window, adapter: Adapter, ui: UiState) -> Self {
        Self {
            window,
            adapter,
            ui,
        }
    }
}

struct Application {
    event_loop_proxy: EventLoopProxy<AccessKitEvent>,
    window: Option<WindowState>,
}

impl Application {
    fn new(event_loop_proxy: EventLoopProxy<AccessKitEvent>) -> Self {
        Self {
            event_loop_proxy,
            window: None,
        }
    }

    fn create_window(&mut self, event_loop: &ActiveEventLoop) -> Result<(), Box<dyn Error>> {
        let window_attributes = Window::default_attributes()
            .with_title(WINDOW_TITLE)
            .with_visible(false);

        let window = event_loop.create_window(window_attributes)?;
        let adapter = Adapter::with_event_loop_proxy(&window, self.event_loop_proxy.clone());
        window.set_visible(true);

        self.window = Some(WindowState::new(window, adapter, UiState::new()));
        Ok(())
    }
}

impl ApplicationHandler<AccessKitEvent> for Application {
    fn window_event(&mut self, _: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;

        adapter.process_event(&window.window, &event);
        match event {
            WindowEvent::CloseRequested => {
                self.window = None;
            }
            _ => (),
        }
    }

    fn user_event(&mut self, _: &ActiveEventLoop, user_event: AccessKitEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;
        let state = &mut window.ui;

        match user_event.window_event {
            AccessKitWindowEvent::InitialTreeRequested => {
                adapter.update_if_active(|| state.build_initial_tree());
            }
            _ => (),
        }
    }

    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
        self.create_window(event_loop)
            .expect("failed to create initial window");
    }

    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
        if self.window.is_none() {
            event_loop.exit();
        }
    }
}

fn main() -> Result<(), Box<dyn Error>> {
    let event_loop = EventLoop::with_user_event().build()?;
    let mut state = Application::new(event_loop.create_proxy());
    event_loop.run_app(&mut state).map_err(Into::into)
}
```

</p>
</details> 

- On Windows: neither NVDA nor Narrator report this apparently, I checked that it was indeed exposed via Accessibility Insights.
- On Linux: Orca announces the orientation of both scrollbars when navigating in flat review mode.
- On macOS: VoiceOver announces the orientation of both scrollbars. Note that Chromium doesn't implement this so I hope I'm doing it right.