### PR TITLE
fix: Return text content from multiline inputs

### DIFF
--- a/platforms/android/src/node.rs
+++ b/platforms/android/src/node.rs
@@ -67,7 +67,11 @@ impl NodeWrapper<'_> {
     }
 
     pub(crate) fn text(&self) -> Option<String> {
-        self.0.value()
+        self.0.value().or_else(|| {
+            self.0
+                .supports_text_ranges()
+                .then(|| self.0.document_range().text())
+        })
     }
 
     pub(crate) fn text_selection(&self) -> Option<(usize, usize)> {


### PR DESCRIPTION
`accesskit_consumer::Node::value` doesn't traverse a multiline input's descendants because we don't want to have the potential performance problem of traversing a large document every time a single character is typed. But I'm not aware of any other option on Android, so I changed the `text` method on `NodeWrapper` in the Android adapter.