### PR TITLE
refactor!: Optimize simple string getters

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -326,8 +326,8 @@ impl<'a> Node<'a> {
         self.data().role()
     }
 
-    pub fn role_description(&self) -> Option<String> {
-        self.data().role_description().map(String::from)
+    pub fn role_description(&self) -> Option<&str> {
+        self.data().role_description()
     }
 
     pub fn has_role_description(&self) -> bool {
@@ -524,10 +524,8 @@ impl<'a> Node<'a> {
             .map(|description| description.to_string())
     }
 
-    pub fn placeholder(&self) -> Option<String> {
-        self.data()
-            .placeholder()
-            .map(|placeholder| placeholder.to_string())
+    pub fn placeholder(&self) -> Option<&str> {
+        self.data().placeholder()
     }
 
     pub fn value(&self) -> Option<String> {

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -355,7 +355,7 @@ impl NodeWrapper<'_> {
     fn attributes(&self) -> HashMap<&'static str, String> {
         let mut attributes = HashMap::new();
         if let Some(placeholder) = self.0.placeholder() {
-            attributes.insert("placeholder-text", placeholder);
+            attributes.insert("placeholder-text", placeholder.to_string());
         }
         attributes
     }
@@ -775,7 +775,7 @@ impl PlatformNode {
     }
 
     pub fn localized_role_name(&self) -> Result<String> {
-        self.resolve(|node| Ok(node.role_description().unwrap_or_default()))
+        self.resolve(|node| Ok(node.role_description().unwrap_or_default().to_string()))
     }
 
     pub fn state(&self) -> StateSet {

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -316,7 +316,7 @@ impl NodeWrapper<'_> {
         self.0.description()
     }
 
-    pub(crate) fn placeholder(&self) -> Option<String> {
+    pub(crate) fn placeholder(&self) -> Option<&str> {
         self.0.placeholder()
     }
 
@@ -452,7 +452,7 @@ declare_class!(
         fn role_description(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
                 if let Some(role_description) = node.role_description() {
-                    Some(NSString::from_str(&role_description))
+                    Some(NSString::from_str(role_description))
                 } else {
                     unsafe { msg_send_id![super(self), accessibilityRoleDescription] }
                 }
@@ -490,7 +490,7 @@ declare_class!(
         fn placeholder(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
                 let wrapper = NodeWrapper(node);
-                wrapper.placeholder().map(|placeholder| NSString::from_str(&placeholder))
+                wrapper.placeholder().map(|placeholder| NSString::from_str(placeholder))
             })
             .flatten()
         }

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -490,7 +490,7 @@ declare_class!(
         fn placeholder(&self) -> Option<Id<NSString>> {
             self.resolve(|node| {
                 let wrapper = NodeWrapper(node);
-                wrapper.placeholder().map(|placeholder| NSString::from_str(placeholder))
+                wrapper.placeholder().map(NSString::from_str)
             })
             .flatten()
         }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -254,7 +254,7 @@ impl NodeWrapper<'_> {
         }
     }
 
-    fn localized_control_type(&self) -> Option<String> {
+    fn localized_control_type(&self) -> Option<&str> {
         self.0.role_description()
     }
 
@@ -270,7 +270,7 @@ impl NodeWrapper<'_> {
         self.0.description()
     }
 
-    fn placeholder(&self) -> Option<String> {
+    fn placeholder(&self) -> Option<&str> {
         self.0.placeholder()
     }
 


### PR DESCRIPTION
I can't think of any reason why `role_description` and `placeholder` on `accesskit_consumer::Node` need to return an `Option<String>` rather than an `Option<&str>`. It just wastes an allocation, at least on Windows and macOS.