### PR TITLE
chore: Mention all adapters in common crate's README

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -5,6 +5,8 @@ This is the shared cross-platform crate for [AccessKit](https://accesskit.dev/).
 To use AccessKit in your application or toolkit, you will also need a platform adapter. The following platform adapters are currently available:
 
 * [accesskit_windows](https://crates.io/crates/accesskit_windows): exposes an AccessKit tree on Windows using the UI Automation API
+* [accesskit_macos](https://crates.io/crates/accesskit_macos): exposes an AccessKit tree on MacOS through the Cocoa `NSAccessibility` protocol
+* [accesskit_unix](https://crates.io/crates/accesskit_unix): exposes an AccessKit tree on Linux and Unix systems through the AT-SPI protocol
 * [accesskit_winit](https://crates.io/crates/accesskit_winit): wraps other platform adapters for use with the [winit](https://crates.io/crates/winit) windowing library
 
-All platform adapters include simple examples.
+Some platform adapters include simple examples.


### PR DESCRIPTION
This was pointed out to me by a game developer who is considering adding AccessKit to their game.