### PR TITLE
fix: Improve `NodeId`'s debug representation

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -625,7 +625,7 @@ pub enum TextDecoration {
 pub type NodeIdContent = u64;
 
 /// The stable identity of a [`Node`], unique within the node's tree.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[repr(transparent)]
@@ -642,6 +642,12 @@ impl From<NodeId> for NodeIdContent {
     #[inline]
     fn from(outer: NodeId) -> Self {
         outer.0
+    }
+}
+
+impl fmt::Debug for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#{}", self.0)
     }
 }
 

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -28,10 +28,10 @@ struct InternalChanges {
 impl State {
     fn validate_global(&self) {
         if !self.nodes.contains_key(&self.data.root) {
-            panic!("Root id #{} is not in the node list", self.data.root.0);
+            panic!("Root ID {:?} is not in the node list", self.data.root);
         }
         if !self.nodes.contains_key(&self.focus) {
-            panic!("Focused id #{} is not in the node list", self.focus.0);
+            panic!("Focused ID {:?} is not in the node list", self.focus);
         }
     }
 
@@ -78,8 +78,8 @@ impl State {
             for (child_index, child_id) in node_data.children().iter().enumerate() {
                 if seen_child_ids.contains(child_id) {
                     panic!(
-                        "Node #{} of TreeUpdate includes duplicate child #{};",
-                        node_id.0, child_id.0
+                        "Node {:?} of TreeUpdate includes duplicate child {:?};",
+                        node_id, child_id
                     );
                 }
                 unreachable.remove(child_id);
@@ -139,7 +139,7 @@ impl State {
             panic!("TreeUpdate includes {} nodes which are neither in the current tree nor a child of another node from the update: {}", pending_nodes.len(), ShortNodeList(&pending_nodes));
         }
         if !pending_children.is_empty() {
-            panic!("TreeUpdate's nodes include {} children ids which are neither in the current tree nor the id of another node from the update: {}", pending_children.len(), ShortNodeList(&pending_children));
+            panic!("TreeUpdate's nodes include {} children ids which are neither in the current tree nor the ID of another node from the update: {}", pending_children.len(), ShortNodeList(&pending_children));
         }
 
         self.focus = update.focus;
@@ -361,7 +361,7 @@ impl<T> fmt::Display for ShortNodeList<'_, T> {
             if i != 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "#{}", id.0)?;
+            write!(f, "{:?}", id)?;
         }
         if iter.next().is_some() {
             write!(f, " ...")?;


### PR DESCRIPTION
We already represent node IDs in this way in our panic messages, so let's make this official. It is going to make reading debug representation of tree updates a bit easier.