### PR TITLE
Add support for tabs

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -407,6 +407,8 @@ impl<'a> Node<'a> {
         self.data().orientation().or_else(|| {
             if self.role() == Role::ListBox {
                 Some(Orientation::Vertical)
+            } else if self.role() == Role::TabList {
+                Some(Orientation::Horizontal)
             } else {
                 None
             }
@@ -689,6 +691,16 @@ impl<'a> Node<'a> {
                 | Role::Tree
                 | Role::TreeGrid
         )
+    }
+
+    pub fn controls(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+        let state = self.tree_state;
+        let data = &self.state.data;
+        data.controls()
+            .iter()
+            .map(move |id| state.node_by_id(*id).unwrap())
     }
 
     pub fn raw_text_selection(&self) -> Option<&TextSelection> {

--- a/platforms/atspi-common/src/lib.rs
+++ b/platforms/atspi-common/src/lib.rs
@@ -17,7 +17,7 @@ pub mod simplified;
 mod util;
 
 pub use atspi_common::{
-    CoordType, Granularity, InterfaceSet, Layer, Role, ScrollType, State, StateSet,
+    CoordType, Granularity, InterfaceSet, Layer, RelationType, Role, ScrollType, State, StateSet,
 };
 
 pub use action::*;

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -14,7 +14,9 @@ use crate::{
     WindowEvent,
 };
 
-pub use crate::{CoordType, Error, Granularity, Layer, Rect, Result, Role, ScrollType, StateSet};
+pub use crate::{
+    CoordType, Error, Granularity, Layer, Rect, RelationType, Result, Role, ScrollType, StateSet,
+};
 
 #[derive(Clone, Hash, PartialEq)]
 pub enum Accessible {
@@ -114,6 +116,13 @@ impl Accessible {
         match self {
             Self::Node(node) => node.map_children(|id| f(Self::Node(node.relative(id)))),
             Self::Root(root) => root.map_children(|node| f(Self::Node(node))),
+        }
+    }
+
+    pub fn relation_set(&self) -> Result<HashMap<RelationType, Vec<Self>>> {
+        match self {
+            Self::Node(node) => node.relation_set(|id| Self::Node(node.relative(id))),
+            Self::Root(_) => Ok(HashMap::new()),
         }
     }
 

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -324,6 +324,9 @@ impl NodeWrapper<'_> {
         if let Some(toggled) = self.0.toggled() {
             return Some(Value::Bool(toggled != Toggled::False));
         }
+        if self.0.role() == Role::Tab {
+            return Some(Value::Bool(self.0.is_selected().unwrap_or(false)));
+        }
         if let Some(value) = self.0.value() {
             return Some(Value::String(value));
         }

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -245,7 +245,12 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         let element: IRawElementProviderSimple = platform_node.into();
         let old_wrapper = NodeWrapper(old_node);
         let new_wrapper = NodeWrapper(new_node);
-        new_wrapper.enqueue_property_changes(&mut self.queue, &element, &old_wrapper);
+        new_wrapper.enqueue_property_changes(
+            &mut self.queue,
+            &PlatformNode::new(self.context, new_node.id()),
+            &element,
+            &old_wrapper,
+        );
         let new_name = new_wrapper.name();
         if new_name.is_some()
             && new_node.live() != Live::Off


### PR DESCRIPTION
Closes #28 

The following example program contains a tab bar with two tabs, one tab revealing a button and the other a checkbox.

<details>
<summary>platforms/winit/examples/tabs.rs</summary>

```rust
use accesskit::{
    Action, ActionRequest, Node, NodeId, Orientation, Rect, Role, Toggled, Tree, TreeUpdate,
};
use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
use std::{error::Error, iter};
use winit::{
    application::ApplicationHandler,
    dpi::LogicalSize,
    event::{ElementState, KeyEvent, WindowEvent},
    event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy},
    keyboard::Key,
    window::{Window, WindowId},
};

const WINDOW_TITLE: &str = "Tabs example";

const WINDOW_ID: NodeId = NodeId(0);
const TABLIST_ID: NodeId = NodeId(1);
const BUTTON_ID: NodeId = NodeId(6);
const CHECKBOX_ID: NodeId = NodeId(7);

const TABS: &[(&str, NodeId, NodeId)] = &[
    ("First tab", NodeId(2), NodeId(4)),
    ("Second tab", NodeId(3), NodeId(5)),
];

const WINDOW_WIDTH: f64 = 400.0;
const WINDOW_HEIGHT: f64 = 400.0;
const TABLIST_HEIGHT: f64 = 40.0;
const TAB_WIDTH: f64 = 100.0;
const BUTTON_RECT: Rect = Rect {
    x0: 20.0,
    y0: TABLIST_HEIGHT + 20.0,
    x1: 20.0 + 150.0,
    y1: TABLIST_HEIGHT + 20.0 + 40.0,
};
const CHECKBOX_RECT: Rect = Rect {
    x0: 20.0,
    y0: TABLIST_HEIGHT + 20.0,
    x1: 20.0 + 200.0,
    y1: TABLIST_HEIGHT + 20.0 + 40.0,
};

fn build_tab(index: usize, selected: bool) -> Node {
    let mut node = Node::new(Role::Tab);
    node.set_bounds(Rect {
        x0: TAB_WIDTH * index as f64,
        y0: 0.0,
        x1: TAB_WIDTH * index as f64 + TAB_WIDTH,
        y1: TABLIST_HEIGHT,
    });
    node.set_controls([TABS[index].2]);
    node.set_label(TABS[index].0);
    node.set_position_in_set(index);
    node.set_selected(selected);
    node.add_action(Action::Click);
    node.add_action(Action::Focus);
    node
}

fn build_tablist() -> Node {
    let mut node = Node::new(Role::TabList);
    node.set_bounds(Rect {
        x0: 0.0,
        y0: 0.0,
        x1: WINDOW_WIDTH,
        y1: TABLIST_HEIGHT,
    });
    node.set_children(
        TABS.iter()
            .map(|(_, id, _)| id)
            .copied()
            .collect::<Vec<NodeId>>(),
    );
    node.set_orientation(Orientation::Horizontal);
    node.set_size_of_set(TABS.len());
    node
}

fn build_tabpanel(index: usize, hidden: bool) -> Node {
    let mut node = Node::new(Role::TabPanel);
    node.set_bounds(Rect {
        x0: 0.0,
        y0: TABLIST_HEIGHT,
        x1: WINDOW_WIDTH,
        y1: WINDOW_HEIGHT,
    });
    node.set_children([if index == 0 { BUTTON_ID } else { CHECKBOX_ID }]);
    if hidden {
        node.set_hidden();
    }
    node.set_label(TABS[index].0);
    node
}

fn build_button() -> Node {
    let mut node = Node::new(Role::Button);
    node.set_bounds(BUTTON_RECT);
    node.set_label("Don't click me");
    node.add_action(Action::Focus);
    node
}

fn build_checkbox() -> Node {
    let mut node = Node::new(Role::CheckBox);
    node.set_bounds(CHECKBOX_RECT);
    node.set_label("Don't tick me");
    node.set_toggled(Toggled::False);
    node.add_action(Action::Focus);
    node
}

struct UiState {
    selected_tab_index: usize,
    focused_tab_index: Option<usize>,
    control_key_pressed: bool,
}

impl UiState {
    fn new() -> Self {
        Self {
            selected_tab_index: 0,
            focused_tab_index: None,
            control_key_pressed: false,
        }
    }

    fn build_root(&mut self) -> Node {
        let mut node = Node::new(Role::Window);
        node.set_children(
            iter::once(TABLIST_ID)
                .chain(TABS.iter().map(|(_, _, id)| id).copied())
                .collect::<Vec<NodeId>>(),
        );
        node.set_label(WINDOW_TITLE);
        node
    }

    fn focus(&self) -> NodeId {
        if let Some(index) = self.focused_tab_index {
            TABS[index].1
        } else if self.selected_tab_index == 0 {
            BUTTON_ID
        } else if self.selected_tab_index == 1 {
            CHECKBOX_ID
        } else {
            WINDOW_ID
        }
    }

    fn build_initial_tree(&mut self) -> TreeUpdate {
        let root = self.build_root();
        let tablist = build_tablist();
        let tree = Tree::new(WINDOW_ID);
        let mut update = TreeUpdate {
            nodes: vec![(WINDOW_ID, root), (TABLIST_ID, tablist)],
            tree: Some(tree),
            focus: self.focus(),
        };
        update.nodes.extend(
            TABS.iter().enumerate().map(|(index, (_, id, _))| {
                (*id, build_tab(index, index == self.selected_tab_index))
            }),
        );
        update
            .nodes
            .extend(TABS.iter().enumerate().map(|(index, (_, _, id))| {
                (*id, build_tabpanel(index, index != self.selected_tab_index))
            }));
        update.nodes.push((BUTTON_ID, build_button()));
        update.nodes.push((CHECKBOX_ID, build_checkbox()));
        update
    }

    fn focus_tablist(&mut self, adapter: &mut Adapter) {
        self.focused_tab_index = Some(self.selected_tab_index);
        adapter.update_if_active(|| TreeUpdate {
            nodes: vec![],
            tree: None,
            focus: self.focus(),
        });
    }

    fn focus_tabpanel(&mut self, adapter: &mut Adapter) {
        self.focused_tab_index = None;
        adapter.update_if_active(|| TreeUpdate {
            nodes: vec![],
            tree: None,
            focus: self.focus(),
        });
    }

    fn update_selected_tab(&mut self, adapter: &mut Adapter, index: usize) {
        let previously_selected_index = self.selected_tab_index;
        self.selected_tab_index = index;
        adapter.update_if_active(|| TreeUpdate {
            nodes: vec![
                (
                    TABS[previously_selected_index].1,
                    build_tab(previously_selected_index, false),
                ),
                (TABS[index].1, build_tab(index, true)),
                (
                    TABS[previously_selected_index].2,
                    build_tabpanel(previously_selected_index, true),
                ),
                (TABS[index].2, build_tabpanel(index, false)),
            ],
            tree: None,
            focus: self.focus(),
        });
    }
}

struct WindowState {
    window: Window,
    adapter: Adapter,
    ui: UiState,
}

impl WindowState {
    fn new(window: Window, adapter: Adapter, ui: UiState) -> Self {
        Self {
            window,
            adapter,
            ui,
        }
    }
}

struct Application {
    event_loop_proxy: EventLoopProxy<AccessKitEvent>,
    window: Option<WindowState>,
}

impl Application {
    fn new(event_loop_proxy: EventLoopProxy<AccessKitEvent>) -> Self {
        Self {
            event_loop_proxy,
            window: None,
        }
    }

    fn create_window(&mut self, event_loop: &ActiveEventLoop) -> Result<(), Box<dyn Error>> {
        let window_attributes = Window::default_attributes()
            .with_title(WINDOW_TITLE)
            .with_visible(false)
            .with_inner_size(LogicalSize::new(400, 300));

        let window = event_loop.create_window(window_attributes)?;
        let adapter =
            Adapter::with_event_loop_proxy(event_loop, &window, self.event_loop_proxy.clone());
        window.set_visible(true);

        self.window = Some(WindowState::new(window, adapter, UiState::new()));
        Ok(())
    }
}

impl ApplicationHandler<AccessKitEvent> for Application {
    fn window_event(&mut self, _: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;
        let state = &mut window.ui;

        adapter.process_event(&window.window, &event);
        match event {
            WindowEvent::CloseRequested => {
                self.window = None;
            }
            WindowEvent::ModifiersChanged(modifiers) => {
                state.control_key_pressed = modifiers.state().control_key();
            }
            WindowEvent::KeyboardInput {
                event:
                    KeyEvent {
                        logical_key: virtual_code,
                        state: ElementState::Pressed,
                        ..
                    },
                ..
            } => match virtual_code {
                Key::Named(winit::keyboard::NamedKey::Tab) if state.control_key_pressed => {
                    state.update_selected_tab(adapter, (state.selected_tab_index + 1) % TABS.len());
                }
                Key::Named(winit::keyboard::NamedKey::Tab) => {
                    if state.focused_tab_index.is_some() {
                        state.focus_tabpanel(adapter);
                    } else {
                        state.focus_tablist(adapter);
                    }
                }
                Key::Named(winit::keyboard::NamedKey::ArrowLeft) => {
                    if state.focused_tab_index.is_some() && state.selected_tab_index > 0 {
                        state.focused_tab_index = Some(state.selected_tab_index - 1);
                        state.update_selected_tab(adapter, state.selected_tab_index - 1);
                    }
                }
                Key::Named(winit::keyboard::NamedKey::ArrowRight) => {
                    if state.focused_tab_index.is_some()
                        && state.selected_tab_index < TABS.len() - 1
                    {
                        state.focused_tab_index = Some(state.selected_tab_index + 1);
                        state.update_selected_tab(adapter, state.selected_tab_index + 1);
                    }
                }
                _ => (),
            },
            _ => (),
        }
    }

    fn user_event(&mut self, _: &ActiveEventLoop, user_event: AccessKitEvent) {
        let window = match &mut self.window {
            Some(window) => window,
            None => return,
        };
        let adapter = &mut window.adapter;
        let state = &mut window.ui;

        match user_event.window_event {
            AccessKitWindowEvent::InitialTreeRequested => {
                adapter.update_if_active(|| state.build_initial_tree());
            }
            AccessKitWindowEvent::ActionRequested(ActionRequest { action, target, .. }) => {
                if action == Action::Click {
                    if let Some(index) = TABS.iter().position(|(_, id, _)| *id == target) {
                        state.focused_tab_index = Some(index);
                        state.update_selected_tab(adapter, index);
                    }
                } else if action == Action::Focus {
                    if let Some(index) = TABS.iter().position(|(_, id, _)| *id == target) {
                        state.focused_tab_index = Some(index);
                        state.focus_tablist(adapter);
                    } else if target == BUTTON_ID || target == CHECKBOX_ID {
                        state.focus_tabpanel(adapter);
                    }
                }
            }
            AccessKitWindowEvent::AccessibilityDeactivated => (),
        }
    }

    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
        self.create_window(event_loop)
            .expect("failed to create initial window");
    }

    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
        if self.window.is_none() {
            event_loop.exit();
        }
    }
}

fn main() -> Result<(), Box<dyn Error>> {
    println!("This example has no visible GUI, and a keyboard interface:");
    println!("- [Tab] navigates between a tab bar and a button or a checkbox.");
    println!(
        "- [Left] and [Right] arrow keys switch between two tabs when the tab bar is focused."
    );
    println!("- [Control]+[Tab] switches between two tabs from anywhere.");
    #[cfg(target_os = "windows")]
    println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
    #[cfg(all(
        feature = "accesskit_unix",
        any(
            target_os = "linux",
            target_os = "dragonfly",
            target_os = "freebsd",
            target_os = "netbsd",
            target_os = "openbsd"
        )
    ))]
    println!("Enable Orca with [Super]+[Alt]+[S].");

    let event_loop = EventLoop::with_user_event().build()?;
    let mut state = Application::new(event_loop.create_proxy());
    event_loop.run_app(&mut state).map_err(Into::into)
}
```

</details>