### PR TITLE
feat: Add `author_id` property

### DIFF
--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -567,6 +567,7 @@ string_property_methods! {
     (description, set_description, clear_description),
     (value, set_value, clear_value),
     (access_key, set_access_key, clear_access_key),
+    (author_id, set_author_id, clear_author_id),
     (class_name, set_class_name, clear_class_name),
     (font_family, set_font_family, clear_font_family),
     (html_tag, set_html_tag, clear_html_tag),

--- a/bindings/python/src/common.rs
+++ b/bindings/python/src/common.rs
@@ -488,6 +488,7 @@ string_property_methods! {
     (description, set_description, clear_description),
     (value, set_value, clear_value),
     (access_key, set_access_key, clear_access_key),
+    (author_id, set_author_id, clear_author_id),
     (class_name, set_class_name, clear_class_name),
     (font_family, set_font_family, clear_font_family),
     (html_tag, set_html_tag, clear_html_tag),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -860,6 +860,7 @@ enum PropertyId {
     Description,
     Value,
     AccessKey,
+    AuthorId,
     ClassName,
     FontFamily,
     HtmlTag,
@@ -1497,6 +1498,9 @@ string_property_methods! {
     ///
     /// [`keyboard_shortcut`]: Node::keyboard_shortcut
     (AccessKey, access_key, set_access_key, clear_access_key),
+    /// A way for application authors to identify this node for automated
+    /// testing purpose. The value must be unique among this node's siblings.
+    (AuthorId, author_id, set_author_id, clear_author_id),
     (ClassName, class_name, set_class_name, clear_class_name),
     /// Only present when different from parent.
     (FontFamily, font_family, set_font_family, clear_font_family),
@@ -1917,6 +1921,7 @@ impl<'de> Visitor<'de> for NodeVisitor {
                             Description,
                             Value,
                             AccessKey,
+                            AuthorId,
                             ClassName,
                             FontFamily,
                             HtmlTag,
@@ -2101,6 +2106,7 @@ impl JsonSchema for Node {
                 Description,
                 Value,
                 AccessKey,
+                AuthorId,
                 ClassName,
                 FontFamily,
                 HtmlTag,

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -596,6 +596,10 @@ impl<'a> Node<'a> {
         self.data().value()
     }
 
+    pub fn author_id(&self) -> Option<&str> {
+        self.data().author_id()
+    }
+
     pub fn class_name(&self) -> Option<&str> {
         self.data().class_name()
     }

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -722,6 +722,16 @@ impl PlatformNode {
         self.id
     }
 
+    pub fn accessible_id(&self) -> Result<String> {
+        self.resolve(|node| {
+            if let Some(author_id) = node.author_id() {
+                Ok(author_id.to_string())
+            } else {
+                Ok(String::new())
+            }
+        })
+    }
+
     pub fn child_at_index(&self, index: usize) -> Result<Option<NodeId>> {
         self.resolve(|node| {
             let child = node

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -89,6 +89,13 @@ impl Accessible {
         }
     }
 
+    pub fn accessible_id(&self) -> Result<String> {
+        match self {
+            Self::Node(node) => node.accessible_id(),
+            Self::Root(_) => Ok(String::new()),
+        }
+    }
+
     pub fn child_at_index(&self, index: usize) -> Result<Option<Self>> {
         match self {
             Self::Node(node) => node

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -401,6 +401,14 @@ declare_class!(
             .flatten()
         }
 
+        #[method_id(accessibilityIdentifier)]
+        fn identifier(&self) -> Option<Id<NSString>> {
+            self.resolve(|node| {
+                node.author_id().map(NSString::from_str)
+            })
+            .flatten()
+        }
+
         #[method_id(accessibilityTitle)]
         fn title(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
@@ -777,6 +785,7 @@ declare_class!(
                     || selector == sel!(accessibilityFrame)
                     || selector == sel!(accessibilityRole)
                     || selector == sel!(accessibilityRoleDescription)
+                    || selector == sel!(accessibilityIdentifier)
                     || selector == sel!(accessibilityTitle)
                     || selector == sel!(accessibilityHelp)
                     || selector == sel!(accessibilityPlaceholderValue)

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -64,8 +64,8 @@ impl NodeAccessibleInterface {
     }
 
     #[dbus_interface(property)]
-    fn accessible_id(&self) -> ObjectId {
-        ObjectId::from(&self.node)
+    fn accessible_id(&self) -> fdo::Result<String> {
+        self.node.accessible_id().map_err(self.map_error())
     }
 
     fn get_child_at_index(&self, index: i32) -> fdo::Result<(OwnedObjectAddress,)> {
@@ -172,8 +172,8 @@ impl RootAccessibleInterface {
     }
 
     #[dbus_interface(property)]
-    fn accessible_id(&self) -> ObjectId {
-        ObjectId::Root
+    fn accessible_id(&self) -> &str {
+        ""
     }
 
     fn get_child_at_index(&self, index: i32) -> fdo::Result<(OwnedObjectAddress,)> {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -295,6 +295,10 @@ impl<'a> NodeWrapper<'a> {
         }
     }
 
+    fn automation_id(&self) -> Option<&str> {
+        self.0.author_id()
+    }
+
     fn class_name(&self) -> Option<&str> {
         self.0.class_name()
     }
@@ -872,6 +876,7 @@ properties! {
     (IsKeyboardFocusable, is_focusable),
     (HasKeyboardFocus, is_focused),
     (LiveSetting, live_setting),
+    (AutomationId, automation_id),
     (ClassName, class_name),
     (Orientation, orientation)
 }

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -40,4 +40,3 @@ accesskit_unix = { version = "0.10.1", path = "../unix", optional = true, defaul
 version = "0.30"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-


### PR DESCRIPTION
Adds a new optional `author_id` property, useful primarily for QA.

- On Unix: the purpose of the `AccessibleId` property have been clarified since I wrote the adapter. These changes make it behave like GTK4.
- On macOS: I haven't really found other implementations of this property, but Apple documentation indicates that `accessibilityIdentifier` is intended for this.

Tested on Windows and Linux by modifying the `mixed_handlers` example like so:

```rust
diff --git a/platforms/winit/examples/mixed_handlers.rs b/platforms/winit/examples/mixed_handlers.rs
index 00281e2..7c1e68f 100644
--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -43,8 +43,14 @@ fn build_button(id: NodeId, name: &str) -> Node {
         BUTTON_2_ID => BUTTON_2_RECT,
         _ => unreachable!(),
     };
+    let author_id = match id {
+        BUTTON_1_ID => "button1",
+        BUTTON_2_ID => "button2",
+        _ => unreachable!(),
+    };

     let mut builder = NodeBuilder::new(Role::Button);
+    builder.set_author_id(author_id);
     builder.set_bounds(rect);
     builder.set_name(name);
     builder.add_action(Action::Focus);

```