### PR TITLE
fix: Avoid reallocations when processing tree updates

### DIFF
--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -76,7 +76,7 @@ impl State {
 
             orphans.remove(&node_id);
 
-            let mut seen_child_ids = HashSet::new();
+            let mut seen_child_ids = HashSet::with_capacity(node_data.children().len());
             for (child_index, child_id) in node_data.children().iter().enumerate() {
                 if seen_child_ids.contains(child_id) {
                     panic!(


### PR DESCRIPTION
We can avoid a few reallocations when applying tree updates to the tree. We know how many `NodeId`s we will add into `seen_child_ids` ahead of time, so use this information to reserve enough space to hold them.