### PR TITLE
Xcode Accessibility Inspector update for the macOS adapter

### DIFF
--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -349,7 +349,7 @@ declare_class!(
 
         #[method_id(accessibilityWindow)]
         fn window(&self) -> Option<Id<AnyObject>> {
-            self.resolve_with_context(|node, context| {
+            self.resolve_with_context(|_, context| {
                 context
                     .view
                     .load()
@@ -360,7 +360,7 @@ declare_class!(
 
         #[method_id(accessibilityTopLevelUIElement)]
         fn top_level(&self) -> Option<Id<AnyObject>> {
-            self.resolve_with_context(|node, context| {
+            self.resolve_with_context(|_, context| {
                 context
                     .view
                     .load()

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -347,6 +347,28 @@ declare_class!(
             .flatten()
         }
 
+        #[method_id(accessibilityWindow)]
+        fn window(&self) -> Option<Id<AnyObject>> {
+            self.resolve_with_context(|node, context| {
+                context
+                    .view
+                    .load()
+                    .and_then(|view| unsafe { NSAccessibility::accessibilityParent(&*view) })
+            })
+            .flatten()
+        }
+
+        #[method_id(accessibilityTopLevelUIElement)]
+        fn top_level(&self) -> Option<Id<AnyObject>> {
+            self.resolve_with_context(|node, context| {
+                context
+                    .view
+                    .load()
+                    .and_then(|view| unsafe { NSAccessibility::accessibilityParent(&*view) })
+            })
+            .flatten()
+        }
+
         #[method_id(accessibilityChildren)]
         fn children(&self) -> Option<Id<NSArray<PlatformNode>>> {
             self.children_internal()
@@ -784,6 +806,8 @@ declare_class!(
                     || selector == sel!(accessibilityChildrenInNavigationOrder)
                     || selector == sel!(accessibilityFrame)
                     || selector == sel!(accessibilityRole)
+                    || selector == sel!(accessibilityWindow)
+                    || selector == sel!(accessibilityTopLevelUIElement)
                     || selector == sel!(accessibilityRoleDescription)
                     || selector == sel!(accessibilityIdentifier)
                     || selector == sel!(accessibilityTitle)

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -271,7 +271,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             target_os = "openbsd"
         )
     ))]
-    println!("Enable Orca with [Super]+[Alt]+[[cfg(target_os = "macos")]
+    println!("Enable Orca with [Super]+[Alt]+[S].");
 
     let event_loop = EventLoop::with_user_event().build()?;
     let mut state = Application::new(event_loop.create_proxy());

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -272,6 +272,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
     ))]
     println!("Enable Orca with [Super]+[Alt]+[S].");
+    #[cfg(target_os = "macos")]
+    println!("Enable VoiceOver with [Cmd]+[F5].");
 
     let event_loop = EventLoop::with_user_event().build()?;
     let mut state = Application::new(event_loop.create_proxy());

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -271,9 +271,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             target_os = "openbsd"
         )
     ))]
-    println!("Enable Orca with [Super]+[Alt]+[S].");
-    #[cfg(target_os = "macos")]
-    println!("Enable VoiceOver with [Cmd]+[F5].");
+    println!("Enable Orca with [Super]+[Alt]+[[cfg(target_os = "macos")]
 
     let event_loop = EventLoop::with_user_event().build()?;
     let mut state = Application::new(event_loop.create_proxy());


### PR DESCRIPTION
* Updated macos adapter to work better with the Xcode Accessibility Inspector, by providing `accessibilityWindow` and `accessibilityTopLevelUIElement` selectors. 

Before:

https://github.com/user-attachments/assets/3211f50c-9f35-4a43-9575-21a1ab50b9e3

After:

https://github.com/user-attachments/assets/f5c42461-8f1d-48bb-94e6-355921869425


The behaviour of VoiceOver has not changed, and reads out the same as before.