### PR TITLE
refactor!: Drop `FrozenNode`

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -9,8 +9,8 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    Action, Affine, FrozenNode as NodeData, Live, NodeId, Orientation, Point, Rect, Role,
-    TextSelection, Toggled,
+    Action, Affine, Live, Node as NodeData, NodeId, Orientation, Point, Rect, Role, TextSelection,
+    Toggled,
 };
 use alloc::{
     string::{String, ToString},

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{FrozenNode as NodeData, NodeId, Tree as TreeData, TreeUpdate};
+use accesskit::{Node as NodeData, NodeId, Tree as TreeData, TreeUpdate};
 use alloc::vec;
 use core::fmt;
 use hashbrown::{HashMap, HashSet};
@@ -72,8 +72,6 @@ impl State {
         }
 
         for (node_id, node_data) in update.nodes {
-            let node_data = NodeData::from(node_data);
-
             unreachable.remove(&node_id);
 
             let mut seen_child_ids = HashSet::with_capacity(node_data.children().len());


### PR DESCRIPTION
If we decide to proceed in the direction started by #495, that is, minimizing temporary allocations when updating the tree at the cost of maintaining two copies of the tree state, then this PR is the next logical step. Dropping `FrozenNode` allows us to update nodes in place, including extending the `Vec` of properties, at the cost of 8 extra bytes per retained node (increasing the size from 120 to 128).