### PR TITLE
feat: Consumer support for scrolling and clipping children

### DIFF
--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -273,8 +273,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn clipped_children() {
+    fn clipped_children_test_tree() -> crate::Tree {
         let update = TreeUpdate {
             nodes: vec![
                 (NodeId(0), {
@@ -355,7 +354,12 @@ mod tests {
             tree: Some(Tree::new(NodeId(0))),
             focus: NodeId(0),
         };
-        let tree = crate::Tree::new(update, false);
+        crate::Tree::new(update, false)
+    }
+
+    #[test]
+    fn clipped_children_excluded_above() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::ExcludeSubtree,
             common_filter(&tree.state().node_by_id(NodeId(1)).unwrap())
@@ -364,14 +368,33 @@ mod tests {
             FilterResult::ExcludeSubtree,
             common_filter(&tree.state().node_by_id(NodeId(2)).unwrap())
         );
+    }
+
+    #[test]
+    fn clipped_children_included_above() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::Include,
             common_filter(&tree.state().node_by_id(NodeId(3)).unwrap())
         );
+    }
+
+    #[test]
+    fn clipped_children_hidden() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::ExcludeSubtree,
             common_filter(&tree.state().node_by_id(NodeId(4)).unwrap())
         );
+        assert_eq!(
+            FilterResult::ExcludeSubtree,
+            common_filter(&tree.state().node_by_id(NodeId(8)).unwrap())
+        );
+    }
+
+    #[test]
+    fn clipped_children_visible() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::Include,
             common_filter(&tree.state().node_by_id(NodeId(5)).unwrap())
@@ -384,14 +407,20 @@ mod tests {
             FilterResult::Include,
             common_filter(&tree.state().node_by_id(NodeId(7)).unwrap())
         );
-        assert_eq!(
-            FilterResult::ExcludeSubtree,
-            common_filter(&tree.state().node_by_id(NodeId(8)).unwrap())
-        );
+    }
+
+    #[test]
+    fn clipped_children_included_below() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::Include,
             common_filter(&tree.state().node_by_id(NodeId(9)).unwrap())
         );
+    }
+
+    #[test]
+    fn clipped_children_excluded_below() {
+        let tree = clipped_children_test_tree();
         assert_eq!(
             FilterResult::ExcludeSubtree,
             common_filter(&tree.state().node_by_id(NodeId(10)).unwrap())

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::Role;
+use accesskit::{Rect, Role};
 
 use crate::node::Node;
 
@@ -12,6 +12,29 @@ pub enum FilterResult {
     Include,
     ExcludeNode,
     ExcludeSubtree,
+}
+
+fn filter_for_sibling_clip_check(node: &Node) -> FilterResult {
+    if node.is_focused() {
+        return FilterResult::Include;
+    }
+
+    if node.is_hidden() {
+        return FilterResult::ExcludeSubtree;
+    }
+
+    FilterResult::Include
+}
+
+fn is_first_sibling_in_parent_bbox<'a>(
+    mut siblings: impl Iterator<Item = Node<'a>>,
+    parent_bbox: Rect,
+) -> bool {
+    siblings.next().is_some_and(|sibling| {
+        sibling
+            .bounding_box()
+            .is_some_and(|bbox| !bbox.intersect(parent_bbox).is_empty())
+    })
 }
 
 pub fn common_filter(node: &Node) -> FilterResult {
@@ -23,15 +46,33 @@ pub fn common_filter(node: &Node) -> FilterResult {
         return FilterResult::ExcludeSubtree;
     }
 
+    let role = node.role();
+    if role == Role::GenericContainer || role == Role::TextRun {
+        return FilterResult::ExcludeNode;
+    }
+
     if let Some(parent) = node.parent() {
         if common_filter(&parent) == FilterResult::ExcludeSubtree {
             return FilterResult::ExcludeSubtree;
         }
-    }
 
-    let role = node.role();
-    if role == Role::GenericContainer || role == Role::TextRun {
-        return FilterResult::ExcludeNode;
+        if parent.clips_children() {
+            if let Some(bbox) = node.bounding_box() {
+                if let Some(parent_bbox) = parent.bounding_box() {
+                    if bbox.intersect(parent_bbox).is_empty()
+                        && !(is_first_sibling_in_parent_bbox(
+                            node.following_filtered_siblings(&filter_for_sibling_clip_check),
+                            parent_bbox,
+                        ) || is_first_sibling_in_parent_bbox(
+                            node.preceding_filtered_siblings(&filter_for_sibling_clip_check),
+                            parent_bbox,
+                        ))
+                    {
+                        return FilterResult::ExcludeSubtree;
+                    }
+                }
+            }
+        }
     }
 
     FilterResult::Include

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -378,6 +378,34 @@ impl<'a> Node<'a> {
         self.data().numeric_value_jump()
     }
 
+    pub fn clips_children(&self) -> bool {
+        self.data().clips_children()
+    }
+
+    pub fn scroll_x(&self) -> Option<f64> {
+        self.data().scroll_x()
+    }
+
+    pub fn scroll_x_min(&self) -> Option<f64> {
+        self.data().scroll_x_min()
+    }
+
+    pub fn scroll_x_max(&self) -> Option<f64> {
+        self.data().scroll_x_max()
+    }
+
+    pub fn scroll_y(&self) -> Option<f64> {
+        self.data().scroll_y()
+    }
+
+    pub fn scroll_y_min(&self) -> Option<f64> {
+        self.data().scroll_y_min()
+    }
+
+    pub fn scroll_y_max(&self) -> Option<f64> {
+        self.data().scroll_y_max()
+    }
+
     pub fn is_text_input(&self) -> bool {
         matches!(
             self.role(),


### PR DESCRIPTION
This exposes the scrolling and `clips_children` on the consumer `Node` struct. It also adds a new rule to the common filter to exclude clipped children, except for one clipped child at either end of a list (so that child can be scrolled into view).