### PR TITLE
feat: Feature-gate the `accesskit_atspi_common::simplified` module

### DIFF
--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -12,7 +12,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["simplified-api"]
 simplified-api = []
 
 [dependencies]

--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["simplified-api"]
+simplified-api = []
+
 [dependencies]
 accesskit = { version = "0.15.0", path = "../../common" }
 accesskit_consumer = { version = "0.23.0", path = "../../consumer" }

--- a/platforms/atspi-common/src/lib.rs
+++ b/platforms/atspi-common/src/lib.rs
@@ -12,6 +12,7 @@ mod events;
 mod filters;
 mod node;
 mod rect;
+#[cfg(feature = "simplified-api")]
 pub mod simplified;
 mod util;
 

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -18,7 +18,7 @@ tokio = ["dep:tokio", "dep:tokio-stream", "atspi/tokio", "zbus/tokio"]
 
 [dependencies]
 accesskit = { version = "0.15.0", path = "../../common" }
-accesskit_atspi_common = { version = "0.7.0", path = "../atspi-common", default-features = false }
+accesskit_atspi_common = { version = "0.7.0", path = "../atspi-common" }
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"
 serde = "1.0"

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -18,7 +18,7 @@ tokio = ["dep:tokio", "dep:tokio-stream", "atspi/tokio", "zbus/tokio"]
 
 [dependencies]
 accesskit = { version = "0.15.0", path = "../../common" }
-accesskit_atspi_common = { version = "0.7.0", path = "../atspi-common" }
+accesskit_atspi_common = { version = "0.7.0", path = "../atspi-common", default-features = false }
 atspi = { version = "0.19", default-features = false }
 futures-lite = "1.13"
 serde = "1.0"


### PR DESCRIPTION
Most users don't actually need this, they should not have to compile it. I'm not set on the name of the feature, feel free to suggest something else.