### PR TITLE
refactor!: Rename `NodeBuilder` to `Node` and the old `Node` to `FrozenNode`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1799,7 +1799,7 @@ vec_property_methods! {
 
 impl fmt::Debug for FrozenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut fmt = f.debug_struct("Node");
+        let mut fmt = f.debug_struct("FrozenNode");
 
         fmt.field("role", &self.role());
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -886,9 +886,26 @@ impl Default for PropertyIndices {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct Properties {
+struct FrozenProperties {
     indices: PropertyIndices,
     values: Box<[PropertyValue]>,
+}
+
+/// An accessibility node snapshot that can't be modified. This is not used by
+/// toolkits or applications, but only by code that retains an AccessKit tree
+/// in memory, such as the `accesskit_consumer` crate.
+#[derive(Clone, PartialEq)]
+pub struct FrozenNode {
+    role: Role,
+    actions: u32,
+    flags: u32,
+    properties: FrozenProperties,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct Properties {
+    indices: PropertyIndices,
+    values: Vec<PropertyValue>,
 }
 
 /// A single accessible object. A complete UI is represented as a tree of these.
@@ -897,7 +914,7 @@ struct Properties {
 /// to other languages, documentation of getter methods is written as if
 /// documenting fields in a struct, and such methods are referred to
 /// as properties.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
@@ -907,21 +924,6 @@ pub struct Node {
     actions: u32,
     flags: u32,
     properties: Properties,
-}
-
-#[derive(Clone, Debug, Default, PartialEq)]
-struct PropertiesBuilder {
-    indices: PropertyIndices,
-    values: Vec<PropertyValue>,
-}
-
-/// Builds a [`Node`].
-#[derive(Clone, Default, PartialEq)]
-pub struct NodeBuilder {
-    role: Role,
-    actions: u32,
-    flags: u32,
-    properties: PropertiesBuilder,
 }
 
 impl PropertyIndices {
@@ -939,7 +941,7 @@ fn unexpected_property_type() -> ! {
     panic!();
 }
 
-impl PropertiesBuilder {
+impl Properties {
     fn get_mut(&mut self, id: PropertyId, default: PropertyValue) -> &mut PropertyValue {
         let index = self.indices.0[id as usize] as usize;
         if index == PropertyId::Unset as usize {
@@ -971,18 +973,20 @@ impl PropertiesBuilder {
             self.values[index as usize] = PropertyValue::None;
         }
     }
+}
 
-    fn build(self) -> Properties {
-        Properties {
-            indices: self.indices,
-            values: self.values.into_boxed_slice(),
+impl From<Properties> for FrozenProperties {
+    fn from(props: Properties) -> Self {
+        Self {
+            indices: props.indices,
+            values: props.values.into_boxed_slice(),
         }
     }
 }
 
 macro_rules! flag_methods {
     ($($(#[$doc:meta])* ($id:ident, $getter:ident, $setter:ident, $clearer:ident)),+) => {
-        impl Node {
+        impl FrozenNode {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> bool {
@@ -996,7 +1000,7 @@ macro_rules! flag_methods {
                 )*
             }
         }
-        impl NodeBuilder {
+        impl Node {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> bool {
@@ -1065,7 +1069,7 @@ macro_rules! copy_type_getters {
 
 macro_rules! box_type_setters {
     ($(($method:ident, $type:ty, $variant:ident)),+) => {
-        impl NodeBuilder {
+        impl Node {
             $(fn $method(&mut self, id: PropertyId, value: impl Into<Box<$type>>) {
                 self.properties.set(id, PropertyValue::$variant(value.into()));
             })*
@@ -1075,7 +1079,7 @@ macro_rules! box_type_setters {
 
 macro_rules! copy_type_setters {
     ($(($method:ident, $type:ty, $variant:ident)),+) => {
-        impl NodeBuilder {
+        impl Node {
             $(fn $method(&mut self, id: PropertyId, value: $type) {
                 self.properties.set(id, PropertyValue::$variant(value));
             })*
@@ -1088,7 +1092,7 @@ macro_rules! vec_type_methods {
         $(slice_type_getters! {
             ($getter, $type, $variant)
         })*
-        impl NodeBuilder {
+        impl Node {
             $(fn $setter(&mut self, id: PropertyId, value: impl Into<Vec<$type>>) {
                 self.properties.set(id, PropertyValue::$variant(value.into()));
             }
@@ -1106,14 +1110,14 @@ macro_rules! vec_type_methods {
 
 macro_rules! property_methods {
     ($($(#[$doc:meta])* ($id:ident, $getter:ident, $type_getter:ident, $getter_result:ty, $setter:ident, $type_setter:ident, $setter_param:ty, $clearer:ident)),+) => {
-        impl Node {
+        impl FrozenNode {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> $getter_result {
                 self.properties.indices.$type_getter(&self.properties.values, PropertyId::$id)
             })*
         }
-        impl NodeBuilder {
+        impl Node {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> $getter_result {
@@ -1137,7 +1141,7 @@ macro_rules! vec_property_methods {
             $(#[$doc])*
             ($id, $getter, $type_getter, &[$item_type], $setter, $type_setter, impl Into<Vec<$item_type>>, $clearer)
         }
-        impl NodeBuilder {
+        impl Node {
             #[inline]
             pub fn $pusher(&mut self, item: $item_type) {
                 self.$type_pusher(PropertyId::$id, item);
@@ -1165,10 +1169,10 @@ macro_rules! node_id_vec_property_methods {
             $(#[$doc])*
             ($id, NodeId, $getter, get_node_id_vec, $setter, set_node_id_vec, $pusher, push_to_node_id_vec, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             slice_properties_debug_method! { debug_node_id_vec_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             slice_properties_debug_method! { debug_node_id_vec_properties, [$($getter,)*] }
         }
     }
@@ -1192,10 +1196,10 @@ macro_rules! node_id_property_methods {
             $(#[$doc])*
             ($id, $getter, get_node_id_property, Option<NodeId>, $setter, set_node_id_property, NodeId, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_node_id_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_node_id_properties, [$($getter,)*] }
         }
     }
@@ -1207,10 +1211,10 @@ macro_rules! string_property_methods {
             $(#[$doc])*
             ($id, $getter, get_string_property, Option<&str>, $setter, set_string_property, impl Into<Box<str>>, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_string_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_string_properties, [$($getter,)*] }
         }
     }
@@ -1222,10 +1226,10 @@ macro_rules! f64_property_methods {
             $(#[$doc])*
             ($id, $getter, get_f64_property, Option<f64>, $setter, set_f64_property, f64, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_f64_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_f64_properties, [$($getter,)*] }
         }
     }
@@ -1237,10 +1241,10 @@ macro_rules! usize_property_methods {
             $(#[$doc])*
             ($id, $getter, get_usize_property, Option<usize>, $setter, set_usize_property, usize, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_usize_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_usize_properties, [$($getter,)*] }
         }
     }
@@ -1252,10 +1256,10 @@ macro_rules! color_property_methods {
             $(#[$doc])*
             ($id, $getter, get_color_property, Option<u32>, $setter, set_color_property, u32, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_color_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_color_properties, [$($getter,)*] }
         }
     }
@@ -1267,10 +1271,10 @@ macro_rules! text_decoration_property_methods {
             $(#[$doc])*
             ($id, $getter, get_text_decoration_property, Option<TextDecoration>, $setter, set_text_decoration_property, TextDecoration, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_text_decoration_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_text_decoration_properties, [$($getter,)*] }
         }
     }
@@ -1282,10 +1286,10 @@ macro_rules! length_slice_property_methods {
             $(#[$doc])*
             ($id, $getter, get_length_slice_property, &[u8], $setter, set_length_slice_property, impl Into<Box<[u8]>>, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             slice_properties_debug_method! { debug_length_slice_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             slice_properties_debug_method! { debug_length_slice_properties, [$($getter,)*] }
         }
     }
@@ -1297,10 +1301,10 @@ macro_rules! coord_slice_property_methods {
             $(#[$doc])*
             ($id, $getter, get_coord_slice_property, Option<&[f32]>, $setter, set_coord_slice_property, impl Into<Box<[f32]>>, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_coord_slice_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_coord_slice_properties, [$($getter,)*] }
         }
     }
@@ -1312,10 +1316,10 @@ macro_rules! bool_property_methods {
             $(#[$doc])*
             ($id, $getter, get_bool_property, Option<bool>, $setter, set_bool_property, bool, $clearer)
         })*
-        impl Node {
+        impl FrozenNode {
             option_properties_debug_method! { debug_bool_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             option_properties_debug_method! { debug_bool_properties, [$($getter,)*] }
         }
     }
@@ -1323,7 +1327,7 @@ macro_rules! bool_property_methods {
 
 macro_rules! unique_enum_property_methods {
     ($($(#[$doc:meta])* ($id:ident, $getter:ident, $setter:ident, $clearer:ident)),+) => {
-        impl Node {
+        impl FrozenNode {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> Option<$id> {
@@ -1335,7 +1339,7 @@ macro_rules! unique_enum_property_methods {
             })*
             option_properties_debug_method! { debug_unique_enum_properties, [$($getter,)*] }
         }
-        impl NodeBuilder {
+        impl Node {
             $($(#[$doc])*
             #[inline]
             pub fn $getter(&self) -> Option<$id> {
@@ -1358,7 +1362,7 @@ macro_rules! unique_enum_property_methods {
     }
 }
 
-impl NodeBuilder {
+impl Node {
     #[inline]
     pub fn new(role: Role) -> Self {
         Self {
@@ -1366,25 +1370,27 @@ impl NodeBuilder {
             ..Default::default()
         }
     }
+}
 
-    pub fn build(self) -> Node {
-        Node {
-            role: self.role,
-            actions: self.actions,
-            flags: self.flags,
-            properties: self.properties.build(),
+impl From<Node> for FrozenNode {
+    fn from(node: Node) -> Self {
+        Self {
+            role: node.role,
+            actions: node.actions,
+            flags: node.flags,
+            properties: node.properties.into(),
         }
     }
 }
 
-impl Node {
+impl FrozenNode {
     #[inline]
     pub fn role(&self) -> Role {
         self.role
     }
 }
 
-impl NodeBuilder {
+impl Node {
     #[inline]
     pub fn role(&self) -> Role {
         self.role
@@ -1395,14 +1401,14 @@ impl NodeBuilder {
     }
 }
 
-impl Node {
+impl FrozenNode {
     #[inline]
     pub fn supports_action(&self, action: Action) -> bool {
         (self.actions & action.mask()) != 0
     }
 }
 
-impl NodeBuilder {
+impl Node {
     #[inline]
     pub fn supports_action(&self, action: Action) -> bool {
         (self.actions & action.mask()) != 0
@@ -1779,11 +1785,11 @@ property_methods! {
     (TextSelection, text_selection, get_text_selection_property, Option<&TextSelection>, set_text_selection, set_text_selection_property, impl Into<Box<TextSelection>>, clear_text_selection)
 }
 
-impl Node {
+impl FrozenNode {
     option_properties_debug_method! { debug_option_properties, [transform, bounds, text_selection,] }
 }
 
-impl NodeBuilder {
+impl Node {
     option_properties_debug_method! { debug_option_properties, [transform, bounds, text_selection,] }
 }
 
@@ -1791,7 +1797,7 @@ vec_property_methods! {
     (CustomActions, CustomAction, custom_actions, get_custom_action_vec, set_custom_actions, set_custom_action_vec, push_custom_action, push_to_custom_action_vec, clear_custom_actions)
 }
 
-impl fmt::Debug for Node {
+impl fmt::Debug for FrozenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fmt = f.debug_struct("Node");
 
@@ -1825,9 +1831,9 @@ impl fmt::Debug for Node {
     }
 }
 
-impl fmt::Debug for NodeBuilder {
+impl fmt::Debug for Node {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut fmt = f.debug_struct("NodeBuilder");
+        let mut fmt = f.debug_struct("Node");
 
         fmt.field("role", &self.role());
 
@@ -1873,11 +1879,11 @@ macro_rules! serialize_property {
 
 #[cfg(feature = "serde")]
 macro_rules! deserialize_property {
-    ($builder:ident, $map:ident, $key:ident, { $($type:ident { $($id:ident),+ }),+ }) => {
+    ($props:ident, $map:ident, $key:ident, { $($type:ident { $($id:ident),+ }),+ }) => {
         match $key {
             $($(PropertyId::$id => {
                 let value = $map.next_value()?;
-                $builder.set(PropertyId::$id, PropertyValue::$type(value));
+                $props.set(PropertyId::$id, PropertyValue::$type(value));
             })*)*
             PropertyId::Unset => {
                 let _ = $map.next_value::<IgnoredAny>()?;
@@ -1953,9 +1959,9 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
     where
         V: MapAccess<'de>,
     {
-        let mut builder = PropertiesBuilder::default();
+        let mut props = Properties::default();
         while let Some(id) = map.next_key()? {
-            deserialize_property!(builder, map, id, {
+            deserialize_property!(props, map, id, {
                 NodeIdVec {
                     Children,
                     Controls,
@@ -2062,7 +2068,7 @@ impl<'de> Visitor<'de> for PropertiesVisitor {
             });
         }
 
-        Ok(builder.build())
+        Ok(props)
     }
 }
 
@@ -2429,38 +2435,38 @@ mod tests {
     fn test_action_mask_to_action_vec() {
         assert_eq!(
             Vec::<Action>::new(),
-            action_mask_to_action_vec(NodeBuilder::new(Role::Unknown).actions)
+            action_mask_to_action_vec(Node::new(Role::Unknown).actions)
         );
 
-        let mut builder = NodeBuilder::new(Role::Unknown);
-        builder.add_action(Action::Click);
+        let mut node = Node::new(Role::Unknown);
+        node.add_action(Action::Click);
         assert_eq!(
             &[Action::Click],
-            action_mask_to_action_vec(builder.actions).as_slice()
+            action_mask_to_action_vec(node.actions).as_slice()
         );
 
-        let mut builder = NodeBuilder::new(Role::Unknown);
-        builder.add_action(Action::ShowContextMenu);
+        let mut node = Node::new(Role::Unknown);
+        node.add_action(Action::ShowContextMenu);
         assert_eq!(
             &[Action::ShowContextMenu],
-            action_mask_to_action_vec(builder.actions).as_slice()
+            action_mask_to_action_vec(node.actions).as_slice()
         );
 
-        let mut builder = NodeBuilder::new(Role::Unknown);
-        builder.add_action(Action::Click);
-        builder.add_action(Action::ShowContextMenu);
+        let mut node = Node::new(Role::Unknown);
+        node.add_action(Action::Click);
+        node.add_action(Action::ShowContextMenu);
         assert_eq!(
             &[Action::Click, Action::ShowContextMenu],
-            action_mask_to_action_vec(builder.actions).as_slice()
+            action_mask_to_action_vec(node.actions).as_slice()
         );
 
-        let mut builder = NodeBuilder::new(Role::Unknown);
-        builder.add_action(Action::Focus);
-        builder.add_action(Action::Blur);
-        builder.add_action(Action::Collapse);
+        let mut node = Node::new(Role::Unknown);
+        node.add_action(Action::Focus);
+        node.add_action(Action::Blur);
+        node.add_action(Action::Collapse);
         assert_eq!(
             &[Action::Focus, Action::Blur, Action::Collapse],
-            action_mask_to_action_vec(builder.actions).as_slice()
+            action_mask_to_action_vec(node.actions).as_slice()
         );
     }
 }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -22,7 +22,7 @@ pub use text::{
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{Affine, NodeBuilder, NodeId, Rect, Role, Tree, TreeUpdate, Vec2};
+    use accesskit::{Affine, Node, NodeId, Rect, Role, Tree, TreeUpdate, Vec2};
 
     use crate::FilterResult;
 
@@ -46,114 +46,114 @@ mod tests {
 
     pub fn test_tree() -> crate::tree::Tree {
         let root = {
-            let mut builder = NodeBuilder::new(Role::RootWebArea);
-            builder.set_children(vec![
+            let mut node = Node::new(Role::RootWebArea);
+            node.set_children(vec![
                 PARAGRAPH_0_ID,
                 PARAGRAPH_1_IGNORED_ID,
                 PARAGRAPH_2_ID,
                 PARAGRAPH_3_IGNORED_ID,
             ]);
-            builder.build()
+            node
         };
         let paragraph_0 = {
-            let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_children(vec![LABEL_0_0_IGNORED_ID]);
-            builder.build()
+            let mut node = Node::new(Role::Paragraph);
+            node.set_children(vec![LABEL_0_0_IGNORED_ID]);
+            node
         };
         let label_0_0_ignored = {
-            let mut builder = NodeBuilder::new(Role::Label);
-            builder.set_name("label_0_0_ignored");
-            builder.build()
+            let mut node = Node::new(Role::Label);
+            node.set_name("label_0_0_ignored");
+            node
         };
         let paragraph_1_ignored = {
-            let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_transform(Affine::translate(Vec2::new(10.0, 40.0)));
-            builder.set_bounds(Rect {
+            let mut node = Node::new(Role::Paragraph);
+            node.set_transform(Affine::translate(Vec2::new(10.0, 40.0)));
+            node.set_bounds(Rect {
                 x0: 0.0,
                 y0: 0.0,
                 x1: 800.0,
                 y1: 40.0,
             });
-            builder.set_children(vec![
+            node.set_children(vec![
                 BUTTON_1_0_HIDDEN_ID,
                 LABEL_1_1_ID,
                 BUTTON_1_2_HIDDEN_ID,
             ]);
-            builder.build()
+            node
         };
         let button_1_0_hidden = {
-            let mut builder = NodeBuilder::new(Role::Button);
-            builder.set_name("button_1_0_hidden");
-            builder.set_hidden();
-            builder.set_children(vec![CONTAINER_1_0_0_HIDDEN_ID]);
-            builder.build()
+            let mut node = Node::new(Role::Button);
+            node.set_name("button_1_0_hidden");
+            node.set_hidden();
+            node.set_children(vec![CONTAINER_1_0_0_HIDDEN_ID]);
+            node
         };
         let container_1_0_0_hidden = {
-            let mut builder = NodeBuilder::new(Role::GenericContainer);
-            builder.set_hidden();
-            builder.build()
+            let mut node = Node::new(Role::GenericContainer);
+            node.set_hidden();
+            node
         };
         let label_1_1 = {
-            let mut builder = NodeBuilder::new(Role::Label);
-            builder.set_bounds(Rect {
+            let mut node = Node::new(Role::Label);
+            node.set_bounds(Rect {
                 x0: 10.0,
                 y0: 10.0,
                 x1: 90.0,
                 y1: 30.0,
             });
-            builder.set_name("label_1_1");
-            builder.build()
+            node.set_name("label_1_1");
+            node
         };
         let button_1_2_hidden = {
-            let mut builder = NodeBuilder::new(Role::Button);
-            builder.set_name("button_1_2_hidden");
-            builder.set_hidden();
-            builder.set_children(vec![CONTAINER_1_2_0_HIDDEN_ID]);
-            builder.build()
+            let mut node = Node::new(Role::Button);
+            node.set_name("button_1_2_hidden");
+            node.set_hidden();
+            node.set_children(vec![CONTAINER_1_2_0_HIDDEN_ID]);
+            node
         };
         let container_1_2_0_hidden = {
-            let mut builder = NodeBuilder::new(Role::GenericContainer);
-            builder.set_hidden();
-            builder.build()
+            let mut node = Node::new(Role::GenericContainer);
+            node.set_hidden();
+            node
         };
         let paragraph_2 = {
-            let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_children(vec![LABEL_2_0_ID]);
-            builder.build()
+            let mut node = Node::new(Role::Paragraph);
+            node.set_children(vec![LABEL_2_0_ID]);
+            node
         };
         let label_2_0 = {
-            let mut builder = NodeBuilder::new(Role::Label);
-            builder.set_name("label_2_0");
-            builder.build()
+            let mut node = Node::new(Role::Label);
+            node.set_name("label_2_0");
+            node
         };
         let paragraph_3_ignored = {
-            let mut builder = NodeBuilder::new(Role::Paragraph);
-            builder.set_children(vec![
+            let mut node = Node::new(Role::Paragraph);
+            node.set_children(vec![
                 EMPTY_CONTAINER_3_0_IGNORED_ID,
                 LINK_3_1_IGNORED_ID,
                 BUTTON_3_2_ID,
                 EMPTY_CONTAINER_3_3_IGNORED_ID,
             ]);
-            builder.build()
+            node
         };
-        let empty_container_3_0_ignored = NodeBuilder::new(Role::GenericContainer).build();
+        let empty_container_3_0_ignored = Node::new(Role::GenericContainer);
         let link_3_1_ignored = {
-            let mut builder = NodeBuilder::new(Role::Link);
-            builder.set_children(vec![LABEL_3_1_0_ID]);
-            builder.set_linked();
-            builder.build()
+            let mut node = Node::new(Role::Link);
+            node.set_children(vec![LABEL_3_1_0_ID]);
+            node.set_linked();
+            node
         };
         let label_3_1_0 = {
-            let mut builder = NodeBuilder::new(Role::Label);
-            builder.set_name("label_3_1_0");
-            builder.build()
+            let mut node = Node::new(Role::Label);
+            node.set_name("label_3_1_0");
+            node
         };
         let button_3_2 = {
-            let mut builder = NodeBuilder::new(Role::Button);
-            builder.set_name("button_3_2");
-            builder.build()
+            let mut node = Node::new(Role::Button);
+            node.set_name("button_3_2");
+            node
         };
-        let empty_container_3_3_ignored = NodeBuilder::new(Role::GenericContainer).build();
+        let empty_container_3_3_ignored = Node::new(Role::GenericContainer);
         let initial_update = TreeUpdate {
             nodes: vec![
                 (ROOT_ID, root),

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -11,8 +11,8 @@
 use std::{iter::FusedIterator, sync::Arc};
 
 use accesskit::{
-    Action, Affine, Live, Node as NodeData, NodeId, Orientation, Point, Rect, Role, TextSelection,
-    Toggled,
+    Action, Affine, FrozenNode as NodeData, Live, NodeId, Orientation, Point, Rect, Role,
+    TextSelection, Toggled,
 };
 
 use crate::filters::FilterResult;
@@ -654,7 +654,7 @@ impl<'a> Node<'a> {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{NodeBuilder, NodeId, Point, Rect, Role, Tree, TreeUpdate};
+    use accesskit::{Node, NodeId, Point, Rect, Role, Tree, TreeUpdate};
 
     use crate::tests::*;
 
@@ -920,11 +920,11 @@ mod tests {
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
-                    let mut builder = NodeBuilder::new(Role::Window);
-                    builder.set_children(vec![NodeId(1)]);
-                    builder.build()
+                    let mut node = Node::new(Role::Window);
+                    node.set_children(vec![NodeId(1)]);
+                    node
                 }),
-                (NodeId(1), NodeBuilder::new(Role::Button).build()),
+                (NodeId(1), Node::new(Role::Button)),
             ],
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
@@ -943,29 +943,29 @@ mod tests {
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
-                    let mut builder = NodeBuilder::new(Role::Window);
-                    builder.set_children(vec![NodeId(1), NodeId(2), NodeId(3), NodeId(4)]);
-                    builder.build()
+                    let mut node = Node::new(Role::Window);
+                    node.set_children(vec![NodeId(1), NodeId(2), NodeId(3), NodeId(4)]);
+                    node
                 }),
                 (NodeId(1), {
-                    let mut builder = NodeBuilder::new(Role::CheckBox);
-                    builder.set_labelled_by(vec![NodeId(2), NodeId(4)]);
-                    builder.build()
+                    let mut node = Node::new(Role::CheckBox);
+                    node.set_labelled_by(vec![NodeId(2), NodeId(4)]);
+                    node
                 }),
                 (NodeId(2), {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(LABEL_1);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(LABEL_1);
+                    node
                 }),
                 (NodeId(3), {
-                    let mut builder = NodeBuilder::new(Role::TextInput);
-                    builder.push_labelled_by(NodeId(4));
-                    builder.build()
+                    let mut node = Node::new(Role::TextInput);
+                    node.push_labelled_by(NodeId(4));
+                    node
                 }),
                 (NodeId(4), {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(LABEL_2);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(LABEL_2);
+                    node
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),
@@ -1016,8 +1016,8 @@ mod tests {
         let update = TreeUpdate {
             nodes: vec![
                 (ROOT_ID, {
-                    let mut builder = NodeBuilder::new(Role::Window);
-                    builder.set_children(vec![
+                    let mut node = Node::new(Role::Window);
+                    node.set_children(vec![
                         DEFAULT_BUTTON_ID,
                         LINK_ID,
                         CHECKBOX_ID,
@@ -1025,97 +1025,97 @@ mod tests {
                         MENU_BUTTON_ID,
                         MENU_ID,
                     ]);
-                    builder.build()
+                    node
                 }),
                 (DEFAULT_BUTTON_ID, {
-                    let mut builder = NodeBuilder::new(Role::DefaultButton);
-                    builder.push_child(DEFAULT_BUTTON_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::DefaultButton);
+                    node.push_child(DEFAULT_BUTTON_LABEL_ID);
+                    node
                 }),
                 (DEFAULT_BUTTON_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Image);
-                    builder.set_name(DEFAULT_BUTTON_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Image);
+                    node.set_name(DEFAULT_BUTTON_LABEL);
+                    node
                 }),
                 (LINK_ID, {
-                    let mut builder = NodeBuilder::new(Role::Link);
-                    builder.push_child(LINK_LABEL_CONTAINER_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::Link);
+                    node.push_child(LINK_LABEL_CONTAINER_ID);
+                    node
                 }),
                 (LINK_LABEL_CONTAINER_ID, {
-                    let mut builder = NodeBuilder::new(Role::GenericContainer);
-                    builder.push_child(LINK_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::GenericContainer);
+                    node.push_child(LINK_LABEL_ID);
+                    node
                 }),
                 (LINK_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(LINK_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(LINK_LABEL);
+                    node
                 }),
                 (CHECKBOX_ID, {
-                    let mut builder = NodeBuilder::new(Role::CheckBox);
-                    builder.push_child(CHECKBOX_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::CheckBox);
+                    node.push_child(CHECKBOX_LABEL_ID);
+                    node
                 }),
                 (CHECKBOX_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(CHECKBOX_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(CHECKBOX_LABEL);
+                    node
                 }),
                 (RADIO_BUTTON_ID, {
-                    let mut builder = NodeBuilder::new(Role::RadioButton);
-                    builder.push_child(RADIO_BUTTON_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::RadioButton);
+                    node.push_child(RADIO_BUTTON_LABEL_ID);
+                    node
                 }),
                 (RADIO_BUTTON_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(RADIO_BUTTON_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(RADIO_BUTTON_LABEL);
+                    node
                 }),
                 (MENU_BUTTON_ID, {
-                    let mut builder = NodeBuilder::new(Role::Button);
-                    builder.push_child(MENU_BUTTON_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::Button);
+                    node.push_child(MENU_BUTTON_LABEL_ID);
+                    node
                 }),
                 (MENU_BUTTON_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(MENU_BUTTON_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(MENU_BUTTON_LABEL);
+                    node
                 }),
                 (MENU_ID, {
-                    let mut builder = NodeBuilder::new(Role::Menu);
-                    builder.set_children([MENU_ITEM_ID, MENU_ITEM_CHECKBOX_ID, MENU_ITEM_RADIO_ID]);
-                    builder.build()
+                    let mut node = Node::new(Role::Menu);
+                    node.set_children([MENU_ITEM_ID, MENU_ITEM_CHECKBOX_ID, MENU_ITEM_RADIO_ID]);
+                    node
                 }),
                 (MENU_ITEM_ID, {
-                    let mut builder = NodeBuilder::new(Role::MenuItem);
-                    builder.push_child(MENU_ITEM_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::MenuItem);
+                    node.push_child(MENU_ITEM_LABEL_ID);
+                    node
                 }),
                 (MENU_ITEM_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(MENU_ITEM_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(MENU_ITEM_LABEL);
+                    node
                 }),
                 (MENU_ITEM_CHECKBOX_ID, {
-                    let mut builder = NodeBuilder::new(Role::MenuItemCheckBox);
-                    builder.push_child(MENU_ITEM_CHECKBOX_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::MenuItemCheckBox);
+                    node.push_child(MENU_ITEM_CHECKBOX_LABEL_ID);
+                    node
                 }),
                 (MENU_ITEM_CHECKBOX_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(MENU_ITEM_CHECKBOX_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(MENU_ITEM_CHECKBOX_LABEL);
+                    node
                 }),
                 (MENU_ITEM_RADIO_ID, {
-                    let mut builder = NodeBuilder::new(Role::MenuItemRadio);
-                    builder.push_child(MENU_ITEM_RADIO_LABEL_ID);
-                    builder.build()
+                    let mut node = Node::new(Role::MenuItemRadio);
+                    node.push_child(MENU_ITEM_RADIO_LABEL_ID);
+                    node
                 }),
                 (MENU_ITEM_RADIO_LABEL_ID, {
-                    let mut builder = NodeBuilder::new(Role::Label);
-                    builder.set_name(MENU_ITEM_RADIO_LABEL);
-                    builder.build()
+                    let mut node = Node::new(Role::Label);
+                    node.set_name(MENU_ITEM_RADIO_LABEL);
+                    node
                 }),
             ],
             tree: Some(Tree::new(ROOT_ID)),

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -1092,25 +1092,25 @@ mod tests {
 
     // This is based on an actual tree produced by egui.
     fn main_multiline_tree(selection: Option<TextSelection>) -> crate::Tree {
-        use accesskit::{Action, Affine, NodeBuilder, Role, TextDirection, Tree, TreeUpdate};
+        use accesskit::{Action, Affine, Node, Role, TextDirection, Tree, TreeUpdate};
 
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
-                    let mut builder = NodeBuilder::new(Role::Window);
-                    builder.set_transform(Affine::scale(1.5));
-                    builder.set_children(vec![NodeId(1)]);
-                    builder.build()
+                    let mut node = Node::new(Role::Window);
+                    node.set_transform(Affine::scale(1.5));
+                    node.set_children(vec![NodeId(1)]);
+                    node
                 }),
                 (NodeId(1), {
-                    let mut builder = NodeBuilder::new(Role::MultilineTextInput);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::MultilineTextInput);
+                    node.set_bounds(Rect {
                         x0: 8.0,
                         y0: 31.666664123535156,
                         x1: 296.0,
                         y1: 123.66666412353516,
                     });
-                    builder.set_children(vec![
+                    node.set_children(vec![
                         NodeId(2),
                         NodeId(3),
                         NodeId(4),
@@ -1118,15 +1118,15 @@ mod tests {
                         NodeId(6),
                         NodeId(7),
                     ]);
-                    builder.add_action(Action::Focus);
+                    node.add_action(Action::Focus);
                     if let Some(selection) = selection {
-                        builder.set_text_selection(selection);
+                        node.set_text_selection(selection);
                     }
-                    builder.build()
+                    node
                 }),
                 (NodeId(2), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 33.666664123535156,
                         x1: 290.9189147949219,
@@ -1136,99 +1136,98 @@ mod tests {
                     // is in an arbitrary spot; its only purpose
                     // is to test conversion between UTF-8 and UTF-16
                     // indices.
-                    builder.set_value("This paragraph is\u{a0}long enough to wrap ");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder.set_character_lengths([
+                    node.set_value("This paragraph is\u{a0}long enough to wrap ");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([
                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1,
                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                     ]);
-                    builder.set_character_positions([
+                    node.set_character_positions([
                         0.0, 7.3333335, 14.666667, 22.0, 29.333334, 36.666668, 44.0, 51.333332,
                         58.666668, 66.0, 73.333336, 80.666664, 88.0, 95.333336, 102.666664, 110.0,
                         117.333336, 124.666664, 132.0, 139.33333, 146.66667, 154.0, 161.33333,
                         168.66667, 176.0, 183.33333, 190.66667, 198.0, 205.33333, 212.66667, 220.0,
                         227.33333, 234.66667, 242.0, 249.33333, 256.66666, 264.0, 271.33334,
                     ]);
-                    builder.set_character_widths([
+                    node.set_character_widths([
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                     ]);
-                    builder.set_word_lengths([5, 10, 3, 5, 7, 3, 5]);
-                    builder.build()
+                    node.set_word_lengths([5, 10, 3, 5, 7, 3, 5]);
+                    node
                 }),
                 (NodeId(3), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 48.33333206176758,
                         x1: 129.5855712890625,
                         y1: 63.0,
                     });
-                    builder.set_value("to another line.\n");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder
-                        .set_character_lengths([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
-                    builder.set_character_positions([
+                    node.set_value("to another line.\n");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
+                    node.set_character_positions([
                         0.0, 7.3333435, 14.666687, 22.0, 29.333344, 36.666687, 44.0, 51.333344,
                         58.666687, 66.0, 73.33334, 80.66669, 88.0, 95.33334, 102.66669, 110.0,
                         117.58557,
                     ]);
-                    builder.set_character_widths([
+                    node.set_character_widths([
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         0.0,
                     ]);
-                    builder.set_word_lengths([3, 8, 6]);
-                    builder.build()
+                    node.set_word_lengths([3, 8, 6]);
+                    node
                 }),
                 (NodeId(4), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 63.0,
                         x1: 144.25222778320313,
                         y1: 77.66666412353516,
                     });
-                    builder.set_value("Another paragraph.\n");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder.set_character_lengths([
+                    node.set_value("Another paragraph.\n");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([
                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
                     ]);
-                    builder.set_character_positions([
+                    node.set_character_positions([
                         0.0, 7.3333335, 14.666667, 22.0, 29.333334, 36.666668, 44.0, 51.333332,
                         58.666668, 66.0, 73.333336, 80.666664, 88.0, 95.333336, 102.666664, 110.0,
                         117.333336, 124.666664, 132.25223,
                     ]);
-                    builder.set_character_widths([
+                    node.set_character_widths([
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 0.0,
                     ]);
-                    builder.set_word_lengths([8, 11]);
-                    builder.build()
+                    node.set_word_lengths([8, 11]);
+                    node
                 }),
                 (NodeId(5), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 77.66666412353516,
                         x1: 12.0,
                         y1: 92.33332824707031,
                     });
-                    builder.set_value("\n");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder.set_character_lengths([1]);
-                    builder.set_character_positions([0.0]);
-                    builder.set_character_widths([0.0]);
-                    builder.set_word_lengths([1]);
-                    builder.build()
+                    node.set_value("\n");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([1]);
+                    node.set_character_positions([0.0]);
+                    node.set_character_widths([0.0]);
+                    node.set_word_lengths([1]);
+                    node
                 }),
                 (NodeId(6), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 92.33332824707031,
                         x1: 158.9188995361328,
@@ -1238,39 +1237,39 @@ mod tests {
                     // (combining characters), each of which encodes to two
                     // UTF-16 code units, to fully test conversion between
                     // UTF-8, UTF-16, and AccessKit character indices.
-                    builder.set_value("Last non-blank line\u{1f44d}\u{1f3fb}\n");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder.set_character_lengths([
+                    node.set_value("Last non-blank line\u{1f44d}\u{1f3fb}\n");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([
                         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 8, 1,
                     ]);
-                    builder.set_character_positions([
+                    node.set_character_positions([
                         0.0, 7.3333335, 14.666667, 22.0, 29.333334, 36.666668, 44.0, 51.333332,
                         58.666668, 66.0, 73.333336, 80.666664, 88.0, 95.333336, 102.666664, 110.0,
                         117.333336, 124.666664, 132.0, 139.33333, 146.9189,
                     ]);
-                    builder.set_character_widths([
+                    node.set_character_widths([
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557, 7.58557,
                         7.58557, 7.58557, 7.58557, 7.58557, 0.0,
                     ]);
-                    builder.set_word_lengths([5, 4, 6, 6]);
-                    builder.build()
+                    node.set_word_lengths([5, 4, 6, 6]);
+                    node
                 }),
                 (NodeId(7), {
-                    let mut builder = NodeBuilder::new(Role::TextRun);
-                    builder.set_bounds(Rect {
+                    let mut node = Node::new(Role::TextRun);
+                    node.set_bounds(Rect {
                         x0: 12.0,
                         y0: 107.0,
                         x1: 12.0,
                         y1: 121.66666412353516,
                     });
-                    builder.set_value("");
-                    builder.set_text_direction(TextDirection::LeftToRight);
-                    builder.set_character_lengths([]);
-                    builder.set_character_positions([]);
-                    builder.set_character_widths([]);
-                    builder.set_word_lengths([0]);
-                    builder.build()
+                    node.set_value("");
+                    node.set_text_direction(TextDirection::LeftToRight);
+                    node.set_character_lengths([]);
+                    node.set_character_positions([]);
+                    node.set_character_widths([]);
+                    node.set_word_lengths([0]);
+                    node
                 }),
             ],
             tree: Some(Tree::new(NodeId(0))),

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -4,8 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    ActionHandler, ActionRequest, ActivationHandler, NodeBuilder, NodeId, Role, Tree as TreeData,
-    TreeUpdate,
+    ActionHandler, ActionRequest, ActivationHandler, Node as NodeProvider, NodeId, Role,
+    Tree as TreeData, TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Tree};
 use objc2::rc::{Id, WeakId};
@@ -165,7 +165,7 @@ impl Adapter {
                 }
                 None => {
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeBuilder::new(Role::Window).build())],
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeProvider::new(Role::Window))],
                         tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -1,8 +1,8 @@
 // Based on the create_window sample in windows-samples-rs.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Live, Node, NodeBuilder, NodeId, Rect,
-    Role, Tree, TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Live, Node, NodeId, Rect, Role, Tree,
+    TreeUpdate,
 };
 use accesskit_windows::Adapter;
 use once_cell::sync::Lazy;
@@ -68,19 +68,19 @@ fn build_button(id: NodeId, name: &str) -> Node {
         _ => unreachable!(),
     };
 
-    let mut builder = NodeBuilder::new(Role::Button);
-    builder.set_bounds(rect);
-    builder.set_name(name);
-    builder.add_action(Action::Focus);
-    builder.add_action(Action::Click);
-    builder.build()
+    let mut node = Node::new(Role::Button);
+    node.set_bounds(rect);
+    node.set_name(name);
+    node.add_action(Action::Focus);
+    node.add_action(Action::Click);
+    node
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::Label);
-    builder.set_name(text);
-    builder.set_live(Live::Polite);
-    builder.build()
+    let mut node = Node::new(Role::Label);
+    node.set_name(text);
+    node.set_live(Live::Polite);
+    node
 }
 
 struct InnerWindowState {
@@ -90,12 +90,12 @@ struct InnerWindowState {
 
 impl InnerWindowState {
     fn build_root(&mut self) -> Node {
-        let mut builder = NodeBuilder::new(Role::Window);
-        builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
+        let mut node = Node::new(Role::Window);
+        node.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
         if self.announcement.is_some() {
-            builder.push_child(ANNOUNCEMENT_ID);
+            node.push_child(ANNOUNCEMENT_ID);
         }
-        builder.build()
+        node
     }
 }
 

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -4,7 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    ActionHandler, ActivationHandler, Live, NodeBuilder, NodeId, Role, Tree as TreeData, TreeUpdate,
+    ActionHandler, ActivationHandler, Live, Node as NodeProvider, NodeId, Role, Tree as TreeData,
+    TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
 use std::{
@@ -309,7 +310,7 @@ impl Adapter {
                 None => {
                     let hwnd = *hwnd;
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeBuilder::new(Role::Window).build())],
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeProvider::new(Role::Window))],
                         tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -4,8 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeId, Role, Tree,
-    TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, Tree, TreeUpdate,
 };
 use windows::{core::*, Win32::UI::Accessibility::*};
 
@@ -18,18 +17,15 @@ const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
 fn make_button(name: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::Button);
-    builder.set_name(name);
-    builder.add_action(Action::Focus);
-    builder.build()
+    let mut node = Node::new(Role::Button);
+    node.set_name(name);
+    node.add_action(Action::Focus);
+    node
 }
 
 fn get_initial_state() -> TreeUpdate {
-    let root = {
-        let mut builder = NodeBuilder::new(Role::Window);
-        builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
-        builder.build()
-    };
+    let mut root = Node::new(Role::Window);
+    root.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
     let button_1 = make_button("Button 1");
     let button_2 = make_button("Button 2");
     TreeUpdate {

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -4,8 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeBuilder, NodeId, Role, Tree,
-    TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, Tree, TreeUpdate,
 };
 use windows::Win32::{Foundation::*, UI::Accessibility::*};
 use winit::{
@@ -27,19 +26,15 @@ const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
 fn make_button(name: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::Button);
-    builder.set_name(name);
-    builder.add_action(Action::Focus);
-    builder.build()
+    let mut node = Node::new(Role::Button);
+    node.set_name(name);
+    node.add_action(Action::Focus);
+    node
 }
 
 fn get_initial_state() -> TreeUpdate {
-    let root = {
-        let mut builder = NodeBuilder::new(Role::Window);
-        builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
-        builder.set_name(WINDOW_TITLE);
-        builder.build()
-    };
+    let mut root = Node::new(Role::Window);
+    root.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
     let button_1 = make_button("Button 1");
     let button_2 = make_button("Button 2");
     TreeUpdate {

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -1,6 +1,5 @@
 use accesskit::{
-    Action, ActionRequest, ActivationHandler, Live, Node, NodeBuilder, NodeId, Rect, Role, Tree,
-    TreeUpdate,
+    Action, ActionRequest, ActivationHandler, Live, Node, NodeId, Rect, Role, Tree, TreeUpdate,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use std::{
@@ -44,19 +43,19 @@ fn build_button(id: NodeId, name: &str) -> Node {
         _ => unreachable!(),
     };
 
-    let mut builder = NodeBuilder::new(Role::Button);
-    builder.set_bounds(rect);
-    builder.set_name(name);
-    builder.add_action(Action::Focus);
-    builder.add_action(Action::Click);
-    builder.build()
+    let mut node = Node::new(Role::Button);
+    node.set_bounds(rect);
+    node.set_name(name);
+    node.add_action(Action::Focus);
+    node.add_action(Action::Click);
+    node
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::Label);
-    builder.set_name(text);
-    builder.set_live(Live::Polite);
-    builder.build()
+    let mut node = Node::new(Role::Label);
+    node.set_name(text);
+    node.set_live(Live::Polite);
+    node
 }
 
 struct UiState {
@@ -73,13 +72,13 @@ impl UiState {
     }
 
     fn build_root(&mut self) -> Node {
-        let mut builder = NodeBuilder::new(Role::Window);
-        builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
+        let mut node = Node::new(Role::Window);
+        node.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
         if self.announcement.is_some() {
-            builder.push_child(ANNOUNCEMENT_ID);
+            node.push_child(ANNOUNCEMENT_ID);
         }
-        builder.set_name(WINDOW_TITLE);
-        builder.build()
+        node.set_name(WINDOW_TITLE);
+        node
     }
 
     fn build_initial_tree(&mut self) -> TreeUpdate {

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -1,6 +1,4 @@
-use accesskit::{
-    Action, ActionRequest, Live, Node, NodeBuilder, NodeId, Rect, Role, Tree, TreeUpdate,
-};
+use accesskit::{Action, ActionRequest, Live, Node, NodeId, Rect, Role, Tree, TreeUpdate};
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use std::error::Error;
 use winit::{
@@ -40,19 +38,19 @@ fn build_button(id: NodeId, name: &str) -> Node {
         _ => unreachable!(),
     };
 
-    let mut builder = NodeBuilder::new(Role::Button);
-    builder.set_bounds(rect);
-    builder.set_name(name);
-    builder.add_action(Action::Focus);
-    builder.add_action(Action::Click);
-    builder.build()
+    let mut node = Node::new(Role::Button);
+    node.set_bounds(rect);
+    node.set_name(name);
+    node.add_action(Action::Focus);
+    node.add_action(Action::Click);
+    node
 }
 
 fn build_announcement(text: &str) -> Node {
-    let mut builder = NodeBuilder::new(Role::Label);
-    builder.set_name(text);
-    builder.set_live(Live::Polite);
-    builder.build()
+    let mut node = Node::new(Role::Label);
+    node.set_name(text);
+    node.set_live(Live::Polite);
+    node
 }
 
 struct UiState {
@@ -69,13 +67,13 @@ impl UiState {
     }
 
     fn build_root(&mut self) -> Node {
-        let mut builder = NodeBuilder::new(Role::Window);
-        builder.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
+        let mut node = Node::new(Role::Window);
+        node.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
         if self.announcement.is_some() {
-            builder.push_child(ANNOUNCEMENT_ID);
+            node.push_child(ANNOUNCEMENT_ID);
         }
-        builder.set_name(WINDOW_TITLE);
-        builder.build()
+        node.set_name(WINDOW_TITLE);
+        node
     }
 
     fn build_initial_tree(&mut self) -> TreeUpdate {


### PR DESCRIPTION
By doing this, passing the new `Node` (former `NodeBuilder`) in `TreeUpdate`, and having the consumer convert to the slightly smaller `FrozenNode`, we make the API more convenient for all users while not giving up the node size optimization. And it's probably slightly better for binary size to do the conversion to `FrozenNode` in just one place.