### PR TITLE
refactor!: Drop `Tree::app_name`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2240,8 +2240,6 @@ impl JsonSchema for Properties {
 pub struct Tree {
     /// The identifier of the tree's root node.
     pub root: NodeId,
-    /// The name of the application this tree belongs to.
-    pub app_name: Option<String>,
     /// The name of the UI toolkit in use.
     pub toolkit_name: Option<String>,
     /// The version of the UI toolkit.
@@ -2253,7 +2251,6 @@ impl Tree {
     pub fn new(root: NodeId) -> Tree {
         Tree {
             root,
-            app_name: None,
             toolkit_name: None,
             toolkit_version: None,
         }

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{FrozenNode as NodeData, NodeId, Tree as TreeData, TreeUpdate};
-use alloc::{string::String, sync::Arc, vec};
+use alloc::{sync::Arc, vec};
 use core::fmt;
 use hashbrown::{HashMap, HashSet};
 use immutable_chunkmap::map::MapM as ChunkMap;
@@ -213,12 +213,12 @@ impl State {
         self.focus_id().map(|id| self.node_by_id(id).unwrap())
     }
 
-    pub fn toolkit_name(&self) -> Option<String> {
-        self.data.toolkit_name.clone()
+    pub fn toolkit_name(&self) -> Option<&str> {
+        self.data.toolkit_name.as_deref()
     }
 
-    pub fn toolkit_version(&self) -> Option<String> {
-        self.data.toolkit_version.clone()
+    pub fn toolkit_version(&self) -> Option<&str> {
+        self.data.toolkit_version.as_deref()
     }
 }
 

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -213,10 +213,6 @@ impl State {
         self.focus_id().map(|id| self.node_by_id(id).unwrap())
     }
 
-    pub fn app_name(&self) -> Option<String> {
-        self.data.app_name.clone()
-    }
-
     pub fn toolkit_name(&self) -> Option<String> {
         self.data.toolkit_name.clone()
     }

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -405,8 +405,8 @@ impl Adapter {
             let tree = self.context.read_tree();
             let tree_state = tree.state();
             let mut app_context = self.context.write_app_context();
-            app_context.toolkit_name = tree_state.toolkit_name();
-            app_context.toolkit_version = tree_state.toolkit_version();
+            app_context.toolkit_name = tree_state.toolkit_name().map(|s| s.to_string());
+            app_context.toolkit_version = tree_state.toolkit_version().map(|s| s.to_string());
             let adapter_index = app_context.adapter_index(self.id).unwrap();
             let root = tree_state.root();
             let root_id = root.id();

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -405,7 +405,6 @@ impl Adapter {
             let tree = self.context.read_tree();
             let tree_state = tree.state();
             let mut app_context = self.context.write_app_context();
-            app_context.name = tree_state.app_name();
             app_context.toolkit_name = tree_state.toolkit_name();
             app_context.toolkit_version = tree_state.toolkit_version();
             let adapter_index = app_context.adapter_index(self.id).unwrap();

--- a/platforms/atspi-common/src/context.rs
+++ b/platforms/atspi-common/src/context.rs
@@ -83,9 +83,9 @@ pub struct AppContext {
 }
 
 impl AppContext {
-    pub fn new() -> Arc<RwLock<Self>> {
+    pub fn new(name: Option<String>) -> Arc<RwLock<Self>> {
         Arc::new(RwLock::new(Self {
-            name: None,
+            name,
             toolkit_name: None,
             toolkit_version: None,
             id: None,

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -695,11 +695,11 @@ impl PlatformNode {
     }
 
     pub fn toolkit_name(&self) -> Result<String> {
-        self.with_tree_state(|state| Ok(state.toolkit_name().unwrap_or_default()))
+        self.with_tree_state(|state| Ok(state.toolkit_name().unwrap_or_default().to_string()))
     }
 
     pub fn toolkit_version(&self) -> Result<String> {
-        self.with_tree_state(|state| Ok(state.toolkit_version().unwrap_or_default()))
+        self.with_tree_state(|state| Ok(state.toolkit_version().unwrap_or_default().to_string()))
     }
 
     pub fn parent(&self) -> Result<NodeIdOrRoot> {

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -34,4 +34,3 @@ objc2-app-kit = { version = "0.2.0", features = [
     "NSView",
     "NSWindow",
 ] }
-

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -33,8 +33,15 @@ use crate::{
 static APP_CONTEXT: OnceLock<Arc<RwLock<AppContext>>> = OnceLock::new();
 static MESSAGES: OnceLock<Sender<Message>> = OnceLock::new();
 
+fn app_name() -> Option<String> {
+    std::env::current_exe().ok().and_then(|path| {
+        path.file_name()
+            .map(|name| name.to_string_lossy().to_string())
+    })
+}
+
 pub(crate) fn get_or_init_app_context<'a>() -> &'a Arc<RwLock<AppContext>> {
-    APP_CONTEXT.get_or_init(AppContext::new)
+    APP_CONTEXT.get_or_init(|| AppContext::new(app_name()))
 }
 
 pub(crate) fn get_or_init_messages() -> Sender<Message> {

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -105,8 +105,7 @@ impl ActivationHandler for InnerWindowState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some("hello_world".to_string());
+        let tree = Tree::new(WINDOW_ID);
 
         let mut result = TreeUpdate {
             nodes: vec![

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -645,9 +645,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode_Impl {
                 }
                 match property_id {
                     UIA_FrameworkIdPropertyId => result = state.toolkit_name().into(),
-                    UIA_ProviderDescriptionPropertyId => {
-                        result = app_and_toolkit_description(state).into()
-                    }
+                    UIA_ProviderDescriptionPropertyId => result = toolkit_description(state).into(),
                     _ => (),
                 }
             }

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -216,23 +216,14 @@ pub(crate) fn window_title(hwnd: WindowHandle) -> Option<BSTR> {
     Some(BSTR::from_wide(&buffer).unwrap())
 }
 
-pub(crate) fn app_and_toolkit_description(state: &TreeState) -> Option<String> {
-    let app_name = state.app_name();
+pub(crate) fn toolkit_description(state: &TreeState) -> Option<String> {
     let toolkit_name = state.toolkit_name();
     let toolkit_version = state.toolkit_version();
-    match (&app_name, &toolkit_name, &toolkit_version) {
-        (Some(app_name), Some(toolkit_name), Some(toolkit_version)) => Some(format!(
-            "{} <{} {}>",
-            app_name, toolkit_name, toolkit_version
-        )),
-        (Some(app_name), Some(toolkit_name), None) => {
-            Some(format!("{} <{}>", app_name, toolkit_name))
-        }
-        (None, Some(toolkit_name), Some(toolkit_version)) => {
+    match (&toolkit_name, &toolkit_version) {
+        (Some(toolkit_name), Some(toolkit_version)) => {
             Some(format!("{} {}", toolkit_name, toolkit_version))
         }
         _ if toolkit_name.is_some() => toolkit_name,
-        _ if app_name.is_some() => app_name,
         _ => None,
     }
 }

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -221,7 +221,7 @@ pub(crate) fn toolkit_description(state: &TreeState) -> Option<String> {
         if let Some(version) = state.toolkit_version() {
             format!("{} {}", name, version)
         } else {
-            name
+            name.to_string()
         }
     })
 }

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -217,15 +217,13 @@ pub(crate) fn window_title(hwnd: WindowHandle) -> Option<BSTR> {
 }
 
 pub(crate) fn toolkit_description(state: &TreeState) -> Option<String> {
-    let toolkit_name = state.toolkit_name();
-    let toolkit_version = state.toolkit_version();
-    match (&toolkit_name, &toolkit_version) {
-        (Some(toolkit_name), Some(toolkit_version)) => {
-            Some(format!("{} {}", toolkit_name, toolkit_version))
+    state.toolkit_name().map(|name| {
+        if let Some(version) = state.toolkit_version() {
+            format!("{} {}", name, version)
+        } else {
+            name
         }
-        _ if toolkit_name.is_some() => toolkit_name,
-        _ => None,
-    }
+    })
 }
 
 pub(crate) fn upgrade<T>(weak: &Weak<T>) -> Result<Arc<T>> {

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -85,8 +85,7 @@ impl UiState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some("simple".to_string());
+        let tree = Tree::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -80,8 +80,7 @@ impl UiState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let mut tree = Tree::new(WINDOW_ID);
-        tree.app_name = Some("simple".to_string());
+        let tree = Tree::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),


### PR DESCRIPTION
I now believe this property was a mistake.

On platforms where assistive technologies have conditional behavior based on the app name, they should get the app name from the platform, not the app itself. This way, correct behavior isn't dependent on the app or toolkit exposing the app name, and we don't give the app the opportunity to lie about its name.

Yes, AT-SPI requires the app to provide its own app name. I consider that a flaw in AT-SPI, which we should work around in the Unix adapter, rather than perpetuating it in our new cross-platform API. In Newton (the new free desktop accessibility stack I prototyped earlier this year), I want ATs to get the app name from the compositor, not the app itself, though I didn't implement that yet.

While I was here, I changed the `toolkit_name` and `toolkit_version` accessors in `accesskit_consumer` to return `Option<&str>` rather than cloning the `Option<String>`, since the latter is an unnecessary pessimization.