### PR TITLE
Add listbox support

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1631,7 +1631,12 @@ usize_property_methods! {
     (RowSpan, row_span, set_row_span, clear_row_span),
     (ColumnSpan, column_span, set_column_span, clear_column_span),
     (Level, level, set_level, clear_level),
+    /// For containers like [`Role::ListBox`], specifies the total number of items.
     (SizeOfSet, size_of_set, set_size_of_set, clear_size_of_set),
+    /// For items like [`Role::ListBoxOption`], specifies their index in the item list.
+    /// This may not exceed the value of [`size_of_set`] as set on the container.
+    ///
+    /// [`size_of_set`]: Node::size_of_set
     (PositionInSet, position_in_set, set_position_in_set, clear_position_in_set)
 }
 

--- a/platforms/atspi-common/src/events.rs
+++ b/platforms/atspi-common/src/events.rs
@@ -40,6 +40,7 @@ pub enum ObjectEvent {
     ChildAdded(usize, NodeId),
     ChildRemoved(NodeId),
     PropertyChanged(Property),
+    SelectionChanged,
     StateChanged(State, bool),
     TextInserted {
         start_index: i32,

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -222,6 +222,71 @@ impl Accessible {
         }
     }
 
+    pub fn supports_selection(&self) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.supports_selection(),
+            Self::Root(_) => Ok(false),
+        }
+    }
+
+    pub fn n_selected_children(&self) -> Result<i32> {
+        match self {
+            Self::Node(node) => node.n_selected_children(),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn selected_child(&self, selected_child_index: usize) -> Result<Option<Self>> {
+        match self {
+            Self::Node(node) => node
+                .selected_child(selected_child_index)
+                .map(|id| id.map(|id| Self::Node(node.relative(id)))),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn select_child(&self, child_index: usize) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.select_child(child_index),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn deselect_selected_child(&self, selected_child_index: usize) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.deselect_selected_child(selected_child_index),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn is_child_selected(&self, child_index: usize) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.is_child_selected(child_index),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn select_all(&self) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.select_all(),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn clear_selection(&self) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.clear_selection(),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
+    pub fn deselect_child(&self, child_index: usize) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.deselect_child(child_index),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
     pub fn supports_text(&self) -> Result<bool> {
         match self {
             Self::Node(node) => node.supports_text(),
@@ -544,6 +609,13 @@ impl Event {
                             Property::Role(value) => EventData::U32(value as u32),
                             Property::Value(value) => EventData::F64(value),
                         }),
+                    },
+                    ObjectEvent::SelectionChanged => Self {
+                        kind: "object:selection-changed".into(),
+                        source,
+                        detail1: 0,
+                        detail2: 0,
+                        data: None,
                     },
                     ObjectEvent::StateChanged(state, value) => Self {
                         kind: format!("object:state-changed:{}", String::from(state)),

--- a/platforms/macos/README.md
+++ b/platforms/macos/README.md
@@ -1,3 +1,7 @@
 # AccessKit macOS adapter
 
 This is the macOS adapter for [AccessKit](https://accesskit.dev/). It exposes an AccessKit accessibility tree through the Cocoa `NSAccessibility` protocol.
+
+## Known issues
+
+- The selected state of ListBox items is not reported ([#520](https://github.com/AccessKit/accesskit/issues/520))

--- a/platforms/unix/src/atspi/interfaces/mod.rs
+++ b/platforms/unix/src/atspi/interfaces/mod.rs
@@ -7,6 +7,7 @@ mod accessible;
 mod action;
 mod application;
 mod component;
+mod selection;
 mod text;
 mod value;
 
@@ -31,5 +32,6 @@ pub(crate) use accessible::*;
 pub(crate) use action::*;
 pub(crate) use application::*;
 pub(crate) use component::*;
+pub(crate) use selection::*;
 pub(crate) use text::*;
 pub(crate) use value::*;

--- a/platforms/unix/src/atspi/interfaces/selection.rs
+++ b/platforms/unix/src/atspi/interfaces/selection.rs
@@ -1,0 +1,82 @@
+// Copyright 2024 The AccessKit Authors. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (found in
+// the LICENSE-APACHE file) or the MIT license (found in
+// the LICENSE-MIT file), at your option.
+
+use accesskit_atspi_common::PlatformNode;
+use zbus::{fdo, interface, names::OwnedUniqueName};
+
+use crate::atspi::{ObjectId, OwnedObjectAddress};
+
+pub(crate) struct SelectionInterface {
+    bus_name: OwnedUniqueName,
+    node: PlatformNode,
+}
+
+impl SelectionInterface {
+    pub fn new(bus_name: OwnedUniqueName, node: PlatformNode) -> Self {
+        Self { bus_name, node }
+    }
+
+    fn map_error(&self) -> impl '_ + FnOnce(accesskit_atspi_common::Error) -> fdo::Error {
+        |error| crate::util::map_error_from_node(&self.node, error)
+    }
+}
+
+#[interface(name = "org.a11y.atspi.Selection")]
+impl SelectionInterface {
+    #[zbus(property)]
+    fn n_selected_children(&self) -> fdo::Result<i32> {
+        self.node.n_selected_children().map_err(self.map_error())
+    }
+
+    fn get_selected_child(&self, selected_child_index: i32) -> fdo::Result<(OwnedObjectAddress,)> {
+        let child = self
+            .node
+            .selected_child(map_child_index(selected_child_index)?)
+            .map_err(self.map_error())?
+            .map(|child| ObjectId::Node {
+                adapter: self.node.adapter_id(),
+                node: child,
+            });
+        Ok(super::optional_object_address(&self.bus_name, child))
+    }
+
+    fn select_child(&self, child_index: i32) -> fdo::Result<bool> {
+        self.node
+            .select_child(map_child_index(child_index)?)
+            .map_err(self.map_error())
+    }
+
+    fn deselect_selected_child(&self, selected_child_index: i32) -> fdo::Result<bool> {
+        self.node
+            .deselect_selected_child(map_child_index(selected_child_index)?)
+            .map_err(self.map_error())
+    }
+
+    fn is_child_selected(&self, child_index: i32) -> fdo::Result<bool> {
+        self.node
+            .is_child_selected(map_child_index(child_index)?)
+            .map_err(self.map_error())
+    }
+
+    fn select_all(&self) -> fdo::Result<bool> {
+        self.node.select_all().map_err(self.map_error())
+    }
+
+    fn clear_selection(&self) -> fdo::Result<bool> {
+        self.node.clear_selection().map_err(self.map_error())
+    }
+
+    fn deselect_child(&self, child_index: i32) -> fdo::Result<bool> {
+        self.node
+            .deselect_child(map_child_index(child_index)?)
+            .map_err(self.map_error())
+    }
+}
+
+fn map_child_index(index: i32) -> fdo::Result<usize> {
+    index
+        .try_into()
+        .map_err(|_| fdo::Error::InvalidArgs("Index can't be negative.".into()))
+}

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -8,7 +8,7 @@ use accesskit::{
     TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
-use hashbrown::HashSet;
+use hashbrown::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::{atomic::Ordering, Arc};
 use windows::Win32::{
@@ -37,6 +37,7 @@ struct AdapterChangeHandler<'a> {
     context: &'a Arc<Context>,
     queue: Vec<QueuedEvent>,
     text_changed: HashSet<NodeId>,
+    selection_changed: HashMap<NodeId, SelectionChanges>,
 }
 
 impl<'a> AdapterChangeHandler<'a> {
@@ -45,6 +46,7 @@ impl<'a> AdapterChangeHandler<'a> {
             context,
             queue: Vec::new(),
             text_changed: HashSet::new(),
+            selection_changed: HashMap::new(),
         }
     }
 }
@@ -81,6 +83,128 @@ impl AdapterChangeHandler<'_> {
             self.insert_text_change_if_needed_parent(node);
         }
     }
+
+    fn handle_selection_state_change(&mut self, node: &Node, is_selected: bool) {
+        // If `node` belongs to a selection container, then map the events with the
+        // selection container as the key because |FinalizeSelectionEvents| needs to
+        // determine whether or not there is only one element selected in order to
+        // optimize what platform events are sent.
+        let key = if let Some(container) = node.selection_container(&filter) {
+            container.id()
+        } else {
+            node.id()
+        };
+
+        let changes = self
+            .selection_changed
+            .entry(key)
+            .or_insert_with(|| SelectionChanges {
+                added_items: HashSet::new(),
+                removed_items: HashSet::new(),
+            });
+        if is_selected {
+            changes.added_items.insert(node.id());
+        } else {
+            changes.removed_items.insert(node.id());
+        }
+    }
+
+    fn enqueue_selection_changes(&mut self, tree: &Tree) {
+        let tree_state = tree.state();
+        for (id, changes) in self.selection_changed.iter() {
+            let Some(node) = tree_state.node_by_id(*id) else {
+                continue;
+            };
+            // Determine if `node` is a selection container with one selected child in
+            // order to optimize what platform events are sent.
+            let mut container = None;
+            let mut only_selected_child = None;
+            if node.is_container_with_selectable_children() {
+                container = Some(node);
+                for child in node.filtered_children(filter) {
+                    if let Some(true) = child.is_selected() {
+                        if only_selected_child.is_none() {
+                            only_selected_child = Some(child);
+                        } else {
+                            only_selected_child = None;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if let Some(only_selected_child) = only_selected_child {
+                self.queue.push(QueuedEvent::Simple {
+                    element: PlatformNode::new(self.context, only_selected_child.id()).into(),
+                    event_id: UIA_SelectionItem_ElementSelectedEventId,
+                });
+                self.queue.push(QueuedEvent::PropertyChanged {
+                    element: PlatformNode::new(self.context, only_selected_child.id()).into(),
+                    property_id: UIA_SelectionItemIsSelectedPropertyId,
+                    old_value: false.into(),
+                    new_value: true.into(),
+                });
+                for child_id in changes.removed_items.iter() {
+                    let platform_node = PlatformNode::new(self.context, *child_id);
+                    self.queue.push(QueuedEvent::PropertyChanged {
+                        element: platform_node.into(),
+                        property_id: UIA_SelectionItemIsSelectedPropertyId,
+                        old_value: true.into(),
+                        new_value: false.into(),
+                    });
+                }
+            } else {
+                // Per UIA documentation, beyond the "invalidate limit" we're supposed to
+                // fire a 'SelectionInvalidated' event.  The exact value isn't specified,
+                // but System.Windows.Automation.Provider uses a value of 20.
+                const INVALIDATE_LIMIT: usize = 20;
+                if let Some(container) = container.filter(|_| {
+                    changes.added_items.len() + changes.removed_items.len() > INVALIDATE_LIMIT
+                }) {
+                    let platform_node = PlatformNode::new(self.context, container.id());
+                    self.queue.push(QueuedEvent::Simple {
+                        element: platform_node.into(),
+                        event_id: UIA_Selection_InvalidatedEventId,
+                    });
+                } else {
+                    let container_is_multiselectable =
+                        container.is_some_and(|c| c.is_multiselectable());
+                    for added_id in changes.added_items.iter() {
+                        self.queue.push(QueuedEvent::Simple {
+                            element: PlatformNode::new(self.context, *added_id).into(),
+                            event_id: match container_is_multiselectable {
+                                true => UIA_SelectionItem_ElementAddedToSelectionEventId,
+                                false => UIA_SelectionItem_ElementSelectedEventId,
+                            },
+                        });
+                        self.queue.push(QueuedEvent::PropertyChanged {
+                            element: PlatformNode::new(self.context, *added_id).into(),
+                            property_id: UIA_SelectionItemIsSelectedPropertyId,
+                            old_value: false.into(),
+                            new_value: true.into(),
+                        });
+                    }
+                    for removed_id in changes.removed_items.iter() {
+                        self.queue.push(QueuedEvent::Simple {
+                            element: PlatformNode::new(self.context, *removed_id).into(),
+                            event_id: UIA_SelectionItem_ElementRemovedFromSelectionEventId,
+                        });
+                        self.queue.push(QueuedEvent::PropertyChanged {
+                            element: PlatformNode::new(self.context, *removed_id).into(),
+                            property_id: UIA_SelectionItemIsSelectedPropertyId,
+                            old_value: true.into(),
+                            new_value: false.into(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SelectionChanges {
+    added_items: HashSet<NodeId>,
+    removed_items: HashSet<NodeId>,
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
@@ -98,13 +222,23 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                 event_id: UIA_LiveRegionChangedEventId,
             });
         }
+        if wrapper.is_selection_item_pattern_supported() && wrapper.is_selected() {
+            self.handle_selection_state_change(node, true);
+        }
     }
 
     fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
+        let old_node_was_filtered_out = filter(old_node) != FilterResult::Include;
         if filter(new_node) != FilterResult::Include {
+            if !old_node_was_filtered_out {
+                let old_wrapper = NodeWrapper(old_node);
+                if old_wrapper.is_selection_item_pattern_supported() && old_wrapper.is_selected() {
+                    self.handle_selection_state_change(old_node, false);
+                }
+            }
             return;
         }
         let platform_node = PlatformNode::new(self.context, new_node.id());
@@ -116,13 +250,19 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         if new_name.is_some()
             && new_node.live() != Live::Off
             && (new_node.live() != old_node.live()
-                || filter(old_node) != FilterResult::Include
+                || old_node_was_filtered_out
                 || new_name != old_wrapper.name())
         {
             self.queue.push(QueuedEvent::Simple {
                 element,
                 event_id: UIA_LiveRegionChangedEventId,
             });
+        }
+        if new_wrapper.is_selection_item_pattern_supported()
+            && (new_wrapper.is_selected() != old_wrapper.is_selected()
+                || (old_node_was_filtered_out && new_wrapper.is_selected()))
+        {
+            self.handle_selection_state_change(new_node, new_wrapper.is_selected());
         }
     }
 
@@ -134,6 +274,13 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
 
     fn node_removed(&mut self, node: &Node) {
         self.insert_text_change_if_needed(node);
+        if filter(node) != FilterResult::Include {
+            return;
+        }
+        let wrapper = NodeWrapper(node);
+        if wrapper.is_selection_item_pattern_supported() {
+            self.handle_selection_state_change(node, false);
+        }
     }
 
     // TODO: handle other events (#20)
@@ -251,6 +398,7 @@ impl Adapter {
                 let mut handler = AdapterChangeHandler::new(context);
                 let mut tree = context.tree.write().unwrap();
                 tree.update_and_process_changes(update_factory(), &mut handler);
+                handler.enqueue_selection_changes(&tree);
                 Some(QueuedEvents(handler.queue))
             }
         }

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -207,6 +207,10 @@ pub(crate) fn element_not_available() -> Error {
     HRESULT(UIA_E_ELEMENTNOTAVAILABLE as _).into()
 }
 
+pub(crate) fn element_not_enabled() -> Error {
+    HRESULT(UIA_E_ELEMENTNOTENABLED as _).into()
+}
+
 pub(crate) fn invalid_operation() -> Error {
     HRESULT(UIA_E_INVALIDOPERATION as _).into()
 }


### PR DESCRIPTION
Fixes #23 

Adds support for list box controls on all supported platforms.

## Known issues

VoiceOver only reports the selected items when the focus leaves the list box and if there is more than one child. I am not sure if this is the expected behavior for such controls. The `accessibilityRows` and `accessibilitySelectedRows` methods seem to never get called, but this might just be because of my very old macOS version.

## Testing

These changes can be tested with [this fork of Slint](https://github.com/DataTriny/slint/tree/listview): `cargo run -p _7guis --bin crud`

The "Names" list view supports keyboard navigation: Up and Down arrows, PageUp, PageDown, Home and End keys, with the Control key modifier to move the focus but not the selection. However, multiple selections are not allowed. I think there are bugs in how the model syncs with the accessibility tree so adding or removing items usually put the application in an inconsistent state.