### PR TITLE
refactor!: Transfer ownership of action requests in the C API

### DIFF
--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -261,7 +261,7 @@ struct action_handler_state {
   Uint32 window_id;
 };
 
-void do_action(const accesskit_action_request *request, void *userdata) {
+void do_action(accesskit_action_request *request, void *userdata) {
   struct action_handler_state *state = userdata;
   SDL_Event event;
   SDL_zero(event);
@@ -275,6 +275,7 @@ void do_action(const accesskit_action_request *request, void *userdata) {
     event.user.code = DO_DEFAULT_ACTION_MSG;
     SDL_PushEvent(&event);
   }
+  accesskit_action_request_free(request);
 }
 
 accesskit_tree_update *build_initial_tree(void *userdata) {

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -88,7 +88,7 @@ accesskit_tree_update *build_initial_tree(void *userdata) {
   return result;
 }
 
-void do_action(const accesskit_action_request *request, void *userdata) {
+void do_action(accesskit_action_request *request, void *userdata) {
   HWND window = userdata;
   if (request->action == ACCESSKIT_ACTION_FOCUS) {
     LPARAM lparam = (LPARAM)(request->target);
@@ -97,6 +97,7 @@ void do_action(const accesskit_action_request *request, void *userdata) {
     LPARAM lparam = (LPARAM)(request->target);
     PostMessage((HWND)window, DO_DEFAULT_ACTION_MSG, 0, lparam);
   }
+  accesskit_action_request_free(request);
 }
 
 accesskit_tree_update *build_tree_update_for_focus_update(void *userdata) {

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -1046,6 +1046,11 @@ impl From<ActionRequest> for action_request {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn accesskit_action_request_free(request: *mut action_request) {
+    drop(unsafe { Box::from_raw(request) });
+}
+
 type ActivationHandlerCallbackUnwrapped = extern "C" fn(userdata: *mut c_void) -> *mut tree_update;
 pub type ActivationHandlerCallback =
     Option<extern "C" fn(userdata: *mut c_void) -> *mut tree_update>;
@@ -1080,9 +1085,9 @@ impl ActivationHandler for FfiActivationHandler {
 }
 
 type ActionHandlerCallbackUnwrapped =
-    extern "C" fn(request: *const action_request, userdata: *mut c_void);
+    extern "C" fn(request: *mut action_request, userdata: *mut c_void);
 pub type ActionHandlerCallback =
-    Option<extern "C" fn(request: *const action_request, userdata: *mut c_void)>;
+    Option<extern "C" fn(request: *mut action_request, userdata: *mut c_void)>;
 
 struct FfiActionHandlerUserdata(*mut c_void);
 
@@ -1104,8 +1109,8 @@ impl FfiActionHandler {
 
 impl ActionHandler for FfiActionHandler {
     fn do_action(&mut self, request: ActionRequest) {
-        let request = request.into();
-        (self.callback)(&request, self.userdata.0);
+        let request = Box::new(action_request::from(request));
+        (self.callback)(Box::into_raw(request), self.userdata.0);
     }
 }
 

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -1088,7 +1088,7 @@ type ActionHandlerCallbackUnwrapped =
     extern "C" fn(request: *mut action_request, userdata: *mut c_void);
 
 /// Ownership of `request` is transfered to the callback. `request` must
-/// be freed using [`accesskit_action_request_free`].
+/// be freed using `accesskit_action_request_free`.
 pub type ActionHandlerCallback =
     Option<extern "C" fn(request: *mut action_request, userdata: *mut c_void)>;
 

--- a/bindings/c/src/common.rs
+++ b/bindings/c/src/common.rs
@@ -1086,6 +1086,9 @@ impl ActivationHandler for FfiActivationHandler {
 
 type ActionHandlerCallbackUnwrapped =
     extern "C" fn(request: *mut action_request, userdata: *mut c_void);
+
+/// Ownership of `request` is transfered to the callback. `request` must
+/// be freed using [`accesskit_action_request_free`].
 pub type ActionHandlerCallback =
     Option<extern "C" fn(request: *mut action_request, userdata: *mut c_void)>;
 


### PR DESCRIPTION
This is the simplest way to allow C API users, like GTK, to asynchronously handle arbitrary action requests on another thread.