### PR TITLE
fix: Improve debug representation of `Node` and `NodeBuilder`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1166,7 +1166,7 @@ macro_rules! vec_property_methods {
 }
 
 macro_rules! slice_properties_debug_method {
-    ($name:ident, $($getter:ident)*) => {
+    ($name:ident, [$($getter:ident,)*]) => {
         fn $name(&self, fmt: &mut fmt::DebugStruct) {
             $(
                 let value = self.$getter();
@@ -1185,16 +1185,16 @@ macro_rules! node_id_vec_property_methods {
             ($id, NodeId, $getter, get_node_id_vec, $setter, set_node_id_vec, $pusher, push_to_node_id_vec, $clearer)
         })*
         impl Node {
-            slice_properties_debug_method! { debug_node_id_vec_properties, $($getter)* }
+            slice_properties_debug_method! { debug_node_id_vec_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            slice_properties_debug_method! { debug_node_id_vec_properties, $($getter)* }
+            slice_properties_debug_method! { debug_node_id_vec_properties, [$($getter,)*] }
         }
     }
 }
 
 macro_rules! option_properties_debug_method {
-    ($name:ident, $($getter:ident)*) => {
+    ($name:ident, [$($getter:ident,)*]) => {
         fn $name(&self, fmt: &mut fmt::DebugStruct) {
             $(
                 let value = self.$getter();
@@ -1213,10 +1213,10 @@ macro_rules! node_id_property_methods {
             ($id, $getter, get_node_id_property, Option<NodeId>, $setter, set_node_id_property, NodeId, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_node_id_properties, $($getter)* }
+            option_properties_debug_method! { debug_node_id_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_node_id_properties, $($getter)* }
+            option_properties_debug_method! { debug_node_id_properties, [$($getter,)*] }
         }
     }
 }
@@ -1228,10 +1228,10 @@ macro_rules! string_property_methods {
             ($id, $getter, get_string_property, Option<&str>, $setter, set_string_property, impl Into<Box<str>>, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_string_properties, $($getter)* }
+            option_properties_debug_method! { debug_string_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_string_properties, $($getter)* }
+            option_properties_debug_method! { debug_string_properties, [$($getter,)*] }
         }
     }
 }
@@ -1243,10 +1243,10 @@ macro_rules! f64_property_methods {
             ($id, $getter, get_f64_property, Option<f64>, $setter, set_f64_property, f64, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_f64_properties, $($getter)* }
+            option_properties_debug_method! { debug_f64_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_f64_properties, $($getter)* }
+            option_properties_debug_method! { debug_f64_properties, [$($getter,)*] }
         }
     }
 }
@@ -1258,10 +1258,10 @@ macro_rules! usize_property_methods {
             ($id, $getter, get_usize_property, Option<usize>, $setter, set_usize_property, usize, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_usize_properties, $($getter)* }
+            option_properties_debug_method! { debug_usize_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_usize_properties, $($getter)* }
+            option_properties_debug_method! { debug_usize_properties, [$($getter,)*] }
         }
     }
 }
@@ -1273,10 +1273,10 @@ macro_rules! color_property_methods {
             ($id, $getter, get_color_property, Option<u32>, $setter, set_color_property, u32, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_color_properties, $($getter)* }
+            option_properties_debug_method! { debug_color_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_color_properties, $($getter)* }
+            option_properties_debug_method! { debug_color_properties, [$($getter,)*] }
         }
     }
 }
@@ -1288,10 +1288,10 @@ macro_rules! text_decoration_property_methods {
             ($id, $getter, get_text_decoration_property, Option<TextDecoration>, $setter, set_text_decoration_property, TextDecoration, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_text_decoration_properties, $($getter)* }
+            option_properties_debug_method! { debug_text_decoration_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_text_decoration_properties, $($getter)* }
+            option_properties_debug_method! { debug_text_decoration_properties, [$($getter,)*] }
         }
     }
 }
@@ -1303,10 +1303,10 @@ macro_rules! length_slice_property_methods {
             ($id, $getter, get_length_slice_property, &[u8], $setter, set_length_slice_property, impl Into<Box<[u8]>>, $clearer)
         })*
         impl Node {
-            slice_properties_debug_method! { debug_length_slice_properties, $($getter)* }
+            slice_properties_debug_method! { debug_length_slice_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            slice_properties_debug_method! { debug_length_slice_properties, $($getter)* }
+            slice_properties_debug_method! { debug_length_slice_properties, [$($getter,)*] }
         }
     }
 }
@@ -1318,10 +1318,10 @@ macro_rules! coord_slice_property_methods {
             ($id, $getter, get_coord_slice_property, Option<&[f32]>, $setter, set_coord_slice_property, impl Into<Box<[f32]>>, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_coord_slice_properties, $($getter)* }
+            option_properties_debug_method! { debug_coord_slice_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_coord_slice_properties, $($getter)* }
+            option_properties_debug_method! { debug_coord_slice_properties, [$($getter,)*] }
         }
     }
 }
@@ -1333,10 +1333,10 @@ macro_rules! bool_property_methods {
             ($id, $getter, get_bool_property, Option<bool>, $setter, set_bool_property, bool, $clearer)
         })*
         impl Node {
-            option_properties_debug_method! { debug_bool_properties, $($getter)* }
+            option_properties_debug_method! { debug_bool_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
-            option_properties_debug_method! { debug_bool_properties, $($getter)* }
+            option_properties_debug_method! { debug_bool_properties, [$($getter,)*] }
         }
     }
 }
@@ -1353,7 +1353,7 @@ macro_rules! unique_enum_property_methods {
                     _ => unexpected_property_type(),
                 }
             })*
-            option_properties_debug_method! { debug_unique_enum_properties, $($getter)* }
+            option_properties_debug_method! { debug_unique_enum_properties, [$($getter,)*] }
         }
         impl NodeBuilder {
             $($(#[$doc])*
@@ -1373,7 +1373,7 @@ macro_rules! unique_enum_property_methods {
             pub fn $clearer(&mut self) {
                 self.properties.clear(PropertyId::$id);
             })*
-            option_properties_debug_method! { debug_unique_enum_properties, $($getter)* }
+            option_properties_debug_method! { debug_unique_enum_properties, [$($getter,)*] }
         }
     }
 }
@@ -1800,6 +1800,14 @@ property_methods! {
     (TextSelection, text_selection, get_text_selection_property, Option<&TextSelection>, set_text_selection, set_text_selection_property, impl Into<Box<TextSelection>>, clear_text_selection)
 }
 
+impl Node {
+    option_properties_debug_method! { debug_option_properties, [transform, bounds, text_selection,] }
+}
+
+impl NodeBuilder {
+    option_properties_debug_method! { debug_option_properties, [transform, bounds, text_selection,] }
+}
+
 vec_property_methods! {
     (CustomActions, CustomAction, custom_actions, get_custom_action_vec, set_custom_actions, set_custom_action_vec, push_custom_action, push_to_custom_action_vec, clear_custom_actions)
 }
@@ -1838,19 +1846,8 @@ impl fmt::Debug for Node {
         self.debug_coord_slice_properties(&mut fmt);
         self.debug_bool_properties(&mut fmt);
         self.debug_unique_enum_properties(&mut fmt);
+        self.debug_option_properties(&mut fmt);
 
-        let transform = self.transform();
-        if transform.is_some() {
-            fmt.field("transform", &transform);
-        }
-        let bounds = self.bounds();
-        if bounds.is_some() {
-            fmt.field("bounds", &bounds);
-        }
-        let text_selection = self.text_selection();
-        if text_selection.is_some() {
-            fmt.field("text_selection", &text_selection);
-        }
         let custom_actions = self.custom_actions();
         if !custom_actions.is_empty() {
             fmt.field("custom_actions", &custom_actions);
@@ -1878,19 +1875,8 @@ impl fmt::Debug for NodeBuilder {
         self.debug_coord_slice_properties(&mut fmt);
         self.debug_bool_properties(&mut fmt);
         self.debug_unique_enum_properties(&mut fmt);
+        self.debug_option_properties(&mut fmt);
 
-        let transform = self.transform();
-        if transform.is_some() {
-            fmt.field("transform", &transform);
-        }
-        let bounds = self.bounds();
-        if bounds.is_some() {
-            fmt.field("bounds", &bounds);
-        }
-        let text_selection = self.text_selection();
-        if text_selection.is_some() {
-            fmt.field("text_selection", &text_selection);
-        }
         let custom_actions = self.custom_actions();
         if !custom_actions.is_empty() {
             fmt.field("custom_actions", &custom_actions);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1190,8 +1190,7 @@ macro_rules! option_properties_debug_method {
     ($name:ident, [$($getter:ident,)*]) => {
         fn $name(&self, fmt: &mut fmt::DebugStruct) {
             $(
-                let value = self.$getter();
-                if value.is_some() {
+                if let Some(value) = self.$getter() {
                     fmt.field(stringify!($getter), &value);
                 }
             )*


### PR DESCRIPTION
Consider this program:

```rust
use accesskit::{Action, DefaultActionVerb, NodeBuilder, Rect, Role};

fn main() {
    let rect = Rect {
        x0: 0.0,
        y0: 0.0,
        x1: 50.0,
        y1: 200.0,
    };
    let mut builder = NodeBuilder::new(Role::Button);
    builder.set_bounds(rect);
    builder.set_name("Send");
    builder.set_busy();
    builder.add_action(Action::Focus);
    builder.set_default_action_verb(DefaultActionVerb::Click);
    println!("{builder:?}");
    let node = builder.build();
    println!("{node:?}");
}
```

This currently outputs:

```
NodeBuilder { role: Button, actions: 2, flags: 64, properties: PropertiesBuilder { indices: PropertyIndices([84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 1, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 2, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 0, 84, 84]), values: [Rect(Rect { x0: 0.0, y0: 0.0, x1: 50.0, y1: 200.0 }), String("Send"), DefaultActionVerb(Click)] } }
Node { role: Button, actions: 2, flags: 64, properties: Properties { indices: PropertyIndices([84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 1, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 2, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 0, 84, 84]), values: [Rect(Rect { x0: 0.0, y0: 0.0, x1: 50.0, y1: 200.0 }), String("Send"), DefaultActionVerb(Click)] } }
```

Without knowing how these structs work under the hood, it is impossible to figure out their state. Yet this can be useful when debugging, I think Bevy might even have an inspector system which take advantage of the debug representation of components.

With this PR, the above program now outputs:

```
NodeBuilder { role: Button, actions: [Focus], is_busy: true, name: Some("Send"), default_action_verb: Some(Click), bounds: Some(Rect { x0: 0.0, y0: 0.0, x1: 50.0, y1: 200.0 }) }
Node { role: Button, actions: [Focus], is_busy: true, name: Some("Send"), default_action_verb: Some(Click), bounds: Some(Rect { x0: 0.0, y0: 0.0, x1: 50.0, y1: 200.0 }) }
```

Because we have a lot of fields, I chose to only show them when their value is different from the default (`false`, `None` or `&[]`).