### PR TITLE
fix: Update minimum supported Rust version to 1.75

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ When reporting an issue, in order to help the maintainers understand what the pr
 
 When making a code contribution to AccessKit, before opening your pull request please make sure that:
 
-- your patch builds with AccessKit's minimal supported Rust version (currently Rust 1.70)
+- your patch builds with AccessKit's minimal supported Rust version (currently Rust 1.75)
 - you added tests where applicable
 - you tested your modifications on all impacted platforms (see below)
 - you updated any relevant documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["gui"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AccessKit/accesskit"
-rust-version = "1.70"
+rust-version = "1.75"
 
 [profile.release]
 lto = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,4 +25,3 @@ enumn = ["dep:enumn"]
 pyo3 = ["dep:pyo3"]
 serde = ["dep:serde", "enumn"]
 schemars = ["dep:schemars", "serde"]
-

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -14,3 +14,4 @@ rust-version.workspace = true
 [dependencies]
 accesskit = { version = "0.16.1", path = "../common" }
 immutable-chunkmap = "2.0.5"
+

--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -21,4 +21,3 @@ atspi-common = { version = "0.3.0", default-features = false }
 serde = "1.0"
 thiserror = "1.0.39"
 zvariant = { version = "3", default-features = false }
-

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -34,4 +34,3 @@ objc2-app-kit = { version = "0.2.0", features = [
     "NSView",
     "NSWindow",
 ] }
-

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,3 +36,4 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
+

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -37,3 +37,4 @@ features = [
 once_cell = "1.13.0"
 scopeguard = "1.1.0"
 winit = "0.30"
+

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -40,3 +40,4 @@ accesskit_unix = { version = "0.12.1", path = "../unix", optional = true, defaul
 version = "0.30"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+


### PR DESCRIPTION
Blocks #456 

We have been stuck on zbus 3 for quite a while now because of this. I think this change won't impact our users at this point, therefore waiting longer would only hurt AccessKit adoption.