### PR TITLE
chore: Use a PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,3 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
The default GitHub token that is provided to the release-please workflow apparently doesn't permit triggering the CI on pull requests opened by release-please anymore. This might be linked to the permissions now set on the workflow.

Since we weren't using a token for a while now, I've edited the existing `RELEASE_PLEASE_TOKEN` secret. It now contains a personnal access token which belongs to the AccessKit organization and that can only write to this specific repository. This token is valid for a year.