### PR TITLE
fix: Tell docs.rs to only build accesskit_windows on Windows

### DIFF
--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -11,6 +11,10 @@ readme = "README.md"
 edition.workspace = true
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = []
+
 [dependencies]
 accesskit = { version = "0.17.0", path = "../../common" }
 accesskit_consumer = { version = "0.25.0", path = "../../consumer" }


### PR DESCRIPTION
Currently, [docs.rs fails to build accesskit_windows](https://docs.rs/crate/accesskit_windows/latest).

I tried documenting the crate on Linux and I get the same compilation errors. I think that this crate now only builds on Windows so we need to tell docs.rs about this. We might want to investigate why this breakage happened later, and if we still want this crate to build on non-Windows platforms.

During investigation, I found broken links in our common crate, I'll deal with them in another PR.