### PR TITLE
refactor!: Drop redundant `HasPopup::True`

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -544,7 +544,6 @@ pub enum Live {
 )]
 #[repr(u8)]
 pub enum HasPopup {
-    True,
     Menu,
     Listbox,
     Tree,


### PR DESCRIPTION
`HasPopup::True` is effectively an alias for `HasPopup::Menu`. Since it is less meaningful and redundant, I propose to drop this variant.