### PR TITLE
chore: Remove atspi-common from the default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ members = [
 default-members = [
     "common",
     "consumer",
-    "platforms/atspi-common",
     "platforms/winit",
 ]
 


### PR DESCRIPTION
This crate only make sense on *nix platforms (for now at least). By putting it in the list of default workspace members, we tell Cargo to build it on every platforms though. We can save some CI time by doing this since it is slow to build on Windows for instance.