### PR TITLE
fix: Optimize use of hash tables in platform adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ version = "0.24.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
+ "hashbrown 0.15.0",
  "once_cell",
  "paste",
  "scopeguard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,10 +55,10 @@ version = "0.18.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
+ "hashbrown 0.15.0",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "once_cell",
 ]
 
 [[package]]

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -17,7 +17,7 @@ default-target = "x86_64-apple-darwin"
 [dependencies]
 accesskit = { version = "0.17.0", path = "../../common" }
 accesskit_consumer = { version = "0.25.0", path = "../../consumer" }
-once_cell = "1.13.0"
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 objc2 = "0.5.1"
 objc2-foundation = { version = "0.2.0", features = [
     "NSArray",

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -5,10 +5,11 @@
 
 use accesskit::{ActionHandler, ActionRequest, NodeId};
 use accesskit_consumer::Tree;
+use hashbrown::HashMap;
 use objc2::rc::{Id, WeakId};
 use objc2_app_kit::*;
 use objc2_foundation::MainThreadMarker;
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use crate::node::PlatformNode;
 

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -5,10 +5,11 @@
 
 use accesskit::{Live, NodeId, Role};
 use accesskit_consumer::{FilterResult, Node, TreeChangeHandler};
+use hashbrown::HashSet;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_app_kit::*;
 use objc2_foundation::{NSMutableDictionary, NSNumber, NSString};
-use std::{collections::HashSet, rc::Rc};
+use std::rc::Rc;
 
 use crate::{context::Context, filters::filter, node::NodeWrapper};
 

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -18,6 +18,7 @@ targets = []
 [dependencies]
 accesskit = { version = "0.17.0", path = "../../common" }
 accesskit_consumer = { version = "0.25.0", path = "../../consumer" }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 paste = "1.0"
 static_assertions = "1.1.0"
 windows-core = "0.58.0"

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -8,10 +8,8 @@ use accesskit::{
     TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
-use std::{
-    collections::HashSet,
-    sync::{atomic::Ordering, Arc},
-};
+use hashbrown::HashSet;
+use std::sync::{atomic::Ordering, Arc};
 use windows::Win32::{
     Foundation::*,
     UI::{Accessibility::*, WindowsAndMessaging::*},


### PR DESCRIPTION
I planned to do this after I changed `accesskit_consumer` to use `hashbrown`. I haven't bothered to do this for `accesskit_atspi_common` or `accesskit_unix`, since interoperability with zbus is a concern for these crates, and the cumulative binary size of the Unix adapter is already quite big.

Also, for the macOS adapter, I decided that using a hash table to keep track of view subclasses was overkill, since the number of items will always be small, and lookup will be rare. So I decided to favor simplicity and minimal code size instead, by using a `Vec` with linear search. The other reason to revisit this was to eliminate the dependency on `once_cell`.