### PR TITLE
refactor!: Unbox the text selection property

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -753,7 +753,7 @@ enum PropertyValue {
     VerticalOffset(VerticalOffset),
     Affine(Box<Affine>),
     Rect(Rect),
-    TextSelection(Box<TextSelection>),
+    TextSelection(TextSelection),
     CustomActionVec(Vec<CustomAction>),
 }
 
@@ -1466,6 +1466,7 @@ option_ref_type_getters! {
     (get_affine_property, Affine, Affine),
     (get_string_property, str, String),
     (get_coord_slice_property, [f32], CoordSlice),
+    (get_rect_property, Rect, Rect),
     (get_text_selection_property, TextSelection, TextSelection)
 }
 
@@ -1474,7 +1475,6 @@ slice_type_getters! {
 }
 
 copy_type_getters! {
-    (get_rect_property, Rect, Rect),
     (get_node_id_property, NodeId, NodeId),
     (get_f64_property, f64, F64),
     (get_usize_property, usize, Usize),
@@ -1487,12 +1487,12 @@ box_type_setters! {
     (set_affine_property, Affine, Affine),
     (set_string_property, str, String),
     (set_length_slice_property, [u8], LengthSlice),
-    (set_coord_slice_property, [f32], CoordSlice),
-    (set_text_selection_property, TextSelection, TextSelection)
+    (set_coord_slice_property, [f32], CoordSlice)
 }
 
 copy_type_setters! {
     (set_rect_property, Rect, Rect),
+    (set_text_selection_property, TextSelection, TextSelection),
     (set_node_id_property, NodeId, NodeId),
     (set_f64_property, f64, F64),
     (set_usize_property, usize, Usize),
@@ -1782,9 +1782,9 @@ property_methods! {
     /// the tree's container (e.g. window).
     ///
     /// [`transform`]: Node::transform
-    (Bounds, bounds, get_rect_property, Option<Rect>, set_bounds, set_rect_property, Rect, clear_bounds),
+    (Bounds, bounds, get_rect_property, Option<&Rect>, set_bounds, set_rect_property, Rect, clear_bounds),
 
-    (TextSelection, text_selection, get_text_selection_property, Option<&TextSelection>, set_text_selection, set_text_selection_property, impl Into<Box<TextSelection>>, clear_text_selection)
+    (TextSelection, text_selection, get_text_selection_property, Option<&TextSelection>, set_text_selection, set_text_selection_property, TextSelection, clear_text_selection)
 }
 
 impl FrozenNode {

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -257,7 +257,7 @@ impl<'a> Node<'a> {
         parent_transform * self.direct_transform()
     }
 
-    pub fn raw_bounds(&self) -> Option<Rect> {
+    pub fn raw_bounds(&self) -> Option<&Rect> {
         self.data().bounds()
     }
 
@@ -269,13 +269,11 @@ impl<'a> Node<'a> {
     /// container (e.g. window).
     pub fn bounding_box(&self) -> Option<Rect> {
         self.raw_bounds()
-            .as_ref()
             .map(|rect| self.transform().transform_rect_bbox(*rect))
     }
 
     pub(crate) fn bounding_box_in_coordinate_space(&self, other: &Node) -> Option<Rect> {
         self.raw_bounds()
-            .as_ref()
             .map(|rect| self.relative_transform(other).transform_rect_bbox(*rect))
     }
 

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -597,7 +597,7 @@ impl<'a> Range<'a> {
         let mut result = Vec::new();
         self.walk(|node| {
             let mut rect = match node.data().bounds() {
-                Some(rect) => rect,
+                Some(rect) => *rect,
                 None => {
                     return Some(Vec::new());
                 }

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -421,7 +421,7 @@ impl NodeWrapper<'_> {
         String::from(if self.0.is_clickable() { "click" } else { "" })
     }
 
-    fn raw_bounds_and_transform(&self) -> (Option<Rect>, Affine) {
+    fn raw_bounds_and_transform(&self) -> (Option<&Rect>, Affine) {
         let state = self.0;
         (state.raw_bounds(), state.direct_transform())
     }


### PR DESCRIPTION
`TextSelection` used to be much bigger when `NodeId` was 128-bit. But now we can unbox that property without increasing the total size of `PropertyValue`. So this PR does that. Also, I decided that the `rect` accessor should return a reference to the `Rect` struct rather than a copy. This makes the accessors for large structs more consistent.