### PR TITLE
fix: Fix a logic error in suffix calculation for text changes

### DIFF
--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -104,10 +104,10 @@ impl<'a> AdapterChangeHandler<'a> {
             }
         }
 
-        let suffix_byte_count = old_text
+        let suffix_byte_count = old_text[prefix_byte_count..]
             .chars()
             .rev()
-            .zip(new_text.chars().rev())
+            .zip(new_text[prefix_byte_count..].chars().rev())
             .take_while(|(old_char, new_char)| old_char == new_char)
             .fold(0, |count, (c, _)| count + c.len_utf8());
 


### PR DESCRIPTION
To reproduce the bug, add two newlines to the end of an empty multi-line edit control. When the second newline is added, the old text will be "\n" and the new text will be "\n\n". Before this fix, the function mistakely calculated 1 byte as a common suffix since both strings ended with a newline, even though that same newline in the old string was also the common prefix.