### PR TITLE
refactor!: Drop unused `Node::is_linked`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -696,7 +696,6 @@ pub struct TextSelection {
 #[repr(u8)]
 enum Flag {
     Hidden,
-    Linked,
     Multiselectable,
     Required,
     Visited,
@@ -1314,7 +1313,6 @@ flag_methods! {
     /// Exclude this node and its descendants from the tree presented to
     /// assistive technologies, and from hit testing.
     (Hidden, is_hidden, set_hidden, clear_hidden),
-    (Linked, is_linked, set_linked, clear_linked),
     (Multiselectable, is_multiselectable, set_multiselectable, clear_multiselectable),
     (Required, is_required, set_required, clear_required),
     (Visited, is_visited, set_visited, clear_visited),

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -145,7 +145,6 @@ mod tests {
         let link_3_1_ignored = {
             let mut node = Node::new(Role::Link);
             node.set_children(vec![LABEL_3_1_0_ID]);
-            node.set_linked();
             node
         };
         let label_3_1_0 = {


### PR DESCRIPTION
This state appears to only map to `STATE_SYSTEM_LINKED` on MSAA where it should be applied to nodes with `Role::Link` and their descendents, [according to the ARIA specification](https://www.w3.org/TR/core-aam-1.2/#role-map-link) and Chromium source code. I think we can safely ignore this property.