### PR TITLE
fix!: Force a semver-breaking release

### DIFF
--- a/platforms/android/Cargo.toml
+++ b/platforms/android/Cargo.toml
@@ -19,3 +19,4 @@ accesskit = { version = "0.19.0", path = "../../common" }
 accesskit_consumer = { version = "0.28.0", path = "../../consumer" }
 jni = "0.21.1"
 log = "0.4.17"
+

--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -21,4 +21,3 @@ atspi-common = { version = "0.9", default-features = false }
 serde = "1.0"
 thiserror = "1.0"
 zvariant = { version = "5.4", default-features = false }
-

--- a/platforms/macos/Cargo.toml
+++ b/platforms/macos/Cargo.toml
@@ -34,4 +34,3 @@ objc2-app-kit = { version = "0.2.0", features = [
     "NSView",
     "NSWindow",
 ] }
-

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,4 +36,3 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
-

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -40,4 +40,3 @@ features = [
 once_cell = "1.13.0"
 scopeguard = "1.1.0"
 winit = "0.30"
-

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -40,4 +40,3 @@ accesskit_android = { version = "0.2.0", path = "../android", optional = true, f
 version = "0.30.5"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-


### PR DESCRIPTION
I forgot to do this workaround when making a semver-breaking change to the `accesskit` crate.