### PR TITLE
fix: Eliminate the dependency on `paste`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "paste",
 ]
 
 [[package]]
@@ -99,7 +98,6 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown",
  "once_cell",
- "paste",
  "scopeguard",
  "static_assertions",
  "windows",
@@ -1357,12 +1355,6 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "paste"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"

--- a/platforms/android/Cargo.toml
+++ b/platforms/android/Cargo.toml
@@ -20,4 +20,3 @@ accesskit_consumer = { version = "0.27.0", path = "../../consumer" }
 jni = "0.21.1"
 log = "0.4.17"
 once_cell = "1.17.1"
-paste = "1.0.12"

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -19,7 +19,6 @@ targets = []
 accesskit = { version = "0.18.0", path = "../../common" }
 accesskit_consumer = { version = "0.27.0", path = "../../consumer" }
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
-paste = "1.0"
 static_assertions = "1.1.0"
 windows-core = "0.58.0"
 


### PR DESCRIPTION
This is an alternative to #527, using manual expansion of identifiers rather than another macro crate.

Fixes #526.