### PR TITLE
fix: Derive `Debug` for adapters

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -26,10 +26,10 @@ use crate::iterators::{
 };
 use crate::tree::State as TreeState;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct NodeState {
     pub(crate) parent_and_index: Option<ParentAndIndex>,
     pub(crate) data: Arc<NodeData>,

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -11,7 +11,7 @@ use immutable_chunkmap::map::MapM as ChunkMap;
 
 use crate::node::{Node, NodeState, ParentAndIndex};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct State {
     pub(crate) nodes: ChunkMap<NodeId, NodeState>,
     pub(crate) data: TreeData,
@@ -229,6 +229,7 @@ pub trait ChangeHandler {
     fn node_removed(&mut self, node: &Node);
 }
 
+#[derive(Debug)]
 pub struct Tree {
     state: State,
 }

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -8,23 +8,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use accesskit::{ActionHandler, NodeId, Role, TreeUpdate};
-use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler, TreeState};
-use atspi_common::{InterfaceSet, Live, State};
-use std::{
-    collections::HashSet,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc, RwLock,
-    },
-};
-
 use crate::{
     context::{ActionHandlerNoMut, ActionHandlerWrapper, AppContext, Context},
     filters::filter,
     node::{NodeIdOrRoot, NodeWrapper, PlatformNode, PlatformRoot},
     util::WindowBounds,
     AdapterCallback, Event, ObjectEvent, WindowEvent,
+};
+use accesskit::{ActionHandler, NodeId, Role, TreeUpdate};
+use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler, TreeState};
+use atspi_common::{InterfaceSet, Live, State};
+use std::fmt::{Debug, Formatter};
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, RwLock,
+    },
 };
 
 struct AdapterChangeHandler<'a> {
@@ -318,6 +318,16 @@ pub struct Adapter {
     id: usize,
     callback: Box<dyn AdapterCallback + Send + Sync>,
     context: Arc<Context>,
+}
+
+impl Debug for Adapter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Adapter")
+            .field("id", &self.id)
+            .field("callback", &"AdapterCallback")
+            .field("context", &self.context)
+            .finish()
+    }
 }
 
 impl Adapter {

--- a/platforms/atspi-common/src/context.rs
+++ b/platforms/atspi-common/src/context.rs
@@ -5,6 +5,7 @@
 
 use accesskit::{ActionHandler, ActionRequest};
 use accesskit_consumer::Tree;
+use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::WindowBounds;
@@ -36,6 +37,17 @@ pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
     pub(crate) action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
     pub(crate) root_window_bounds: RwLock<WindowBounds>,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("app_context", &self.app_context)
+            .field("tree", &self.tree)
+            .field("action_handler", &"ActionHandler")
+            .field("root_window_bounds", &self.root_window_bounds)
+            .finish()
+    }
 }
 
 impl Context {
@@ -74,6 +86,7 @@ impl Context {
     }
 }
 
+#[derive(Debug)]
 pub struct AppContext {
     pub(crate) name: Option<String>,
     pub(crate) toolkit_name: Option<String>,

--- a/platforms/atspi-common/src/util.rs
+++ b/platforms/atspi-common/src/util.rs
@@ -9,7 +9,7 @@ use atspi_common::{CoordType, Granularity};
 
 use crate::Error;
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub struct WindowBounds {
     pub outer: Rect,
     pub inner: Rect,

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -3,15 +3,15 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
+use crate::node::PlatformNode;
 use accesskit::{ActionHandler, ActionRequest, NodeId};
 use accesskit_consumer::Tree;
 use hashbrown::HashMap;
 use objc2::rc::{Id, WeakId};
 use objc2_app_kit::*;
 use objc2_foundation::MainThreadMarker;
+use std::fmt::Debug;
 use std::{cell::RefCell, rc::Rc};
-
-use crate::node::PlatformNode;
 
 pub(crate) trait ActionHandlerNoMut {
     fn do_action(&self, request: ActionRequest);
@@ -37,6 +37,18 @@ pub(crate) struct Context {
     pub(crate) action_handler: Rc<dyn ActionHandlerNoMut>,
     platform_nodes: RefCell<HashMap<NodeId, Id<PlatformNode>>>,
     pub(crate) mtm: MainThreadMarker,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("view", &self.view)
+            .field("tree", &self.tree)
+            .field("action_handler", &"ActionHandler")
+            .field("platform_nodes", &self.platform_nodes)
+            .field("mtm", &self.mtm)
+            .finish()
+    }
 }
 
 impl Context {

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -348,6 +348,7 @@ pub(crate) struct PlatformNodeIvars {
 }
 
 declare_class!(
+    #[derive(Debug)]
     pub(crate) struct PlatformNode;
 
     unsafe impl ClassType for PlatformNode {

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -11,6 +11,7 @@ use accesskit_atspi_common::{
 #[cfg(not(feature = "tokio"))]
 use async_channel::Sender;
 use atspi::InterfaceSet;
+use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "tokio")]
 use tokio::sync::mpsc::UnboundedSender as Sender;
@@ -71,6 +72,35 @@ pub(crate) enum AdapterState {
     Active(AdapterImpl),
 }
 
+impl Debug for AdapterState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdapterState::Inactive {
+                is_window_focused,
+                root_window_bounds,
+                action_handler: _,
+            } => f
+                .debug_struct("Inactive")
+                .field("is_window_focused", is_window_focused)
+                .field("root_window_bounds", root_window_bounds)
+                .field("action_handler", &"ActionHandler")
+                .finish(),
+            AdapterState::Pending {
+                is_window_focused,
+                root_window_bounds,
+                action_handler: _,
+            } => f
+                .debug_struct("Pending")
+                .field("is_window_focused", is_window_focused)
+                .field("root_window_bounds", root_window_bounds)
+                .field("action_handler", &"ActionHandler")
+                .finish(),
+            AdapterState::Active(r#impl) => f.debug_tuple("Active").field(r#impl).finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Adapter {
     messages: Sender<Message>,
     id: usize,

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -9,6 +9,7 @@ use accesskit::{
 };
 use accesskit_consumer::{FilterResult, Node, Tree, TreeChangeHandler};
 use hashbrown::HashSet;
+use std::fmt::{Debug, Formatter};
 use std::sync::{atomic::Ordering, Arc};
 use windows::Win32::{
     Foundation::*,
@@ -150,6 +151,26 @@ enum State {
     Active(Arc<Context>),
 }
 
+impl Debug for State {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::Inactive {
+                hwnd,
+                is_window_focused,
+                action_handler: _,
+            } => f
+                .debug_struct("Inactive")
+                .field("hwnd", hwnd)
+                .field("is_window_focused", is_window_focused)
+                .field("action_handler", &"ActionHandler")
+                .finish(),
+            State::Placeholder(context) => f.debug_tuple("Placeholder").field(context).finish(),
+            State::Active(context) => f.debug_tuple("Active").field(context).finish(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Adapter {
     state: State,
 }

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -5,6 +5,7 @@
 
 use accesskit::{ActionHandler, ActionRequest, Point};
 use accesskit_consumer::Tree;
+use std::fmt::{Debug, Formatter};
 use std::sync::{atomic::AtomicBool, Arc, Mutex, RwLock, RwLockReadGuard};
 
 use crate::{util::*, window_handle::WindowHandle};
@@ -32,6 +33,17 @@ pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
     pub(crate) action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
     pub(crate) is_placeholder: AtomicBool,
+}
+
+impl Debug for Context {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Context")
+            .field("hwnd", &self.hwnd)
+            .field("tree", &self.tree)
+            .field("action_handler", &"ActionHandler")
+            .field("is_placeholder", &self.is_placeholder)
+            .finish()
+    }
 }
 
 impl Context {


### PR DESCRIPTION
Derive the Debug trait for the unix platform adapter.

Side note, I now have [code](https://github.com/drewcrawford/app_window) in the wings that relies on my PRs.  I need to explore alternatives to relying on my patches landing here.