### PR TITLE
fix: Correctly handle recursive filtering

### DIFF
--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -23,6 +23,12 @@ pub fn common_filter(node: &Node) -> FilterResult {
         return FilterResult::ExcludeSubtree;
     }
 
+    if let Some(parent) = node.parent() {
+        if common_filter(&parent) == FilterResult::ExcludeSubtree {
+            return FilterResult::ExcludeSubtree;
+        }
+    }
+
     let role = node.role();
     if role == Role::GenericContainer || role == Role::InlineTextBox {
         return FilterResult::ExcludeNode;


### PR DESCRIPTION
I discovered that this was a problem when testing a GTK app with the actual AT-SPI adapter. Attempting to unregister the interfaces for a removed node resulted in a D-Bus error saying that the Accessible interface hadn't been registered in the first place. The problem was that the node wasn't registered in the first place, since its parent had the `hidden` flag set, meaning that the parent's filter result was `ExcludeSubtree`. But when the node was removed, its filter result was `Include`, since calling `filter` on the node didn't check the parent, and the node itself didn't have the `hidden` flag set.

So now, `common_filter` checks the parent.

I added `add_subtree` and `remove_subtree` because a callback to `node_updated` on a single node can indicate a change in the visibility of the whole subtree. And I added the `added_nodes` and `removed_nodes` sets to ensure that no matter what sequence of events happens, we don't try to register or unregister a node twice in a single set of changes.