### PR TITLE
perf: Replace `Box<str>` with `Cow<'static, str>`

### DIFF
--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -16,9 +16,17 @@ const WINDOW_ID: NodeId = NodeId(0);
 const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
-fn make_button(label: &str) -> Node {
+fn make_button_with_static_label(label: &'static str) -> Node {
     let mut node = Node::new(Role::Button);
     node.set_label(label);
+    node.add_action(Action::Focus);
+    node
+}
+
+#[allow(unused)]
+fn make_button_with_dynamic_label(label: &str) -> Node {
+    let mut node = Node::new(Role::Button);
+    node.set_label(label.to_owned());
     node.add_action(Action::Focus);
     node
 }
@@ -26,8 +34,8 @@ fn make_button(label: &str) -> Node {
 fn get_initial_state() -> TreeUpdate {
     let mut root = Node::new(Role::Window);
     root.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
-    let button_1 = make_button("Button 1");
-    let button_2 = make_button("Button 2");
+    let button_1 = make_button_with_static_label("Button 1");
+    let button_2 = make_button_with_static_label("Button 2");
     TreeUpdate {
         nodes: vec![
             (WINDOW_ID, root),

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -25,9 +25,17 @@ const WINDOW_ID: NodeId = NodeId(0);
 const BUTTON_1_ID: NodeId = NodeId(1);
 const BUTTON_2_ID: NodeId = NodeId(2);
 
-fn make_button(label: &str) -> Node {
+fn make_button_with_static_label(label: &'static str) -> Node {
     let mut node = Node::new(Role::Button);
     node.set_label(label);
+    node.add_action(Action::Focus);
+    node
+}
+
+#[allow(unused)]
+fn make_button_with_dynamic_label(label: &str) -> Node {
+    let mut node = Node::new(Role::Button);
+    node.set_label(label.to_owned());
     node.add_action(Action::Focus);
     node
 }
@@ -35,8 +43,8 @@ fn make_button(label: &str) -> Node {
 fn get_initial_state() -> TreeUpdate {
     let mut root = Node::new(Role::Window);
     root.set_children(vec![BUTTON_1_ID, BUTTON_2_ID]);
-    let button_1 = make_button("Button 1");
-    let button_2 = make_button("Button 2");
+    let button_1 = make_button_with_static_label("Button 1");
+    let button_2 = make_button_with_static_label("Button 2");
     TreeUpdate {
         nodes: vec![
             (WINDOW_ID, root),

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -36,7 +36,7 @@ const BUTTON_2_RECT: Rect = Rect {
     y1: 100.0,
 };
 
-fn build_button(id: NodeId, label: &str) -> Node {
+fn build_button_with_static_label(id: NodeId, label: &'static str) -> Node {
     let rect = match id {
         BUTTON_1_ID => BUTTON_1_RECT,
         BUTTON_2_ID => BUTTON_2_RECT,
@@ -51,9 +51,25 @@ fn build_button(id: NodeId, label: &str) -> Node {
     node
 }
 
-fn build_announcement(text: &str) -> Node {
+#[allow(unused)]
+fn build_button_with_dynamic_label(id: NodeId, label: &str) -> Node {
+    let rect = match id {
+        BUTTON_1_ID => BUTTON_1_RECT,
+        BUTTON_2_ID => BUTTON_2_RECT,
+        _ => unreachable!(),
+    };
+
+    let mut node = Node::new(Role::Button);
+    node.set_bounds(rect);
+    node.set_label(label.to_owned());
+    node.add_action(Action::Focus);
+    node.add_action(Action::Click);
+    node
+}
+
+fn build_announcement_with_dynamic_label(text: &str) -> Node {
     let mut node = Node::new(Role::Label);
-    node.set_value(text);
+    node.set_value(text.to_owned());
     node.set_live(Live::Polite);
     node
 }
@@ -83,8 +99,8 @@ impl UiState {
 
     fn build_initial_tree(&mut self) -> TreeUpdate {
         let root = self.build_root();
-        let button_1 = build_button(BUTTON_1_ID, "Button 1");
-        let button_2 = build_button(BUTTON_2_ID, "Button 2");
+        let button_1 = build_button_with_static_label(BUTTON_1_ID, "Button 1");
+        let button_2 = build_button_with_static_label(BUTTON_2_ID, "Button 2");
         let tree = Tree::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
@@ -96,9 +112,10 @@ impl UiState {
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {
-            result
-                .nodes
-                .push((ANNOUNCEMENT_ID, build_announcement(announcement)));
+            result.nodes.push((
+                ANNOUNCEMENT_ID,
+                build_announcement_with_dynamic_label(announcement),
+            ));
         }
         result
     }
@@ -120,7 +137,7 @@ impl UiState {
         };
         self.announcement = Some(text.into());
         adapter.update_if_active(|| {
-            let announcement = build_announcement(text);
+            let announcement = build_announcement_with_dynamic_label(text);
             let root = self.build_root();
             TreeUpdate {
                 nodes: vec![(ANNOUNCEMENT_ID, announcement), (WINDOW_ID, root)],

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -31,7 +31,7 @@ const BUTTON_2_RECT: Rect = Rect {
     y1: 100.0,
 };
 
-fn build_button(id: NodeId, label: &str) -> Node {
+fn build_button_with_static_label(id: NodeId, label: &'static str) -> Node {
     let rect = match id {
         BUTTON_1_ID => BUTTON_1_RECT,
         BUTTON_2_ID => BUTTON_2_RECT,
@@ -46,9 +46,25 @@ fn build_button(id: NodeId, label: &str) -> Node {
     node
 }
 
-fn build_announcement(text: &str) -> Node {
+#[allow(unused)]
+fn build_button_with_dynamic_label(id: NodeId, label: &str) -> Node {
+    let rect = match id {
+        BUTTON_1_ID => BUTTON_1_RECT,
+        BUTTON_2_ID => BUTTON_2_RECT,
+        _ => unreachable!(),
+    };
+
+    let mut node = Node::new(Role::Button);
+    node.set_bounds(rect);
+    node.set_label(label.to_owned());
+    node.add_action(Action::Focus);
+    node.add_action(Action::Click);
+    node
+}
+
+fn build_announcement_with_dynamic_label(text: &str) -> Node {
     let mut node = Node::new(Role::Label);
-    node.set_value(text);
+    node.set_value(text.to_owned());
     node.set_live(Live::Polite);
     node
 }
@@ -78,8 +94,8 @@ impl UiState {
 
     fn build_initial_tree(&mut self) -> TreeUpdate {
         let root = self.build_root();
-        let button_1 = build_button(BUTTON_1_ID, "Button 1");
-        let button_2 = build_button(BUTTON_2_ID, "Button 2");
+        let button_1 = build_button_with_static_label(BUTTON_1_ID, "Button 1");
+        let button_2 = build_button_with_static_label(BUTTON_2_ID, "Button 2");
         let tree = Tree::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
@@ -91,9 +107,10 @@ impl UiState {
             focus: self.focus,
         };
         if let Some(announcement) = &self.announcement {
-            result
-                .nodes
-                .push((ANNOUNCEMENT_ID, build_announcement(announcement)));
+            result.nodes.push((
+                ANNOUNCEMENT_ID,
+                build_announcement_with_dynamic_label(announcement),
+            ));
         }
         result
     }
@@ -115,7 +132,7 @@ impl UiState {
         };
         self.announcement = Some(text.into());
         adapter.update_if_active(|| {
-            let announcement = build_announcement(text);
+            let announcement = build_announcement_with_dynamic_label(text);
             let root = self.build_root();
             TreeUpdate {
                 nodes: vec![(ANNOUNCEMENT_ID, announcement), (WINDOW_ID, root)],


### PR DESCRIPTION
Related with https://github.com/AccessKit/accesskit/issues/444.
`Box<str>` conversion requires one more possible reallocation in all variants of `String` except itself, we should use `Cow<'static, str>` to avoid that.
I'm not sure if this is a breaking change.