### PR TITLE
fix: `Node::is_focusable` always returns true if the node is focused

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -47,8 +47,12 @@ impl<'a> Node<'a> {
         self.tree_state.focus_id() == Some(self.id())
     }
 
+    pub fn is_focused_in_tree(&self) -> bool {
+        self.tree_state.focus == self.id()
+    }
+
     pub fn is_focusable(&self) -> bool {
-        self.supports_action(Action::Focus)
+        self.supports_action(Action::Focus) || self.is_focused_in_tree()
     }
 
     pub fn is_root(&self) -> bool {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -16,7 +16,7 @@ use crate::node::{Node, NodeState, ParentAndIndex};
 pub struct State {
     pub(crate) nodes: ChunkMap<NodeId, NodeState>,
     pub(crate) data: TreeData,
-    focus: NodeId,
+    pub(crate) focus: NodeId,
     is_host_focused: bool,
 }
 


### PR DESCRIPTION
I think it's reasonable to only add a given action to a node if that action does something meaningful in the node's current state. And we may want to recommend that. But things like the UIA `IsKeyboardFocusable` property and the AT-SPI focusable state should be set even when the node is already focused, so the node might not have the `Focus` action in that state.

One subtlety: I added a helper, `is_focused_in_tree`, to check whether the node is focused within the tree, regardless of whether the host (e.g. window) is focused. If the node is focused in the tree, then the node might not have the `Focus` action, regardless of whether the host is focused.