### PR TITLE
feat!: Make the core crate no-std

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ features = ["schemars", "serde"]
 enumn = { version = "0.1.6", optional = true }
 pyo3 = { version = "0.20", optional = true }
 schemars = { version = "0.8.7", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"], optional = true }
 
 [features]
 enumn = ["dep:enumn"]

--- a/common/src/geometry.rs
+++ b/common/src/geometry.rs
@@ -9,7 +9,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use std::{
+use core::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
@@ -65,20 +65,6 @@ impl Affine {
     #[inline]
     pub const fn scale_non_uniform(s_x: f64, s_y: f64) -> Affine {
         Affine([s_x, 0.0, 0.0, s_y, 0.0, 0.0])
-    }
-
-    /// An affine transform representing rotation.
-    ///
-    /// The convention for rotation is that a positive angle rotates a
-    /// positive X direction into positive Y. Thus, in a Y-down coordinate
-    /// system (as is common for graphics), it is a clockwise rotation, and
-    /// in Y-up (traditional for math), it is anti-clockwise.
-    ///
-    /// The angle, `th`, is expressed in radians.
-    #[inline]
-    pub fn rotate(th: f64) -> Affine {
-        let (s, c) = th.sin_cos();
-        Affine([c, s, -s, c, 0.0, 0.0])
     }
 
     /// An affine transform representing translation.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
+#![cfg_attr(not(any(feature = "pyo3", feature = "schemars")), no_std)]
+
+extern crate alloc;
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::fmt;
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 #[cfg(feature = "schemars")]
@@ -22,7 +28,6 @@ use serde::{
     ser::{SerializeMap, Serializer},
     Deserialize, Serialize,
 };
-use std::fmt;
 
 mod geometry;
 pub use geometry::{Affine, Point, Rect, Size, Vec2};

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -14,4 +14,3 @@ rust-version.workspace = true
 [dependencies]
 accesskit = { version = "0.16.3", path = "../common" }
 immutable-chunkmap = "2.0.5"
-

--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -21,3 +21,4 @@ atspi-common = { version = "0.6", default-features = false }
 serde = "1.0"
 thiserror = "1.0"
 zvariant = { version = "4.2", default-features = false }
+

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -34,3 +34,4 @@ objc2-app-kit = { version = "0.2.0", features = [
     "NSView",
     "NSWindow",
 ] }
+

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,4 +36,3 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
-

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -37,4 +37,3 @@ features = [
 once_cell = "1.13.0"
 scopeguard = "1.1.0"
 winit = "0.30"
-

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -40,4 +40,3 @@ accesskit_unix = { version = "0.12.3", path = "../unix", optional = true, defaul
 version = "0.30"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-


### PR DESCRIPTION
This is a prerequisite for eventually implementing accessibility for toolkits in embedded environments, such as those supported by Slint. And I don't think it's too drastic a change for the potential benefits.

The next step is to make `accesskit_consumer` no-std. That depends on estokes/immutable-chunkmap#10.

It's a breaking change because I had to drop the `Affine::rotate` method, which depends on a math function that's not in core. I don't think that's really a problem; I've never used that method. And anyway, this is more of a feature than a fix. And I have more breaking changes planned for this next release cycle.

This also adds the usual dummy changes to force the proper version number bump for the downstream crates.