### PR TITLE
fix: Return a null object for AT-SPI application's parent

### DIFF
--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -78,8 +78,7 @@ impl Bus {
             .at(path.clone(), ApplicationInterface(node.clone()))
             .await?
         {
-            let desktop = self
-                .socket_proxy
+            self.socket_proxy
                 .embed(&(self.unique_name().as_str(), ObjectId::Root.path().into()))
                 .await?;
 
@@ -87,11 +86,7 @@ impl Bus {
                 .object_server()
                 .at(
                     path,
-                    RootAccessibleInterface::new(
-                        self.unique_name().to_owned(),
-                        desktop.into(),
-                        node,
-                    ),
+                    RootAccessibleInterface::new(self.unique_name().to_owned(), node),
                 )
                 .await?;
         }
@@ -230,7 +225,7 @@ impl Bus {
                         kind: "",
                         detail1: 0,
                         detail2: 0,
-                        any_data: child.to_address(self.unique_name().clone()).into(),
+                        any_data: child.to_address(self.unique_name().inner()).into(),
                         properties,
                     },
                 )
@@ -294,7 +289,7 @@ impl Bus {
                         kind: "add",
                         detail1: index as i32,
                         detail2: 0,
-                        any_data: child.to_address(self.unique_name().clone()).into(),
+                        any_data: child.to_address(self.unique_name().inner()).into(),
                         properties,
                     },
                 )
@@ -313,7 +308,7 @@ impl Bus {
                         kind: "remove",
                         detail1: -1,
                         detail2: 0,
-                        any_data: child.to_address(self.unique_name().clone()).into(),
+                        any_data: child.to_address(self.unique_name().inner()).into(),
                         properties,
                     },
                 )
@@ -345,7 +340,7 @@ impl Bus {
                                     },
                                     NodeIdOrRoot::Root => ObjectId::Root,
                                 };
-                                parent.to_address(self.unique_name().clone()).into()
+                                parent.to_address(self.unique_name().inner()).into()
                             }
                             Property::Role(value) => Value::U32(value as u32),
                             Property::Value(value) => Value::F64(value),

--- a/platforms/unix/src/atspi/interfaces/accessible.rs
+++ b/platforms/unix/src/atspi/interfaces/accessible.rs
@@ -49,7 +49,7 @@ impl NodeAccessibleInterface {
                 },
                 NodeIdOrRoot::Root => ObjectId::Root,
             }
-            .to_address(self.bus_name.clone())
+            .to_address(self.bus_name.inner())
         })
     }
 
@@ -90,7 +90,7 @@ impl NodeAccessibleInterface {
                     adapter: self.node.adapter_id(),
                     node: child,
                 }
-                .to_address(self.bus_name.clone())
+                .to_address(self.bus_name.inner())
             })
             .map_err(self.map_error())
     }
@@ -116,7 +116,7 @@ impl NodeAccessibleInterface {
     }
 
     fn get_application(&self) -> (OwnedObjectAddress,) {
-        (ObjectId::Root.to_address(self.bus_name.clone()),)
+        (ObjectId::Root.to_address(self.bus_name.inner()),)
     }
 
     fn get_interfaces(&self) -> fdo::Result<InterfaceSet> {
@@ -126,21 +126,12 @@ impl NodeAccessibleInterface {
 
 pub(crate) struct RootAccessibleInterface {
     bus_name: OwnedUniqueName,
-    desktop_address: OwnedObjectAddress,
     root: PlatformRoot,
 }
 
 impl RootAccessibleInterface {
-    pub fn new(
-        bus_name: OwnedUniqueName,
-        desktop_address: OwnedObjectAddress,
-        root: PlatformRoot,
-    ) -> Self {
-        Self {
-            bus_name,
-            desktop_address,
-            root,
-        }
+    pub fn new(bus_name: OwnedUniqueName, root: PlatformRoot) -> Self {
+        Self { bus_name, root }
     }
 }
 
@@ -158,7 +149,7 @@ impl RootAccessibleInterface {
 
     #[dbus_interface(property)]
     fn parent(&self) -> OwnedObjectAddress {
-        self.desktop_address.clone()
+        OwnedObjectAddress::null()
     }
 
     #[dbus_interface(property)]
@@ -191,7 +182,7 @@ impl RootAccessibleInterface {
     fn get_children(&self) -> fdo::Result<Vec<OwnedObjectAddress>> {
         self.root
             .map_child_ids(|(adapter, node)| {
-                ObjectId::Node { adapter, node }.to_address(self.bus_name.clone())
+                ObjectId::Node { adapter, node }.to_address(self.bus_name.inner())
             })
             .map_err(map_root_error)
     }
@@ -209,7 +200,7 @@ impl RootAccessibleInterface {
     }
 
     fn get_application(&self) -> (OwnedObjectAddress,) {
-        (ObjectId::Root.to_address(self.bus_name.clone()),)
+        (ObjectId::Root.to_address(self.bus_name.inner()),)
     }
 
     fn get_interfaces(&self) -> InterfaceSet {

--- a/platforms/unix/src/atspi/interfaces/mod.rs
+++ b/platforms/unix/src/atspi/interfaces/mod.rs
@@ -11,20 +11,19 @@ mod text;
 mod value;
 
 use crate::atspi::{ObjectId, OwnedObjectAddress};
-use zbus::{fdo, names::OwnedUniqueName};
+use zbus::{fdo, names::UniqueName};
 
 fn map_root_error(error: accesskit_atspi_common::Error) -> fdo::Error {
     crate::util::map_error(ObjectId::Root, error)
 }
 
 fn optional_object_address(
-    bus_name: &OwnedUniqueName,
+    bus_name: &UniqueName,
     object_id: Option<ObjectId>,
 ) -> (OwnedObjectAddress,) {
-    let bus_name = bus_name.clone();
     match object_id {
         Some(id) => (id.to_address(bus_name),),
-        None => (OwnedObjectAddress::null(bus_name),),
+        None => (OwnedObjectAddress::null(),),
     }
 }
 

--- a/platforms/unix/src/atspi/object_address.rs
+++ b/platforms/unix/src/atspi/object_address.rs
@@ -6,7 +6,7 @@
 use atspi::Accessible;
 use serde::{Deserialize, Serialize};
 use zbus::{
-    names::{OwnedUniqueName, UniqueName},
+    names::UniqueName,
     zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value},
 };
 
@@ -14,18 +14,21 @@ const NULL_PATH: &str = "/org/a11y/atspi/null";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, OwnedValue, Type, Value)]
 pub(crate) struct OwnedObjectAddress {
-    bus_name: OwnedUniqueName,
+    bus_name: String,
     path: OwnedObjectPath,
 }
 
 impl OwnedObjectAddress {
-    pub(crate) fn new(bus_name: OwnedUniqueName, path: OwnedObjectPath) -> Self {
-        Self { bus_name, path }
+    pub(crate) fn new(bus_name: &UniqueName, path: OwnedObjectPath) -> Self {
+        Self {
+            bus_name: bus_name.to_string(),
+            path,
+        }
     }
 
-    pub(crate) fn null(bus_name: OwnedUniqueName) -> Self {
+    pub(crate) fn null() -> Self {
         Self {
-            bus_name,
+            bus_name: String::new(),
             path: ObjectPath::from_str_unchecked(NULL_PATH).into(),
         }
     }
@@ -34,7 +37,7 @@ impl OwnedObjectAddress {
 impl From<Accessible> for OwnedObjectAddress {
     fn from(object: Accessible) -> Self {
         Self {
-            bus_name: OwnedUniqueName::from(UniqueName::from_string_unchecked(object.name)),
+            bus_name: object.name,
             path: object.path,
         }
     }

--- a/platforms/unix/src/atspi/object_id.rs
+++ b/platforms/unix/src/atspi/object_id.rs
@@ -8,7 +8,7 @@ use accesskit::NodeId;
 use accesskit_atspi_common::PlatformNode;
 use serde::{Serialize, Serializer};
 use zbus::{
-    names::OwnedUniqueName,
+    names::UniqueName,
     zvariant::{ObjectPath, OwnedObjectPath, Signature, Structure, StructureBuilder, Type},
 };
 
@@ -22,7 +22,7 @@ pub(crate) enum ObjectId {
 }
 
 impl ObjectId {
-    pub(crate) fn to_address(&self, bus_name: OwnedUniqueName) -> OwnedObjectAddress {
+    pub(crate) fn to_address(&self, bus_name: &UniqueName) -> OwnedObjectAddress {
         OwnedObjectAddress::new(bus_name, self.path())
     }
 


### PR DESCRIPTION
AT-SPI's documentation clarified this since I first implemented the Unix adapter: the root/application node's parent is not the desktop object but a null reference, and the bus name component of an object reference is an empty string.