### PR TITLE
refactor!: Rename the static text role to label

### DIFF
--- a/bindings/c/examples/sdl/hello_world.c
+++ b/bindings/c/examples/sdl/hello_world.c
@@ -45,7 +45,7 @@ accesskit_node *build_button(accesskit_node_id id, const char *name) {
 
 accesskit_node *build_announcement(const char *text) {
   accesskit_node_builder *builder =
-      accesskit_node_builder_new(ACCESSKIT_ROLE_STATIC_TEXT);
+      accesskit_node_builder_new(ACCESSKIT_ROLE_LABEL);
   accesskit_node_builder_set_name(builder, text);
   accesskit_node_builder_set_live(builder, ACCESSKIT_LIVE_POLITE);
   return accesskit_node_builder_build(builder);

--- a/bindings/c/examples/windows/hello_world.c
+++ b/bindings/c/examples/windows/hello_world.c
@@ -40,7 +40,7 @@ accesskit_node *build_button(accesskit_node_id id, const char *name) {
 
 accesskit_node *build_announcement(const char *text) {
   accesskit_node_builder *builder =
-      accesskit_node_builder_new(ACCESSKIT_ROLE_STATIC_TEXT);
+      accesskit_node_builder_new(ACCESSKIT_ROLE_LABEL);
   accesskit_node_builder_set_name(builder, text);
   accesskit_node_builder_set_live(builder, ACCESSKIT_LIVE_POLITE);
   return accesskit_node_builder_build(builder);

--- a/bindings/python/examples/pygame/hello_world.py
+++ b/bindings/python/examples/pygame/hello_world.py
@@ -34,7 +34,7 @@ def build_button(id, name):
 
 
 def build_announcement(text):
-    builder = accesskit.NodeBuilder(accesskit.Role.STATIC_TEXT)
+    builder = accesskit.NodeBuilder(accesskit.Role.LABEL)
     builder.set_name(text)
     builder.set_live(accesskit.Live.POLITE)
     return builder.build()

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -53,7 +53,7 @@ pub enum Role {
     Unknown,
     InlineTextBox,
     Cell,
-    StaticText,
+    Label,
     Image,
     Link,
     Row,

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -630,12 +630,7 @@ mod tests {
             .next()
             .is_none());
         assert_eq!(
-            [
-                STATIC_TEXT_1_1_ID,
-                PARAGRAPH_2_ID,
-                STATIC_TEXT_3_1_0_ID,
-                BUTTON_3_2_ID
-            ],
+            [LABEL_1_1_ID, PARAGRAPH_2_ID, LABEL_3_1_0_ID, BUTTON_3_2_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
@@ -646,7 +641,7 @@ mod tests {
         assert_eq!(
             [BUTTON_3_2_ID],
             tree.state()
-                .node_by_id(STATIC_TEXT_3_1_0_ID)
+                .node_by_id(LABEL_3_1_0_ID)
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
                 .map(|node| node.id())
@@ -671,12 +666,7 @@ mod tests {
             .next_back()
             .is_none());
         assert_eq!(
-            [
-                BUTTON_3_2_ID,
-                STATIC_TEXT_3_1_0_ID,
-                PARAGRAPH_2_ID,
-                STATIC_TEXT_1_1_ID
-            ],
+            [BUTTON_3_2_ID, LABEL_3_1_0_ID, PARAGRAPH_2_ID, LABEL_1_1_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
@@ -688,7 +678,7 @@ mod tests {
         assert_eq!(
             [BUTTON_3_2_ID,],
             tree.state()
-                .node_by_id(STATIC_TEXT_3_1_0_ID)
+                .node_by_id(LABEL_3_1_0_ID)
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
                 .rev()
@@ -714,7 +704,7 @@ mod tests {
             .next()
             .is_none());
         assert_eq!(
-            [PARAGRAPH_2_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_0_ID],
+            [PARAGRAPH_2_ID, LABEL_1_1_ID, PARAGRAPH_0_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -723,9 +713,9 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
-            [PARAGRAPH_2_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_0_ID],
+            [PARAGRAPH_2_ID, LABEL_1_1_ID, PARAGRAPH_0_ID],
             tree.state()
-                .node_by_id(STATIC_TEXT_3_1_0_ID)
+                .node_by_id(LABEL_3_1_0_ID)
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
                 .map(|node| node.id())
@@ -750,7 +740,7 @@ mod tests {
             .next_back()
             .is_none());
         assert_eq!(
-            [PARAGRAPH_0_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_2_ID],
+            [PARAGRAPH_0_ID, LABEL_1_1_ID, PARAGRAPH_2_ID],
             tree.state()
                 .node_by_id(PARAGRAPH_3_IGNORED_ID)
                 .unwrap()
@@ -760,9 +750,9 @@ mod tests {
                 .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
-            [PARAGRAPH_0_ID, STATIC_TEXT_1_1_ID, PARAGRAPH_2_ID],
+            [PARAGRAPH_0_ID, LABEL_1_1_ID, PARAGRAPH_2_ID],
             tree.state()
-                .node_by_id(STATIC_TEXT_3_1_0_ID)
+                .node_by_id(LABEL_3_1_0_ID)
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
                 .rev()
@@ -784,9 +774,9 @@ mod tests {
         assert_eq!(
             [
                 PARAGRAPH_0_ID,
-                STATIC_TEXT_1_1_ID,
+                LABEL_1_1_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_3_1_0_ID,
+                LABEL_3_1_0_ID,
                 BUTTON_3_2_ID
             ],
             tree.state()
@@ -804,7 +794,7 @@ mod tests {
             .is_none());
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .filtered_children(test_tree_filter)
             .next()
@@ -817,9 +807,9 @@ mod tests {
         assert_eq!(
             [
                 BUTTON_3_2_ID,
-                STATIC_TEXT_3_1_0_ID,
+                LABEL_3_1_0_ID,
                 PARAGRAPH_2_ID,
-                STATIC_TEXT_1_1_ID,
+                LABEL_1_1_ID,
                 PARAGRAPH_0_ID
             ],
             tree.state()
@@ -838,7 +828,7 @@ mod tests {
             .is_none());
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .filtered_children(test_tree_filter)
             .next_back()

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -28,19 +28,19 @@ mod tests {
 
     pub const ROOT_ID: NodeId = NodeId(0);
     pub const PARAGRAPH_0_ID: NodeId = NodeId(1);
-    pub const STATIC_TEXT_0_0_IGNORED_ID: NodeId = NodeId(2);
+    pub const LABEL_0_0_IGNORED_ID: NodeId = NodeId(2);
     pub const PARAGRAPH_1_IGNORED_ID: NodeId = NodeId(3);
     pub const BUTTON_1_0_HIDDEN_ID: NodeId = NodeId(4);
     pub const CONTAINER_1_0_0_HIDDEN_ID: NodeId = NodeId(5);
-    pub const STATIC_TEXT_1_1_ID: NodeId = NodeId(6);
+    pub const LABEL_1_1_ID: NodeId = NodeId(6);
     pub const BUTTON_1_2_HIDDEN_ID: NodeId = NodeId(7);
     pub const CONTAINER_1_2_0_HIDDEN_ID: NodeId = NodeId(8);
     pub const PARAGRAPH_2_ID: NodeId = NodeId(9);
-    pub const STATIC_TEXT_2_0_ID: NodeId = NodeId(10);
+    pub const LABEL_2_0_ID: NodeId = NodeId(10);
     pub const PARAGRAPH_3_IGNORED_ID: NodeId = NodeId(11);
     pub const EMPTY_CONTAINER_3_0_IGNORED_ID: NodeId = NodeId(12);
     pub const LINK_3_1_IGNORED_ID: NodeId = NodeId(13);
-    pub const STATIC_TEXT_3_1_0_ID: NodeId = NodeId(14);
+    pub const LABEL_3_1_0_ID: NodeId = NodeId(14);
     pub const BUTTON_3_2_ID: NodeId = NodeId(15);
     pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId = NodeId(16);
 
@@ -57,12 +57,12 @@ mod tests {
         };
         let paragraph_0 = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_children(vec![STATIC_TEXT_0_0_IGNORED_ID]);
+            builder.set_children(vec![LABEL_0_0_IGNORED_ID]);
             builder.build()
         };
-        let static_text_0_0_ignored = {
-            let mut builder = NodeBuilder::new(Role::StaticText);
-            builder.set_name("static_text_0_0_ignored");
+        let label_0_0_ignored = {
+            let mut builder = NodeBuilder::new(Role::Label);
+            builder.set_name("label_0_0_ignored");
             builder.build()
         };
         let paragraph_1_ignored = {
@@ -76,7 +76,7 @@ mod tests {
             });
             builder.set_children(vec![
                 BUTTON_1_0_HIDDEN_ID,
-                STATIC_TEXT_1_1_ID,
+                LABEL_1_1_ID,
                 BUTTON_1_2_HIDDEN_ID,
             ]);
             builder.build()
@@ -93,15 +93,15 @@ mod tests {
             builder.set_hidden();
             builder.build()
         };
-        let static_text_1_1 = {
-            let mut builder = NodeBuilder::new(Role::StaticText);
+        let label_1_1 = {
+            let mut builder = NodeBuilder::new(Role::Label);
             builder.set_bounds(Rect {
                 x0: 10.0,
                 y0: 10.0,
                 x1: 90.0,
                 y1: 30.0,
             });
-            builder.set_name("static_text_1_1");
+            builder.set_name("label_1_1");
             builder.build()
         };
         let button_1_2_hidden = {
@@ -118,12 +118,12 @@ mod tests {
         };
         let paragraph_2 = {
             let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_children(vec![STATIC_TEXT_2_0_ID]);
+            builder.set_children(vec![LABEL_2_0_ID]);
             builder.build()
         };
-        let static_text_2_0 = {
-            let mut builder = NodeBuilder::new(Role::StaticText);
-            builder.set_name("static_text_2_0");
+        let label_2_0 = {
+            let mut builder = NodeBuilder::new(Role::Label);
+            builder.set_name("label_2_0");
             builder.build()
         };
         let paragraph_3_ignored = {
@@ -139,13 +139,13 @@ mod tests {
         let empty_container_3_0_ignored = NodeBuilder::new(Role::GenericContainer).build();
         let link_3_1_ignored = {
             let mut builder = NodeBuilder::new(Role::Link);
-            builder.set_children(vec![STATIC_TEXT_3_1_0_ID]);
+            builder.set_children(vec![LABEL_3_1_0_ID]);
             builder.set_linked();
             builder.build()
         };
-        let static_text_3_1_0 = {
-            let mut builder = NodeBuilder::new(Role::StaticText);
-            builder.set_name("static_text_3_1_0");
+        let label_3_1_0 = {
+            let mut builder = NodeBuilder::new(Role::Label);
+            builder.set_name("label_3_1_0");
             builder.build()
         };
         let button_3_2 = {
@@ -158,19 +158,19 @@ mod tests {
             nodes: vec![
                 (ROOT_ID, root),
                 (PARAGRAPH_0_ID, paragraph_0),
-                (STATIC_TEXT_0_0_IGNORED_ID, static_text_0_0_ignored),
+                (LABEL_0_0_IGNORED_ID, label_0_0_ignored),
                 (PARAGRAPH_1_IGNORED_ID, paragraph_1_ignored),
                 (BUTTON_1_0_HIDDEN_ID, button_1_0_hidden),
                 (CONTAINER_1_0_0_HIDDEN_ID, container_1_0_0_hidden),
-                (STATIC_TEXT_1_1_ID, static_text_1_1),
+                (LABEL_1_1_ID, label_1_1),
                 (BUTTON_1_2_HIDDEN_ID, button_1_2_hidden),
                 (CONTAINER_1_2_0_HIDDEN_ID, container_1_2_0_hidden),
                 (PARAGRAPH_2_ID, paragraph_2),
-                (STATIC_TEXT_2_0_ID, static_text_2_0),
+                (LABEL_2_0_ID, label_2_0),
                 (PARAGRAPH_3_IGNORED_ID, paragraph_3_ignored),
                 (EMPTY_CONTAINER_3_0_IGNORED_ID, empty_container_3_0_ignored),
                 (LINK_3_1_IGNORED_ID, link_3_1_ignored),
-                (STATIC_TEXT_3_1_0_ID, static_text_3_1_0),
+                (LABEL_3_1_0_ID, label_3_1_0),
                 (BUTTON_3_2_ID, button_3_2),
                 (EMPTY_CONTAINER_3_3_IGNORED_ID, empty_container_3_3_ignored),
             ],
@@ -184,7 +184,7 @@ mod tests {
         let id = node.id();
         if node.is_hidden() {
             FilterResult::ExcludeSubtree
-        } else if id == STATIC_TEXT_0_0_IGNORED_ID
+        } else if id == LABEL_0_0_IGNORED_ID
             || id == PARAGRAPH_1_IGNORED_ID
             || id == PARAGRAPH_3_IGNORED_ID
             || id == EMPTY_CONTAINER_3_0_IGNORED_ID

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -474,7 +474,7 @@ impl<'a> Node<'a> {
 
 fn descendant_label_filter(node: &Node) -> FilterResult {
     match node.role() {
-        Role::StaticText | Role::Image => FilterResult::Include,
+        Role::Label | Role::Image => FilterResult::Include,
         Role::GenericContainer => FilterResult::ExcludeNode,
         _ => FilterResult::ExcludeSubtree,
     }
@@ -678,7 +678,7 @@ mod tests {
         assert_eq!(
             Some((PARAGRAPH_0_ID, 0)),
             tree.state()
-                .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+                .node_by_id(LABEL_0_0_IGNORED_ID)
                 .unwrap()
                 .parent_and_index()
                 .map(|(parent, index)| (parent.id(), index))
@@ -697,11 +697,11 @@ mod tests {
     fn deepest_first_child() {
         let tree = test_tree();
         assert_eq!(
-            STATIC_TEXT_0_0_IGNORED_ID,
+            LABEL_0_0_IGNORED_ID,
             tree.state().root().deepest_first_child().unwrap().id()
         );
         assert_eq!(
-            STATIC_TEXT_0_0_IGNORED_ID,
+            LABEL_0_0_IGNORED_ID,
             tree.state()
                 .node_by_id(PARAGRAPH_0_ID)
                 .unwrap()
@@ -711,7 +711,7 @@ mod tests {
         );
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .deepest_first_child()
             .is_none());
@@ -723,7 +723,7 @@ mod tests {
         assert_eq!(
             ROOT_ID,
             tree.state()
-                .node_by_id(STATIC_TEXT_1_1_ID)
+                .node_by_id(LABEL_1_1_ID)
                 .unwrap()
                 .filtered_parent(&test_tree_filter)
                 .unwrap()
@@ -755,7 +755,7 @@ mod tests {
             .is_none());
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .deepest_first_filtered_child(&test_tree_filter)
             .is_none());
@@ -829,17 +829,17 @@ mod tests {
             .is_descendant_of(&tree.state().root()));
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .is_descendant_of(&tree.state().root()));
         assert!(tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .is_descendant_of(&tree.state().node_by_id(PARAGRAPH_0_ID).unwrap()));
         assert!(!tree
             .state()
-            .node_by_id(STATIC_TEXT_0_0_IGNORED_ID)
+            .node_by_id(LABEL_0_0_IGNORED_ID)
             .unwrap()
             .is_descendant_of(&tree.state().node_by_id(PARAGRAPH_2_ID).unwrap()));
         assert!(!tree
@@ -885,7 +885,7 @@ mod tests {
                 y1: 70.0,
             }),
             tree.state()
-                .node_by_id(STATIC_TEXT_1_1_ID)
+                .node_by_id(LABEL_1_1_ID)
                 .unwrap()
                 .bounding_box()
         );
@@ -900,14 +900,14 @@ mod tests {
             .node_at_point(Point::new(10.0, 40.0), &test_tree_filter)
             .is_none());
         assert_eq!(
-            Some(STATIC_TEXT_1_1_ID),
+            Some(LABEL_1_1_ID),
             tree.state()
                 .root()
                 .node_at_point(Point::new(20.0, 50.0), &test_tree_filter)
                 .map(|node| node.id())
         );
         assert_eq!(
-            Some(STATIC_TEXT_1_1_ID),
+            Some(LABEL_1_1_ID),
             tree.state()
                 .root()
                 .node_at_point(Point::new(50.0, 60.0), &test_tree_filter)
@@ -958,7 +958,7 @@ mod tests {
                     builder.build()
                 }),
                 (NodeId(2), {
-                    let mut builder = NodeBuilder::new(Role::StaticText);
+                    let mut builder = NodeBuilder::new(Role::Label);
                     builder.set_name(LABEL_1);
                     builder.build()
                 }),
@@ -968,7 +968,7 @@ mod tests {
                     builder.build()
                 }),
                 (NodeId(4), {
-                    let mut builder = NodeBuilder::new(Role::StaticText);
+                    let mut builder = NodeBuilder::new(Role::Label);
                     builder.set_name(LABEL_2);
                     builder.build()
                 }),
@@ -1020,7 +1020,7 @@ mod tests {
                     builder.build()
                 }),
                 (NodeId(5), {
-                    let mut builder = NodeBuilder::new(Role::StaticText);
+                    let mut builder = NodeBuilder::new(Role::Label);
                     builder.set_name(LINK_LABEL);
                     builder.build()
                 }),

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -869,10 +869,7 @@ impl<'a> Node<'a> {
 
     pub fn supports_text_ranges(&self) -> bool {
         (self.is_text_input()
-            || matches!(
-                self.role(),
-                Role::StaticText | Role::Document | Role::Terminal
-            ))
+            || matches!(self.role(), Role::Label | Role::Document | Role::Terminal))
             && self.inline_text_boxes().next().is_some()
     }
 

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -225,7 +225,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Slider => AtspiRole::Slider,
             Role::SpinButton => AtspiRole::SpinButton,
             Role::Splitter => AtspiRole::Separator,
-            Role::StaticText => AtspiRole::Static,
+            Role::Label => AtspiRole::Label,
             Role::Status => AtspiRole::StatusBar,
             Role::SvgRoot => AtspiRole::DocumentFrame,
             Role::Tab => AtspiRole::PageTab,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -38,7 +38,7 @@ fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
             Role::Unknown => NSAccessibilityUnknownRole,
             Role::InlineTextBox => NSAccessibilityUnknownRole,
             Role::Cell => NSAccessibilityCellRole,
-            Role::StaticText => NSAccessibilityStaticTextRole,
+            Role::Label => NSAccessibilityStaticTextRole,
             Role::Image => NSAccessibilityImageRole,
             Role::Link => NSAccessibilityLinkRole,
             Role::Row => NSAccessibilityRowRole,
@@ -269,7 +269,7 @@ impl<'a> NodeWrapper<'a> {
 
     pub(crate) fn title(&self) -> Option<String> {
         let state = self.0;
-        if state.role() == Role::StaticText && state.raw_value().is_none() {
+        if state.role() == Role::Label && state.raw_value().is_none() {
             // In this case, macOS wants the text to be the value, not title.
             return None;
         }
@@ -295,7 +295,7 @@ impl<'a> NodeWrapper<'a> {
         if let Some(value) = state.numeric_value() {
             return Some(Value::Number(value));
         }
-        if state.role() == Role::StaticText {
+        if state.role() == Role::Label {
             if let Some(name) = self.name() {
                 return Some(Value::String(name));
             }

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,4 +36,3 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
-

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -77,7 +77,7 @@ fn build_button(id: NodeId, name: &str) -> Node {
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::StaticText);
+    let mut builder = NodeBuilder::new(Role::Label);
     builder.set_name(text);
     builder.set_live(Live::Polite);
     builder.build()

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -51,7 +51,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Unknown => UIA_CustomControlTypeId,
             Role::InlineTextBox => UIA_CustomControlTypeId,
             Role::Cell => UIA_DataItemControlTypeId,
-            Role::StaticText => UIA_TextControlTypeId,
+            Role::Label => UIA_TextControlTypeId,
             Role::Image => UIA_ImageControlTypeId,
             Role::Link => UIA_HyperlinkControlTypeId,
             Role::Row => UIA_DataItemControlTypeId,

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -53,7 +53,7 @@ fn build_button(id: NodeId, name: &str) -> Node {
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::StaticText);
+    let mut builder = NodeBuilder::new(Role::Label);
     builder.set_name(text);
     builder.set_live(Live::Polite);
     builder.build()

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -50,7 +50,7 @@ fn build_button(id: NodeId, name: &str) -> Node {
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::StaticText);
+    let mut builder = NodeBuilder::new(Role::Label);
     builder.set_name(text);
     builder.set_live(Live::Polite);
     builder.build()


### PR DESCRIPTION
The term "static text" is archaic; it goes back to the early days of Windows and, if I remember correctly, the original Macintosh Toolbox. But every modern GUI toolkit I can think of, as far back as Java's AWT in the 90s, refers to this type of object as a label, whether or not it's actually labeling another control. To achieve our goal of making accessibility approachable to today's developers, we should eliminate unfamiliar and archaic terminology wherever we can. So, while this is another inconvenience for our early adopters, I think this name change is worthwhile.

Also, I now believe that the role that we used to call static text, that we now call label, should map to the AT-SPI label role, not the AT-SPI static role. This is based on what I see in both GTK 3 and 4, which use the label role whether or not the text actually has a label relationship with another widget.