### PR TITLE
fix: Optimize the "short node list" helper used in panic messages

### DIFF
--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{FrozenNode as NodeData, NodeId, Tree as TreeData, TreeUpdate};
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use alloc::{string::String, sync::Arc, vec};
 use core::fmt;
 use hashbrown::{HashMap, HashSet};
 use immutable_chunkmap::map::MapM as ChunkMap;

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -341,12 +341,12 @@ impl<T> fmt::Display for ShortNodeList<'_, T> {
         write!(f, "[")?;
         let mut iter = self.0.iter();
         for i in 0..10 {
-            if i != 0 {
-                write!(f, ", ")?;
-            }
             let Some((id, _)) = iter.next() else {
                 break;
             };
+            if i != 0 {
+                write!(f, ", ")?;
+            }
             write!(f, "#{}", id.0)?;
         }
         if iter.next().is_some() {

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,7 +4,8 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{FrozenNode as NodeData, NodeId, Tree as TreeData, TreeUpdate};
-use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use core::fmt;
 use hashbrown::{HashMap, HashSet};
 use immutable_chunkmap::map::MapM as ChunkMap;
 
@@ -135,10 +136,10 @@ impl State {
         }
 
         if !pending_nodes.is_empty() {
-            panic!("TreeUpdate includes {} nodes which are neither in the current tree nor a child of another node from the update: {}", pending_nodes.len(), short_node_list(pending_nodes.keys()));
+            panic!("TreeUpdate includes {} nodes which are neither in the current tree nor a child of another node from the update: {}", pending_nodes.len(), ShortNodeList(&pending_nodes));
         }
         if !pending_children.is_empty() {
-            panic!("TreeUpdate's nodes include {} children ids which are neither in the current tree nor the id of another node from the update: {}", pending_children.len(), short_node_list(pending_children.keys()));
+            panic!("TreeUpdate's nodes include {} children ids which are neither in the current tree nor the id of another node from the update: {}", pending_children.len(), ShortNodeList(&pending_children));
         }
 
         self.focus = update.focus;
@@ -333,24 +334,25 @@ impl Tree {
     }
 }
 
-fn short_node_list<'a>(nodes: impl ExactSizeIterator<Item = &'a NodeId>) -> String {
-    if nodes.len() > 10 {
-        format!(
-            "[{} ...]",
-            nodes
-                .take(10)
-                .map(|id| format!("#{}", id.0))
-                .collect::<Vec<_>>()
-                .join(", "),
-        )
-    } else {
-        format!(
-            "[{}]",
-            nodes
-                .map(|id| format!("#{}", id.0))
-                .collect::<Vec<_>>()
-                .join(", "),
-        )
+struct ShortNodeList<'a, T>(&'a HashMap<NodeId, T>);
+
+impl<T> fmt::Display for ShortNodeList<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        let mut iter = self.0.iter();
+        for i in 0..10 {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            let Some((id, _)) = iter.next() else {
+                break;
+            };
+            write!(f, "#{}", id.0)?;
+        }
+        if iter.next().is_some() {
+            write!(f, " ...")?;
+        }
+        write!(f, "]")
     }
 }
 


### PR DESCRIPTION
This eliminate intermediate allocations as well as some code duplications between the two branches of the old implementation. And in builds where panic messages aren't printed at all (e.g. using the unstable `build-std` and `panic_immediate_abort` features), the new design allows the code for constructing the truncated node ID list to be completely dropped.

In a normal size-optimized release build on x64 with `panic = "abort"`, this saves 2.5 KB of object code. In a `panic_immediate_abort` build (of the Windows `hello_world` example), this saves 4 KB.