### PR TITLE
winit: Don't treat `accesskit_unix` as a feature

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 features = ["winit/rwh_06", "winit/x11", "winit/wayland"]
 
 [features]
-default = ["accesskit_unix", "async-io", "rwh_06"]
+default = ["async-io", "rwh_06"]
 rwh_05 = ["winit/rwh_05", "dep:rwh_05"]
 rwh_06 = ["winit/rwh_06", "dep:rwh_06"]
 async-io = ["accesskit_unix/async-io"]
@@ -34,7 +34,7 @@ accesskit_windows = { version = "0.20.0", path = "../windows" }
 accesskit_macos = { version = "0.15.0", path = "../macos" }
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-accesskit_unix = { version = "0.10.1", path = "../unix", optional = true, default-features = false }
+accesskit_unix = { version = "0.10.1", path = "../unix", default-features = false }
 
 [dev-dependencies.winit]
 version = "0.30"

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -283,15 +283,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
     #[cfg(target_os = "windows")]
     println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
-    #[cfg(all(
-        feature = "accesskit_unix",
-        any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
     ))]
     println!("Enable Orca with [Super]+[Alt]+[S].");
 

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -261,15 +261,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
     #[cfg(target_os = "windows")]
     println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
-    #[cfg(all(
-        feature = "accesskit_unix",
-        any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
     ))]
     println!("Enable Orca with [Super]+[Alt]+[S].");
 

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -12,7 +12,6 @@
 /// - If you use another async runtime or if you don't use one at all, the default feature will suit your needs.
 
 #[cfg(all(
-    feature = "accesskit_unix",
     any(
         target_os = "linux",
         target_os = "dragonfly",
@@ -26,7 +25,6 @@
 compile_error!("Either \"async-io\" (default) or \"tokio\" feature must be enabled.");
 
 #[cfg(all(
-    feature = "accesskit_unix",
     any(
         target_os = "linux",
         target_os = "dragonfly",

--- a/platforms/winit/src/platform_impl/mod.rs
+++ b/platforms/winit/src/platform_impl/mod.rs
@@ -14,15 +14,12 @@ mod platform;
 #[path = "macos.rs"]
 mod platform;
 
-#[cfg(all(
-    feature = "accesskit_unix",
-    any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    )
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
 ))]
 #[path = "unix.rs"]
 mod platform;
@@ -30,16 +27,11 @@ mod platform;
 #[cfg(not(any(
     target_os = "windows",
     target_os = "macos",
-    all(
-        feature = "accesskit_unix",
-        any(
-            target_os = "linux",
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        )
-    )
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
 )))]
 #[path = "null.rs"]
 mod platform;


### PR DESCRIPTION
We don't need to check both for a feature (enabled by default) and the various `target_os` values.

As a result, the `accesskit_unix` dependency is no longer optional on the Unix platforms.