### PR TITLE
fix: Optimize dynamic string building

### DIFF
--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -111,11 +111,12 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         let old_wrapper = NodeWrapper(old_node);
         let new_wrapper = NodeWrapper(new_node);
         new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
-        if new_wrapper.name().is_some()
+        let new_name = new_wrapper.name();
+        if new_name.is_some()
             && new_node.live() != Live::Off
-            && (new_wrapper.name() != old_wrapper.name()
-                || new_node.live() != old_node.live()
-                || filter(old_node) != FilterResult::Include)
+            && (new_node.live() != old_node.live()
+                || filter(old_node) != FilterResult::Include
+                || new_name != old_wrapper.name())
         {
             self.queue.push(QueuedEvent::Simple {
                 element,

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -258,12 +258,15 @@ impl NodeWrapper<'_> {
         self.0.role_description()
     }
 
-    pub(crate) fn name(&self) -> Option<String> {
+    pub(crate) fn name(&self) -> Option<WideString> {
+        let mut result = WideString::default();
         if self.0.label_comes_from_value() {
-            self.0.value()
+            self.0.write_value(&mut result)
         } else {
-            self.0.label()
+            self.0.write_label(&mut result)
         }
+        .unwrap()
+        .then_some(result)
     }
 
     fn description(&self) -> Option<String> {
@@ -339,8 +342,10 @@ impl NodeWrapper<'_> {
         self.0.numeric_value().is_some()
     }
 
-    fn value(&self) -> String {
-        self.0.value().unwrap()
+    fn value(&self) -> WideString {
+        let mut result = WideString::default();
+        self.0.write_value(&mut result).unwrap();
+        result
     }
 
     fn is_read_only(&self) -> bool {

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -483,7 +483,11 @@ impl ITextRangeProvider_Impl for PlatformRange_Impl {
     fn GetText(&self, _max_length: i32) -> Result<BSTR> {
         // The Microsoft docs imply that the provider isn't _required_
         // to truncate text at the max length, so we just ignore it.
-        self.read(|range| Ok(range.text().into()))
+        self.read(|range| {
+            let mut result = WideString::default();
+            range.write_text(&mut result).unwrap();
+            Ok(result.into())
+        })
     }
 
     fn Move(&self, unit: TextUnit, count: i32) -> Result<i32> {


### PR DESCRIPTION
This reduces intermediate allocations, especially when dynamically building a label.

One could imagine taking advantage of this in a self-voicing adapter to write the label, value, or text range directly into the buffer that contains the utterance to be spoken, and that buffer could be reused across utterances.

On Windows, this allows us to construct the dynamic string as UTF-16 in one pass, rather than constructing it as UTF-8 and then re-encoding it to UTF-16 in another pass, adding a temporary allocation.

This change happens to add 512 bytes to the binary size of a `panic_immediate_abort` build of the Windows `hello_world` example on x86-64. It doesn't have any effect on the binary size of that same example built as a normal release build with `panic = "abort"`.