### PR TITLE
fix!: Panic if the window is visible when the adapter is created, for adapters where this is a problem

### DIFF
--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -149,11 +149,19 @@ impl SubclassingAdapter {
     /// This must be called on the thread that owns the window. The activation
     /// handler will always be called on that thread. The action handler
     /// may or may not be called on that thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the window is already visible.
     pub fn new(
         hwnd: HWND,
         activation_handler: impl 'static + ActivationHandler,
         action_handler: impl 'static + ActionHandler + Send,
     ) -> Self {
+        if unsafe { IsWindowVisible(hwnd) }.into() {
+            panic!("The AccessKit Windows subclassing adapter must be created before the window is shown (made visible) for the first time.");
+        }
+
         let mut r#impl = SubclassImpl::new(hwnd, activation_handler, action_handler);
         r#impl.install();
         Self(r#impl)

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -142,6 +142,10 @@ impl Adapter {
     /// until you send the first update. For an optimal implementation,
     /// consider using [`Adapter::with_direct_handlers`] or
     /// [`Adapter::with_mixed_handlers`] instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the window is already visible.
     pub fn with_event_loop_proxy<T: From<Event> + Send + 'static>(
         event_loop: &ActiveEventLoop,
         window: &Window,
@@ -179,6 +183,10 @@ impl Adapter {
     /// some platform adapters to use a placeholder tree until you send
     /// the first update. However, remember that each of these handlers may be
     /// called on any thread, depending on the underlying platform adapter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the window is already visible.
     pub fn with_direct_handlers(
         event_loop: &ActiveEventLoop,
         window: &Window,
@@ -212,6 +220,10 @@ impl Adapter {
     /// while using a direct, caller-provided activation handler that can
     /// return the initial tree synchronously. Remember that the thread on which
     /// the activation handler is called is platform-dependent.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the window is already visible.
     pub fn with_mixed_handlers<T: From<Event> + Send + 'static>(
         event_loop: &ActiveEventLoop,
         window: &Window,

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -186,6 +186,10 @@ impl Adapter {
         action_handler: impl 'static + ActionHandler + Send,
         deactivation_handler: impl 'static + DeactivationHandler + Send,
     ) -> Self {
+        if window.is_visible() == Some(true) {
+            panic!("The AccessKit winit adapter must be created before the window is shown (made visible) for the first time.");
+        }
+
         let inner = platform_impl::Adapter::new(
             event_loop,
             window,


### PR DESCRIPTION
I've concluded that we have to enforce this rule in the most obnoxious way possible.