### PR TITLE
feat: Scrolling on Android

### DIFF
--- a/platforms/android/src/adapter.rs
+++ b/platforms/android/src/adapter.rs
@@ -10,7 +10,7 @@
 
 use accesskit::{
     Action, ActionData, ActionHandler, ActionRequest, ActivationHandler, Node as NodeData, NodeId,
-    Point, Role, TextSelection, Tree as TreeData, TreeUpdate,
+    Orientation, Point, Role, ScrollUnit, TextSelection, Tree as TreeData, TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Node, TextPosition, Tree, TreeChangeHandler};
 use jni::{
@@ -21,7 +21,7 @@ use jni::{
 
 use crate::{
     action::{PlatformAction, PlatformActionInner},
-    event::{QueuedEvent, QueuedEvents},
+    event::{QueuedEvent, QueuedEvents, ScrollDimension},
     filters::filter,
     node::{add_action, NodeWrapper},
     util::*,
@@ -112,6 +112,34 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
                     });
                 }
             }
+        }
+        let scroll_x =
+            if let (Some(old), Some(new)) = (old_wrapper.scroll_x(), new_wrapper.scroll_x()) {
+                (new != old).then(|| ScrollDimension {
+                    current: new,
+                    delta: new - old,
+                    max: new_wrapper.max_scroll_x(),
+                })
+            } else {
+                None
+            };
+        let scroll_y =
+            if let (Some(old), Some(new)) = (old_wrapper.scroll_y(), new_wrapper.scroll_y()) {
+                (new != old).then(|| ScrollDimension {
+                    current: new,
+                    delta: new - old,
+                    max: new_wrapper.max_scroll_y(),
+                })
+            } else {
+                None
+            };
+        if scroll_x.is_some() || scroll_y.is_some() {
+            let id = self.node_id_map.get_or_create_java_id(new_node);
+            self.events.push(QueuedEvent::Scrolled {
+                virtual_view_id: id,
+                x: scroll_x,
+                y: scroll_y,
+            });
         }
         // TODO: other events
     }
@@ -372,6 +400,41 @@ impl Adapter {
                 action: Action::Focus,
                 target,
                 data: None,
+            },
+            ACTION_SCROLL_BACKWARD | ACTION_SCROLL_FORWARD => ActionRequest {
+                action: {
+                    let node = tree_state.node_by_id(target).unwrap();
+                    if let Some(orientation) = node.orientation() {
+                        match orientation {
+                            Orientation::Horizontal => {
+                                if action == ACTION_SCROLL_BACKWARD {
+                                    Action::ScrollLeft
+                                } else {
+                                    Action::ScrollRight
+                                }
+                            }
+                            Orientation::Vertical => {
+                                if action == ACTION_SCROLL_BACKWARD {
+                                    Action::ScrollUp
+                                } else {
+                                    Action::ScrollDown
+                                }
+                            }
+                        }
+                    } else if action == ACTION_SCROLL_BACKWARD {
+                        if node.supports_action(Action::ScrollUp) {
+                            Action::ScrollUp
+                        } else {
+                            Action::ScrollLeft
+                        }
+                    } else if node.supports_action(Action::ScrollDown) {
+                        Action::ScrollDown
+                    } else {
+                        Action::ScrollRight
+                    }
+                },
+                target,
+                data: Some(ActionData::ScrollUnit(ScrollUnit::Item)),
             },
             ACTION_ACCESSIBILITY_FOCUS => {
                 self.accessibility_focus = Some(virtual_view_id);

--- a/platforms/android/src/util.rs
+++ b/platforms/android/src/util.rs
@@ -14,6 +14,8 @@ pub(crate) const ACTION_ACCESSIBILITY_FOCUS: jint = 1 << 6;
 pub(crate) const ACTION_CLEAR_ACCESSIBILITY_FOCUS: jint = 1 << 7;
 pub(crate) const ACTION_NEXT_AT_MOVEMENT_GRANULARITY: jint = 1 << 8;
 pub(crate) const ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY: jint = 1 << 9;
+pub(crate) const ACTION_SCROLL_FORWARD: jint = 1 << 12;
+pub(crate) const ACTION_SCROLL_BACKWARD: jint = 1 << 13;
 pub(crate) const ACTION_SET_SELECTION: jint = 1 << 17;
 
 pub(crate) const ACTION_ARGUMENT_MOVEMENT_GRANULARITY_INT: &str =
@@ -30,6 +32,7 @@ pub(crate) const EVENT_VIEW_FOCUSED: jint = 1 << 3;
 pub(crate) const EVENT_VIEW_TEXT_CHANGED: jint = 1 << 4;
 pub(crate) const EVENT_VIEW_HOVER_ENTER: jint = 1 << 7;
 pub(crate) const EVENT_VIEW_HOVER_EXIT: jint = 1 << 8;
+pub(crate) const EVENT_VIEW_SCROLLED: jint = 1 << 12;
 pub(crate) const EVENT_VIEW_TEXT_SELECTION_CHANGED: jint = 1 << 13;
 pub(crate) const EVENT_VIEW_ACCESSIBILITY_FOCUSED: jint = 1 << 15;
 pub(crate) const EVENT_VIEW_ACCESSIBILITY_FOCUS_CLEARED: jint = 1 << 16;


### PR DESCRIPTION
Specifically, this implements the actions for scroling backward and forward by one line/item, and sets the right class name for the `ScrollView` role, so TalkBack will request those actions when flicking left and right through a list. This can be tested by building and running the Masonry demo in the [test-virtual-scroll branch of android-view](https://github.com/rust-mobile/android-view/tree/test-virtual-scroll).