### PR TITLE
fix!: Make accesskit_android an optional dependency of accesskit_winit

### DIFF
--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -34,7 +34,7 @@ accesskit_macos = { version = "0.19.0", path = "../macos" }
 accesskit_unix = { version = "0.14.0", path = "../unix", optional = true, default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-accesskit_android = { version = "0.1.0", path = "../android", features = ["embedded-dex"] }
+accesskit_android = { version = "0.1.0", path = "../android", optional = true, features = ["embedded-dex"] }
 
 [dev-dependencies.winit]
 version = "0.30.5"

--- a/platforms/winit/src/platform_impl/mod.rs
+++ b/platforms/winit/src/platform_impl/mod.rs
@@ -27,7 +27,7 @@ mod platform;
 #[path = "unix.rs"]
 mod platform;
 
-#[cfg(target_os = "android")]
+#[cfg(all(feature = "accesskit_android", target_os = "android"))]
 #[path = "android.rs"]
 mod platform;
 
@@ -44,7 +44,7 @@ mod platform;
             target_os = "openbsd"
         )
     ),
-    target_os = "android"
+    all(feature = "accesskit_android", target_os = "android")
 )))]
 #[path = "null.rs"]
 mod platform;


### PR DESCRIPTION
The new adapter is not enabled by default on the winit adapter.