### PR TITLE
fix: Fix a compilation error in atspi-common `Event::new`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: cargo clippy -p accesskit_atspi_common
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo clippy -p accesskit_atspi_common --all-features -- -D warnings
+
   find-msrv:
     runs-on: ubuntu-latest
     outputs:

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -618,7 +618,7 @@ impl Event {
                         data: None,
                     },
                     ObjectEvent::StateChanged(state, value) => Self {
-                        kind: format!("object:state-changed:{}", String::from(state)),
+                        kind: format!("object:state-changed:{}", state.to_static_str()),
                         source,
                         detail1: value as i32,
                         detail2: 0,


### PR DESCRIPTION
I apparently forgot to compile atspi-common with all features when I did the zbus 5/atspi migration.

Since atspi-common is not a default member of the workspace, and since its simplified-api feature is not enabled by default, this was not caught by the CI. I've added a step in the clippy job to make sure it can compile.