### PR TITLE
fix!: Drop the `is_hovered` property

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -695,7 +695,6 @@ pub struct TextSelection {
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[repr(u8)]
 enum Flag {
-    Hovered,
     Hidden,
     Linked,
     Multiselectable,
@@ -1428,7 +1427,6 @@ impl Node {
 }
 
 flag_methods! {
-    (Hovered, is_hovered, set_hovered, clear_hovered),
     /// Exclude this node and its descendants from the tree presented to
     /// assistive technologies, and from hit testing.
     (Hidden, is_hidden, set_hidden, clear_hidden),


### PR DESCRIPTION
As @DataTriny points out, Chromium does nothing with this property in any of its backends for modern accessibility APIs. There was a state flag for it in MSAA, but we don't implement MSAA. And it's easy enough for an AT to calculate this state itself by looking at the cursor position.