### PR TITLE
fix: Raise events when adding or removing nodes due to filtering on Unix

### DIFF
--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -47,10 +47,6 @@ impl NodeWrapper<'_> {
         self.0.description()
     }
 
-    pub(crate) fn parent_id(&self) -> Option<NodeId> {
-        self.0.parent_id()
-    }
-
     pub(crate) fn id(&self) -> NodeId {
         self.0.id()
     }
@@ -540,17 +536,7 @@ impl NodeWrapper<'_> {
                 )),
             );
         }
-        let parent_id = self.parent_id();
-        if parent_id != old.parent_id() {
-            let parent = self
-                .0
-                .filtered_parent(&filter)
-                .map_or(NodeIdOrRoot::Root, |node| NodeIdOrRoot::Node(node.id()));
-            adapter.emit_object_event(
-                self.id(),
-                ObjectEvent::PropertyChanged(Property::Parent(parent)),
-            );
-        }
+        self.notify_parent_change(adapter, old);
         let role = self.role();
         if role != old.role() {
             adapter.emit_object_event(
@@ -568,6 +554,17 @@ impl NodeWrapper<'_> {
         }
     }
 
+    pub(crate) fn notify_parent_change(&self, adapter: &Adapter, old: &NodeWrapper) {
+        let parent = self.0.filtered_parent(&filter);
+        if parent.map(|p| p.id()) != old.0.filtered_parent(&filter).map(|p| p.id()) {
+            let parent = parent.map_or(NodeIdOrRoot::Root, |node| NodeIdOrRoot::Node(node.id()));
+            adapter.emit_object_event(
+                self.id(),
+                ObjectEvent::PropertyChanged(Property::Parent(parent)),
+            );
+        }
+    }
+
     fn notify_bounds_changes(
         &self,
         window_bounds: &WindowBounds,
@@ -581,7 +578,7 @@ impl NodeWrapper<'_> {
         }
     }
 
-    fn notify_children_changes(&self, adapter: &Adapter, old: &NodeWrapper<'_>) {
+    pub(crate) fn notify_children_changes(&self, adapter: &Adapter, old: &NodeWrapper<'_>) {
         let old_filtered_children = old.filtered_child_ids().collect::<Vec<NodeId>>();
         let new_filtered_children = self.filtered_child_ids().collect::<Vec<NodeId>>();
         for (index, child) in new_filtered_children.iter().enumerate() {

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -189,11 +189,15 @@ impl Bus {
     where
         T: zbus::object_server::Interface,
     {
-        map_or_ignoring_broken_pipe(
+        let result = map_or_ignoring_broken_pipe(
             self.conn.object_server().remove::<T, _>(path).await,
             false,
             |result| result,
-        )
+        );
+        match result {
+            Err(zbus::Error::InterfaceNotFound) => Ok(false),
+            _ => result,
+        }
     }
 
     pub(crate) async fn emit_object_event(


### PR DESCRIPTION
We already create and destroy nodes in the DBus tree, but we also need to send appropriate events or otherwise ATs have no way of figuring out the changes.