### PR TITLE
Adopt windows version range >=0.54, <=0.57

### DIFF
--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -16,9 +16,13 @@ accesskit = { version = "0.15.0", path = "../../common" }
 accesskit_consumer = { version = "0.23.0", path = "../../consumer" }
 paste = "1.0"
 static_assertions = "1.1.0"
+# Note: this explicit dependency is required because in `windows` 0.56
+# the `implement` macro changed to use the windows_core crate directly.
+# Keep this in sync with `windows` crate version range.
+windows-core = ">=0.54, <=0.57"
 
 [dependencies.windows]
-version = "0.54"
+version = ">=0.54, <=0.57"
 features = [
     "implement",
     "Win32_Foundation",


### PR DESCRIPTION
`windows` is a "heavy" crate. Duplicate `windows` versions in a tree can add precious seconds to compile times (or even _minutes_ by some Bevy user reports). On the Bevy side, we are trying to ensure that `windows` is only compiled once. We also believe it is in the ecosystem's best interest (and in the interest of crate owners that consume `windows`) to align their versioning with the rest of ecosystem. Therefore, I would like to encourage crate owners to adopt the following approach to `windows` crate usage:

1. Adopt "range versioning" for windows instead of locking to a specific version.
2. Before adding a new version to the range, test that each previous version in the range still compiles.
3. Only remove old versions from the range when _absolutely necessary_. Try your hardest to ensure that your version support aligns with other ecosystem crates.

We've picked 0.54 as a baseline because breaking API changes were made to use Rust Results instead of HRESULT.

I have personally tested that accesskit compiles with 0.54, 0.56 (0.55 does not exist), and 0.57.