### PR TITLE
feat: Make the consumer crate no-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ name = "accesskit_consumer"
 version = "0.25.0"
 dependencies = [
  "accesskit",
+ "hashbrown 0.15.0",
  "immutable-chunkmap",
 ]
 
@@ -764,6 +765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +925,9 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -939,9 +949,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "immutable-chunkmap"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4419f022e55cc63d5bbd6b44b71e1d226b9c9480a47824c706e9d54e5c40c5eb"
+checksum = "12f97096f508d54f8f8ab8957862eee2ccd628847b6217af1a335e1c44dee578"
 dependencies = [
  "arrayvec",
 ]

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -13,4 +13,5 @@ rust-version.workspace = true
 
 [dependencies]
 accesskit = { version = "0.17.0", path = "../common" }
-immutable-chunkmap = "2.0.5"
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
+immutable-chunkmap = "2.0.6"

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use std::iter::FusedIterator;
+use core::iter::FusedIterator;
 
 use accesskit::NodeId;
 
@@ -435,7 +435,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> FusedIterator for FilteredChildren<'
 pub(crate) enum LabelledBy<'a, Filter: Fn(&Node) -> FilterResult> {
     FromDescendants(FilteredChildren<'a, Filter>),
     Explicit {
-        ids: std::slice::Iter<'a, NodeId>,
+        ids: core::slice::Iter<'a, NodeId>,
         tree_state: &'a TreeState,
     },
 }
@@ -477,6 +477,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> FusedIterator for LabelledBy<'a, Fil
 mod tests {
     use crate::tests::*;
     use accesskit::NodeId;
+    use alloc::vec::Vec;
 
     #[test]
     fn following_siblings() {

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -3,6 +3,10 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
+#![no_std]
+
+extern crate alloc;
+
 pub(crate) mod tree;
 pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
 
@@ -23,6 +27,7 @@ pub use text::{
 #[cfg(test)]
 mod tests {
     use accesskit::{Affine, Node, NodeId, Rect, Role, Tree, TreeUpdate, Vec2};
+    use alloc::vec;
 
     use crate::FilterResult;
 

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -8,12 +8,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use std::{iter::FusedIterator, sync::Arc};
-
 use accesskit::{
     Action, Affine, FrozenNode as NodeData, Live, NodeId, Orientation, Point, Rect, Role,
     TextSelection, Toggled,
 };
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::iter::FusedIterator;
 
 use crate::filters::FilterResult;
 use crate::iterators::{
@@ -665,6 +669,7 @@ impl<'a> Node<'a> {
 #[cfg(test)]
 mod tests {
     use accesskit::{Node, NodeId, Point, Rect, Role, Tree, TreeUpdate};
+    use alloc::vec;
 
     use crate::tests::*;
 

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -6,7 +6,8 @@
 use accesskit::{
     NodeId, Point, Rect, Role, TextDirection, TextPosition as WeakPosition, TextSelection,
 };
-use std::{cmp::Ordering, iter::FusedIterator};
+use alloc::{string::String, vec::Vec};
+use core::{cmp::Ordering, iter::FusedIterator};
 
 use crate::{FilterResult, Node, TreeState};
 
@@ -488,7 +489,7 @@ pub struct Range<'a> {
 impl<'a> Range<'a> {
     fn new(node: Node<'a>, mut start: InnerPosition<'a>, mut end: InnerPosition<'a>) -> Self {
         if start.comparable(&node) > end.comparable(&node) {
-            std::mem::swap(&mut start, &mut end);
+            core::mem::swap(&mut start, &mut end);
         }
         Self { node, start, end }
     }
@@ -1089,6 +1090,7 @@ impl<'a> Node<'a> {
 #[cfg(test)]
 mod tests {
     use accesskit::{NodeId, Point, Rect, TextSelection};
+    use alloc::vec;
 
     // This is based on an actual tree produced by egui.
     fn main_multiline_tree(selection: Option<TextSelection>) -> crate::Tree {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,11 +4,9 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{FrozenNode as NodeData, NodeId, Tree as TreeData, TreeUpdate};
+use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+use hashbrown::{HashMap, HashSet};
 use immutable_chunkmap::map::MapM as ChunkMap;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
 
 use crate::node::{Node, NodeState, ParentAndIndex};
 
@@ -103,7 +101,7 @@ impl State {
                 } else {
                     pending_children.insert(*child_id, parent_and_index);
                 }
-                seen_child_ids.insert(child_id);
+                seen_child_ids.insert(*child_id);
             }
 
             if let Some(node_state) = self.nodes.get_mut_cow(&node_id) {
@@ -147,14 +145,14 @@ impl State {
         self.is_host_focused = is_host_focused;
 
         if !orphans.is_empty() {
-            let mut to_remove = HashSet::new();
+            let mut to_remove = Vec::new();
 
             fn traverse_orphan(
                 nodes: &ChunkMap<NodeId, NodeState>,
-                to_remove: &mut HashSet<NodeId>,
+                to_remove: &mut Vec<NodeId>,
                 id: NodeId,
             ) {
-                to_remove.insert(id);
+                to_remove.push(id);
                 let node = nodes.get(&id).unwrap();
                 for child_id in node.data.children().iter() {
                     traverse_orphan(nodes, to_remove, *child_id);
@@ -367,6 +365,7 @@ fn short_node_list<'a>(nodes: impl ExactSizeIterator<Item = &'a NodeId>) -> Stri
 #[cfg(test)]
 mod tests {
     use accesskit::{Node, NodeId, Role, Tree, TreeUpdate};
+    use alloc::vec;
 
     #[test]
     fn init_tree_with_root_node() {

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "Zlib",
 ]
 deny = []
 copyleft = "warn"


### PR DESCRIPTION
I think the only potentially controversial part of this is the decision to switch from hash tables to B-trees for the temporary data structures that are built while processing an update. Here's my reasoning.

`HashMap` and `HashSet` aren't in `alloc` because the default hasher requires entropy. We could add a `std` feature to `accesskit_consumer` and then bring in `hashbrown` as a dependency only when `std` is disabled. But for simplicity, I'd rather not add an extra feature and different code paths if we can avoid it.

I don't like depending on a random number generator anyway, even when using `std`. Predictability is a valuable attribute in software, and I think it's worth maximizing it at as many levels of the stack as possible. Also, at least on Windows, using the random number generator adds an extra library dependency that non-Rust users have to use when statically linking AccessKit.

As for performance, according to the Rust [collections documentation](https://doc.rust-lang.org/std/collections/index.html), the performance of B-tree operations is O(log(n)), where as the expected performance for hash tables is O(1). Note, though, that the latter is _expected_ performance, meaning that it's not guaranteed because hashing is probabilistic. In my opinion, log(n) never gets too large, and having that predictable upper bound is better.

I'm aware that the page I linked above also says to use hash tables unless one has a specific reason to do otherwise. I think I now disagree with that advice. I think it overvalues best-case performance compared to predictability.

Switching to B-trees does increase total binary size. I mitigated this somewhat by going to the trouble to avoid removing entries from the temporary `pending_nodes` and `pending_children` maps. This should be good for speed as well, since as I mentioned, the maps are temporary; they go away as soon as update processing is finished. With this mitigation, the added binary size, for a size-optimized build with `panic = "abort"` on x86-64, is just under 10 KB. When I switch the platform adapters to also use B-trees for their own structures, that should drop a few KB.