### PR TITLE
fix: Clamp character index when getting focus from a text selection

### DIFF
--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -912,7 +912,7 @@ impl<'a> Node<'a> {
 
     pub fn text_selection_focus(&self) -> Option<Position> {
         self.data().text_selection().map(|selection| {
-            let focus = InnerPosition::upgrade(self.tree_state, selection.focus).unwrap();
+            let focus = InnerPosition::clamped_upgrade(self.tree_state, selection.focus).unwrap();
             Position {
                 root_node: *self,
                 inner: focus,


### PR DESCRIPTION
Relates to #416 

Given an egui multiline text area, there is another way to get a panic, as reported to me by a Linux user:

- Write "Hello",
- Press the Enter key twice,
- Write "world",
- Press the up arrow to place the caret on the empty line.

This fix makes `Node::text_selection_focus` consistent with `Node::text_selection` and prevents panicking, but doesn't fix the underlying issue in egui, as "world" is now announced instead of "blank".