### PR TITLE
fix duplicate definitions

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -346,6 +346,7 @@ impl Action {
         1 << (self as u8)
     }
 
+    #[cfg(not(feature = "enumn"))]
     fn n(value: u8) -> Option<Self> {
         // Manually implement something similar to the enumn crate. We don't
         // want to bring this crate by default though and we can't use a


### PR DESCRIPTION
Since using accesskit `0.16.2` the following issue appears when enabling the `enumn` feature
```shell
error[E0592]: duplicate definitions with name `n`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit-0.16.2/src/lib.rs:270:38
    |
270 | #[cfg_attr(feature = "enumn", derive(enumn::N))]
    |                                      ^^^^^^^^ duplicate definitions for `n`
...
349 |     fn n(value: u8) -> Option<Self> {
    |     ------------------------------- other definition for `n`
    |
    = note: this error originates in the derive macro `enumn::N` (in Nightly builds, run with -Z macro-backtrace for more info)
error[E0034]: multiple applicable items in scope
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit-0.16.2/src/lib.rs:386:39
    |
386 |     while let Some(variant) = Action::n(i) {
    |                                       ^ multiple `n` found
    |
note: candidate #1 is defined in an impl for the type `Action`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit-0.16.2/src/lib.rs:270:38
    |
270 | #[cfg_attr(feature = "enumn", derive(enumn::N))]
    |                                      ^^^^^^^^
note: candidate #2 is defined in an impl for the type `Action`
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/accesskit-0.16.2/src/lib.rs:349:5
    |
349 |     fn n(value: u8) -> Option<Self> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `enumn::N` (in Nightly builds, run with -Z macro-backtrace for more info)
   ```

I fixed this by not compiling the custom n() function when the `enumn` feature is enabled.

Fixes #460 
