### PR TITLE
Add isEnabled to MacOS adapter

### DIFF
--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -524,7 +524,7 @@ declare_class!(
         }
 
         #[method(isAccessibilityEnabled)]
-        fn enabled(&self) -> bool {
+        fn is_enabled(&self) -> bool {
             self.resolve(|node| !node.is_disabled()).unwrap_or(false)
         }
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -525,7 +525,7 @@ declare_class!(
 
         #[method(isAccessibilityEnabled)]
         fn enabled(&self) -> bool {
-            self.resolve(|node| !node.is_disabled()).unwrap_or(true)
+            self.resolve(|node| !node.is_disabled()).unwrap_or(false)
         }
 
         #[method(setAccessibilityFocused:)]

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -523,6 +523,11 @@ declare_class!(
                 .unwrap_or(false)
         }
 
+        #[method(isAccessibilityEnabled)]
+        fn enabled(&self) -> bool {
+            self.resolve(|node| !node.is_disabled()).unwrap_or(true)
+        }
+
         #[method(setAccessibilityFocused:)]
         fn set_focused(&self, focused: bool) {
             self.resolve_with_context(|node, context| {
@@ -806,6 +811,7 @@ declare_class!(
                     || selector == sel!(accessibilityChildrenInNavigationOrder)
                     || selector == sel!(accessibilityFrame)
                     || selector == sel!(accessibilityRole)
+                    || selector == sel!(isAccessibilityEnabled)
                     || selector == sel!(accessibilityWindow)
                     || selector == sel!(accessibilityTopLevelUIElement)
                     || selector == sel!(accessibilityRoleDescription)


### PR DESCRIPTION
Added isAccessibilityEnabled to MacOS adapter.

This is based on the is_disabled attribute from the consumer crate.

If an accessibility node is explicitly set to disabled, it is marked as disabled on the MacOS accessibility node.
Otherwise it is marked as enabled.

When read out by VoiceOver, the item is read as "dimmed".


https://github.com/user-attachments/assets/89286e40-c532-465a-a39f-14294da3ac60

