### PR TITLE
refactor!: Add event loop parameter to winit adapter constructors

### DIFF
--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -181,6 +181,7 @@ impl Application {
             state: Arc::clone(&ui),
         };
         let adapter = Adapter::with_mixed_handlers(
+            event_loop,
             &window,
             activation_handler,
             self.event_loop_proxy.clone(),

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -161,7 +161,8 @@ impl Application {
             .with_visible(false);
 
         let window = event_loop.create_window(window_attributes)?;
-        let adapter = Adapter::with_event_loop_proxy(&window, self.event_loop_proxy.clone());
+        let adapter =
+            Adapter::with_event_loop_proxy(event_loop, &window, self.event_loop_proxy.clone());
         window.set_visible(true);
 
         self.window = Some(WindowState::new(window, adapter, UiState::new()));

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -52,7 +52,7 @@ compile_error!(
 use accesskit::{ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, TreeUpdate};
 use winit::{
     event::WindowEvent as WinitWindowEvent,
-    event_loop::EventLoopProxy,
+    event_loop::{ActiveEventLoop, EventLoopProxy},
     window::{Window, WindowId},
 };
 
@@ -143,6 +143,7 @@ impl Adapter {
     /// consider using [`Adapter::with_direct_handlers`] or
     /// [`Adapter::with_mixed_handlers`] instead.
     pub fn with_event_loop_proxy<T: From<Event> + Send + 'static>(
+        event_loop: &ActiveEventLoop,
         window: &Window,
         proxy: EventLoopProxy<T>,
     ) -> Self {
@@ -157,6 +158,7 @@ impl Adapter {
         };
         let deactivation_handler = WinitDeactivationHandler { window_id, proxy };
         Self::with_direct_handlers(
+            event_loop,
             window,
             activation_handler,
             action_handler,
@@ -178,12 +180,14 @@ impl Adapter {
     /// the first update. However, remember that each of these handlers may be
     /// called on any thread, depending on the underlying platform adapter.
     pub fn with_direct_handlers(
+        event_loop: &ActiveEventLoop,
         window: &Window,
         activation_handler: impl 'static + ActivationHandler + Send,
         action_handler: impl 'static + ActionHandler + Send,
         deactivation_handler: impl 'static + DeactivationHandler + Send,
     ) -> Self {
         let inner = platform_impl::Adapter::new(
+            event_loop,
             window,
             activation_handler,
             action_handler,
@@ -205,6 +209,7 @@ impl Adapter {
     /// return the initial tree synchronously. Remember that the thread on which
     /// the activation handler is called is platform-dependent.
     pub fn with_mixed_handlers<T: From<Event> + Send + 'static>(
+        event_loop: &ActiveEventLoop,
         window: &Window,
         activation_handler: impl 'static + ActivationHandler + Send,
         proxy: EventLoopProxy<T>,
@@ -216,6 +221,7 @@ impl Adapter {
         };
         let deactivation_handler = WinitDeactivationHandler { window_id, proxy };
         Self::with_direct_handlers(
+            event_loop,
             window,
             activation_handler,
             action_handler,

--- a/platforms/winit/src/platform_impl/macos.rs
+++ b/platforms/winit/src/platform_impl/macos.rs
@@ -8,7 +8,7 @@ use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, TreeUpdate};
 use accesskit_macos::SubclassingAdapter;
-use winit::{event::WindowEvent, window::Window};
+use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::Window};
 
 pub struct Adapter {
     adapter: SubclassingAdapter,
@@ -16,6 +16,7 @@ pub struct Adapter {
 
 impl Adapter {
     pub fn new(
+        _event_loop: &ActiveEventLoop,
         window: &Window,
         activation_handler: impl 'static + ActivationHandler,
         action_handler: impl 'static + ActionHandler,

--- a/platforms/winit/src/platform_impl/null.rs
+++ b/platforms/winit/src/platform_impl/null.rs
@@ -3,12 +3,13 @@
 // the LICENSE-APACHE file).
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, TreeUpdate};
-use winit::{event::WindowEvent, window::Window};
+use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::Window};
 
 pub struct Adapter;
 
 impl Adapter {
     pub fn new(
+        _event_loop: &ActiveEventLoop,
         _window: &Window,
         _activation_handler: impl 'static + ActivationHandler,
         _action_handler: impl 'static + ActionHandler,

--- a/platforms/winit/src/platform_impl/unix.rs
+++ b/platforms/winit/src/platform_impl/unix.rs
@@ -4,7 +4,7 @@
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, Rect, TreeUpdate};
 use accesskit_unix::Adapter as UnixAdapter;
-use winit::{event::WindowEvent, window::Window};
+use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::Window};
 
 pub struct Adapter {
     adapter: UnixAdapter,
@@ -12,7 +12,8 @@ pub struct Adapter {
 
 impl Adapter {
     pub fn new(
-        _: &Window,
+        _event_loop: &ActiveEventLoop,
+        _window: &Window,
         activation_handler: impl 'static + ActivationHandler + Send,
         action_handler: impl 'static + ActionHandler + Send,
         deactivation_handler: impl 'static + DeactivationHandler + Send,

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -8,7 +8,7 @@ use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, TreeUpdate};
 use accesskit_windows::{SubclassingAdapter, HWND};
-use winit::{event::WindowEvent, window::Window};
+use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::Window};
 
 pub struct Adapter {
     adapter: SubclassingAdapter,
@@ -16,6 +16,7 @@ pub struct Adapter {
 
 impl Adapter {
     pub fn new(
+        _event_loop: &ActiveEventLoop,
         window: &Window,
         activation_handler: impl 'static + ActivationHandler,
         action_handler: impl 'static + ActionHandler + Send,


### PR DESCRIPTION
I did this as part of the work on the Android adapter, but I think we should separate this out into its own PR so it has its own changelog entry and is explicitly pointed out as a breaking change.