### PR TITLE
refactor!: Rename `Role::InlineTextBox` to `TextRun`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -55,7 +55,7 @@ pub use geometry::{Affine, Point, Rect, Size, Vec2};
 pub enum Role {
     #[default]
     Unknown,
-    InlineTextBox,
+    TextRun,
     Cell,
     Label,
     Image,
@@ -701,7 +701,7 @@ pub struct CustomAction {
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct TextPosition {
-    /// The node's role must be [`Role::InlineTextBox`].
+    /// The node's role must be [`Role::TextRun`].
     pub node: NodeId,
     /// The index of an item in [`Node::character_lengths`], or the length
     /// of that slice if the position is at the end of the line.
@@ -1476,7 +1476,7 @@ flag_methods! {
     /// is in touch exploration mode, e.g. a virtual keyboard normally
     /// behaves this way.
     (TouchTransparent, is_touch_transparent, set_touch_transparent, clear_touch_transparent),
-    /// Use for a textbox that allows focus/selection but not input.
+    /// Use for a text widget that allows focus/selection but not input.
     (ReadOnly, is_read_only, set_read_only, clear_read_only),
     /// Use for a control or group of controls that disallows input.
     (Disabled, is_disabled, set_disabled, clear_disabled),
@@ -1667,7 +1667,7 @@ text_decoration_property_methods! {
 }
 
 length_slice_property_methods! {
-    /// For inline text. The length (non-inclusive) of each character
+    /// For text runs, the length (non-inclusive) of each character
     /// in UTF-8 code units (bytes). The sum of these lengths must equal
     /// the length of [`value`], also in bytes.
     ///
@@ -1677,7 +1677,7 @@ length_slice_property_methods! {
     /// the lengths of the characters from the text itself; this information
     /// must be provided by the text editing implementation.
     ///
-    /// If this node is the last text box in a line that ends with a hard
+    /// If this node is the last text run in a line that ends with a hard
     /// line break, that line break should be included at the end of this
     /// node's value as either a CRLF or LF; in both cases, the line break
     /// should be counted as a single character for the sake of this slice.
@@ -1687,7 +1687,7 @@ length_slice_property_methods! {
     /// [`value`]: Node::value
     (CharacterLengths, character_lengths, set_character_lengths, clear_character_lengths),
 
-    /// For inline text. The length of each word in characters, as defined
+    /// For text runs, the length of each word in characters, as defined
     /// in [`character_lengths`]. The sum of these lengths must equal
     /// the length of [`character_lengths`].
     ///
@@ -1713,7 +1713,7 @@ length_slice_property_methods! {
 }
 
 coord_slice_property_methods! {
-    /// For inline text. This is the position of each character within
+    /// For text runs, this is the position of each character within
     /// the node's bounding box, in the direction given by
     /// [`text_direction`], in the coordinate space of this node.
     ///
@@ -1731,7 +1731,7 @@ coord_slice_property_methods! {
     /// [`character_lengths`]: Node::character_lengths
     (CharacterPositions, character_positions, set_character_positions, clear_character_positions),
 
-    /// For inline text. This is the advance width of each character,
+    /// For text runs, this is the advance width of each character,
     /// in the direction given by [`text_direction`], in the coordinate
     /// space of this node.
     ///

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -30,7 +30,7 @@ pub fn common_filter(node: &Node) -> FilterResult {
     }
 
     let role = node.role();
-    if role == Role::GenericContainer || role == Role::InlineTextBox {
+    if role == Role::GenericContainer || role == Role::TextRun {
         return FilterResult::ExcludeNode;
     }
 

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -172,7 +172,7 @@ impl<'a> AdapterChangeHandler<'a> {
     }
 
     fn emit_text_change_if_needed(&mut self, old_node: &Node, new_node: &Node) {
-        if let Role::InlineTextBox | Role::GenericContainer = new_node.role() {
+        if let Role::TextRun | Role::GenericContainer = new_node.role() {
             if let (Some(old_parent), Some(new_parent)) = (
                 old_node.filtered_parent(&filter),
                 new_node.filtered_parent(&filter),

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -158,7 +158,7 @@ impl<'a> NodeWrapper<'a> {
             Role::Iframe | Role::IframePresentational => AtspiRole::InternalFrame,
             // TODO: If there are unignored children, then it should be AtspiRole::ImageMap.
             Role::Image => AtspiRole::Image,
-            Role::InlineTextBox => AtspiRole::Static,
+            Role::TextRun => AtspiRole::Static,
             Role::Legend => AtspiRole::Label,
             // Layout table objects are treated the same as `Role::GenericContainer`.
             Role::LayoutTable => AtspiRole::Section,

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -173,7 +173,7 @@ impl EventGenerator {
     }
 
     fn insert_text_change_if_needed(&mut self, node: &Node) {
-        if node.role() != Role::InlineTextBox {
+        if node.role() != Role::TextRun {
             return;
         }
         if let Some(node) = node.filtered_parent(&filter) {

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -36,7 +36,7 @@ fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
     unsafe {
         match role {
             Role::Unknown => NSAccessibilityUnknownRole,
-            Role::InlineTextBox => NSAccessibilityUnknownRole,
+            Role::TextRun => NSAccessibilityUnknownRole,
             Role::Cell => NSAccessibilityCellRole,
             Role::Label => NSAccessibilityStaticTextRole,
             Role::Image => NSAccessibilityImageRole,

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -74,7 +74,7 @@ impl AdapterChangeHandler<'_> {
     }
 
     fn insert_text_change_if_needed(&mut self, node: &Node) {
-        if node.role() != Role::InlineTextBox {
+        if node.role() != Role::TextRun {
             return;
         }
         if let Some(node) = node.filtered_parent(&filter) {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -49,7 +49,7 @@ impl<'a> NodeWrapper<'a> {
         // TODO: Handle special cases. (#14)
         match role {
             Role::Unknown => UIA_CustomControlTypeId,
-            Role::InlineTextBox => UIA_CustomControlTypeId,
+            Role::TextRun => UIA_CustomControlTypeId,
             Role::Cell => UIA_DataItemControlTypeId,
             Role::Label => UIA_TextControlTypeId,
             Role::Image => UIA_ImageControlTypeId,


### PR DESCRIPTION
I copied "inline text box" from Chromium. But "text run" will be more familiar to anyone who has worked on a modern text layout implementation. And it's shorter.