### PR TITLE
ci: Use latest image for Windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
     name: cargo clippy
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     needs: find-msrv
     strategy:
       matrix:
-        os: [macOS-latest, windows-2019, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
     name: cargo test
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
         run: cargo test
 
       - name: cargo test -p accesskit_windows
-        if: matrix.os == 'windows-2019'
+        if: matrix.os == 'windows-latest'
         run: cargo test -p accesskit_windows
 
   check-android-dex:


### PR DESCRIPTION
`windows-2019` GitHub runner images [are being deprecated](https://github.com/actions/runner-images/issues/12045) and will stop working by the end of this month. I think these images are stable enough that we can use the latest without worring of it breaking the CI so that we don't have to update this again.