### PR TITLE
refactor!: Refactor actions for scrolling by discrete units

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2603,7 +2603,11 @@ pub struct TreeUpdate {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-#[repr(C)]
+#[cfg_attr(
+    feature = "pyo3",
+    pyclass(module = "accesskit", rename_all = "SCREAMING_SNAKE_CASE", eq)
+)]
+#[repr(u8)]
 pub enum ScrollUnit {
     /// A single item of a list, line of text (for vertical scrolling),
     /// character (for horizontal scrolling), or an approximation of


### PR DESCRIPTION
This drops the `ScrollBackward` and `ScrollForward` actions, leaving only the actions for left, right, up, and down. It also adds a `ScrollUnit` enum for specifying whether to scroll by an item/line or a full page.