### PR TITLE
feat: Let parents declare actions supported on their children

### DIFF
--- a/platforms/android/src/adapter.rs
+++ b/platforms/android/src/adapter.rs
@@ -387,7 +387,10 @@ impl Adapter {
             ACTION_CLICK => ActionRequest {
                 action: {
                     let node = tree_state.node_by_id(target).unwrap();
-                    if node.is_focusable() && !node.is_focused() && !node.is_clickable() {
+                    if node.is_focusable(&filter)
+                        && !node.is_focused()
+                        && !node.is_clickable(&filter)
+                    {
                         Action::Focus
                     } else {
                         Action::Click
@@ -422,12 +425,13 @@ impl Adapter {
                             }
                         }
                     } else if action == ACTION_SCROLL_BACKWARD {
-                        if node.supports_action(Action::ScrollUp) {
+                        if node.supports_action(Action::ScrollUp, &filter) {
                             Action::ScrollUp
                         } else {
                             Action::ScrollLeft
                         }
-                    } else if node.supports_action(Action::ScrollDown) {
+                    } else if node.supports_action(Action::ScrollDown, &filter)
+                    {
                         Action::ScrollDown
                     } else {
                         Action::ScrollRight
@@ -492,7 +496,7 @@ impl Adapter {
         // TalkBack expects the text selection change to take effect
         // immediately, so we optimistically update the node.
         // But don't be *too* optimistic.
-        if !node.supports_action(Action::SetTextSelection) {
+        if !node.supports_action(Action::SetTextSelection, &filter) {
             return None;
         }
         let (anchor, focus, extra) = selection_factory(&node)?;

--- a/platforms/android/src/node.rs
+++ b/platforms/android/src/node.rs
@@ -12,7 +12,10 @@ use accesskit::{Action, Live, Role, Toggled};
 use accesskit_consumer::Node;
 use jni::{objects::JObject, sys::jint, JNIEnv};
 
-use crate::{filters::filter, util::*};
+use crate::{
+    filters::filter,
+    util::*,
+};
 
 pub(crate) fn add_action(env: &mut JNIEnv, node_info: &JObject, action: jint) {
     // Note: We're using the deprecated addAction signature.
@@ -36,7 +39,7 @@ impl NodeWrapper<'_> {
     }
 
     fn is_focusable(&self) -> bool {
-        self.0.is_focusable() && self.0.role() != Role::ScrollView
+        self.0.is_focusable(&filter) && self.0.role() != Role::ScrollView
     }
 
     fn is_focused(&self) -> bool {
@@ -60,10 +63,17 @@ impl NodeWrapper<'_> {
     }
 
     fn is_scrollable(&self) -> bool {
-        self.0.supports_action(Action::ScrollDown)
-            || self.0.supports_action(Action::ScrollLeft)
-            || self.0.supports_action(Action::ScrollRight)
-            || self.0.supports_action(Action::ScrollUp)
+        self.0
+            .supports_action(Action::ScrollDown, &filter)
+            || self
+                .0
+                .supports_action(Action::ScrollLeft, &filter)
+            || self
+                .0
+                .supports_action(Action::ScrollRight, &filter)
+            || self
+                .0
+                .supports_action(Action::ScrollUp, &filter)
     }
 
     fn is_selected(&self) -> bool {
@@ -331,7 +341,7 @@ impl NodeWrapper<'_> {
         .unwrap();
 
         let can_focus = self.is_focusable() && !self.0.is_focused();
-        if self.0.is_clickable() || can_focus {
+        if self.0.is_clickable(&filter) || can_focus {
             add_action(env, node_info, ACTION_CLICK);
         }
         if can_focus {
@@ -353,10 +363,21 @@ impl NodeWrapper<'_> {
             )
             .unwrap();
         }
-        if self.0.supports_action(Action::ScrollLeft) || self.0.supports_action(Action::ScrollUp) {
+        if self
+            .0
+            .supports_action(Action::ScrollLeft, &filter)
+            || self
+                .0
+                .supports_action(Action::ScrollUp, &filter)
+        {
             add_action(env, node_info, ACTION_SCROLL_BACKWARD);
         }
-        if self.0.supports_action(Action::ScrollRight) || self.0.supports_action(Action::ScrollDown)
+        if self
+            .0
+            .supports_action(Action::ScrollRight, &filter)
+            || self
+                .0
+                .supports_action(Action::ScrollDown, &filter)
         {
             add_action(env, node_info, ACTION_SCROLL_FORWARD);
         }

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -291,7 +291,7 @@ impl NodeWrapper<'_> {
             atspi_state.insert(State::Editable);
         }
         // TODO: Focus and selection.
-        if state.is_focusable() {
+        if state.is_focusable(&filter) {
             atspi_state.insert(State::Focusable);
         }
         let filter_result = filter(self.0);
@@ -392,7 +392,7 @@ impl NodeWrapper<'_> {
     }
 
     fn supports_action(&self) -> bool {
-        self.0.is_clickable()
+        self.0.is_clickable(&filter)
     }
 
     fn supports_component(&self) -> bool {
@@ -441,7 +441,7 @@ impl NodeWrapper<'_> {
     }
 
     fn n_actions(&self) -> i32 {
-        if self.0.is_clickable() {
+        if self.0.is_clickable(&filter) {
             1
         } else {
             0
@@ -452,7 +452,11 @@ impl NodeWrapper<'_> {
         if index != 0 {
             return String::new();
         }
-        String::from(if self.0.is_clickable() { "click" } else { "" })
+        String::from(if self.0.is_clickable(&filter) {
+            "click"
+        } else {
+            ""
+        })
     }
 
     fn raw_bounds_and_transform(&self) -> (Option<Rect>, Affine) {
@@ -1061,7 +1065,7 @@ impl PlatformNode {
             if let Some(child) = node.filtered_children(filter).nth(child_index) {
                 if let Some(true) = child.is_selected() {
                     Ok(true)
-                } else if child.is_selectable() && child.is_clickable() {
+                } else if child.is_selectable() && child.is_clickable(&filter) {
                     context.do_action(ActionRequest {
                         action: Action::Click,
                         target: child.id(),
@@ -1084,7 +1088,7 @@ impl PlatformNode {
                 .filter(|c| c.is_selected() == Some(true))
                 .nth(selected_child_index)
             {
-                if child.is_clickable() {
+                if child.is_clickable(&filter) {
                     context.do_action(ActionRequest {
                         action: Action::Click,
                         target: child.id(),
@@ -1124,7 +1128,7 @@ impl PlatformNode {
             if let Some(child) = node.filtered_children(filter).nth(child_index) {
                 if let Some(false) = child.is_selected() {
                     Ok(true)
-                } else if child.is_selectable() && child.is_clickable() {
+                } else if child.is_selectable() && child.is_clickable(&filter) {
                     context.do_action(ActionRequest {
                         action: Action::Click,
                         target: child.id(),

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -600,7 +600,7 @@ declare_class!(
         fn set_focused(&self, focused: bool) {
             self.resolve_with_context(|node, context| {
                 if focused {
-                    if node.is_focusable() {
+                    if node.is_focusable(&filter) {
                         context.do_action(ActionRequest {
                             action: Action::Focus,
                             target: node.id(),
@@ -609,7 +609,7 @@ declare_class!(
                     }
                 } else {
                     let root = node.tree_state.root();
-                    if root.is_focusable() {
+                    if root.is_focusable(&filter) {
                         context.do_action(ActionRequest {
                             action: Action::Focus,
                             target: root.id(),
@@ -623,7 +623,7 @@ declare_class!(
         #[method(accessibilityPerformPress)]
         fn press(&self) -> bool {
             self.resolve_with_context(|node, context| {
-                let clickable = node.is_clickable();
+                let clickable = node.is_clickable(&filter);
                 if clickable {
                     context.do_action(ActionRequest {
                         action: Action::Click,
@@ -639,7 +639,7 @@ declare_class!(
         #[method(accessibilityPerformIncrement)]
         fn increment(&self) -> bool {
             self.resolve_with_context(|node, context| {
-                let supports_increment = node.supports_increment();
+                let supports_increment = node.supports_increment(&filter);
                 if supports_increment {
                     context.do_action(ActionRequest {
                         action: Action::Increment,
@@ -655,7 +655,7 @@ declare_class!(
         #[method(accessibilityPerformDecrement)]
         fn decrement(&self) -> bool {
             self.resolve_with_context(|node, context| {
-                let supports_decrement = node.supports_decrement();
+                let supports_decrement = node.supports_decrement(&filter);
                 if supports_decrement {
                     context.do_action(ActionRequest {
                         action: Action::Decrement,
@@ -859,7 +859,7 @@ declare_class!(
         fn set_selected(&self, selected: bool) {
             self.resolve_with_context(|node, context| {
                 let wrapper = NodeWrapper(node);
-                if !node.is_clickable()
+                if !node.is_clickable(&filter)
                     || !wrapper.is_item_like()
                     || !node.is_selectable()
                 {
@@ -913,7 +913,7 @@ declare_class!(
         fn pick(&self) -> bool {
             self.resolve_with_context(|node, context| {
                 let wrapper = NodeWrapper(node);
-                let selectable = node.is_clickable()
+                let selectable = node.is_clickable(&filter)
                     && wrapper.is_item_like()
                     && node.is_selectable();
                 if selectable {
@@ -965,16 +965,16 @@ declare_class!(
         fn is_selector_allowed(&self, selector: Sel) -> bool {
             self.resolve(|node| {
                 if selector == sel!(setAccessibilityFocused:) {
-                    return node.is_focusable();
+                    return node.is_focusable(&filter);
                 }
                 if selector == sel!(accessibilityPerformPress) {
-                    return node.is_clickable();
+                    return node.is_clickable(&filter);
                 }
                 if selector == sel!(accessibilityPerformIncrement) {
-                    return node.supports_increment();
+                    return node.supports_increment(&filter);
                 }
                 if selector == sel!(accessibilityPerformDecrement) {
-                    return node.supports_decrement();
+                    return node.supports_decrement(&filter);
                 }
                 if selector == sel!(accessibilityNumberOfCharacters)
                     || selector == sel!(accessibilitySelectedText)
@@ -1011,7 +1011,7 @@ declare_class!(
                     || selector == sel!(accessibilityPerformPick)
                 {
                     let wrapper = NodeWrapper(node);
-                    return node.is_clickable()
+                    return node.is_clickable(&filter)
                         && wrapper.is_item_like()
                         && node.is_selectable();
                 }

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,3 +36,4 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
+

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -289,7 +289,7 @@ impl NodeWrapper<'_> {
     }
 
     fn is_focusable(&self) -> bool {
-        self.0.is_focusable()
+        self.0.is_focusable(&filter)
     }
 
     fn is_focused(&self) -> bool {
@@ -334,7 +334,7 @@ impl NodeWrapper<'_> {
     }
 
     fn is_invoke_pattern_supported(&self) -> bool {
-        self.0.is_invocable()
+        self.0.is_invocable(&filter)
     }
 
     fn is_value_pattern_supported(&self) -> bool {

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -40,3 +40,4 @@ accesskit_android = { version = "0.3.0", path = "../android", optional = true, f
 version = "0.30.5"
 default-features = false
 features = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+


### PR DESCRIPTION
The initial use case for this is the implementation of `ScrollIntoView` in Masonry, on the [virtual-scroll-a11y branch](https://github.com/linebender/masonry/tree/virtual-scroll-a11y). When given a choice between adding complexity in AccessKit and adding complexity in UI frameworks, I favor the former. In this case, the latter would mean that the Masonry core framework would have to add some way for the `VirtualScroll` widget to indicate that the `ScrollIntoView` action should be added on all of its children, even though the children can be of any widget type.

The reason for specifying that this applies to direct children in the _filtered_ tree is that I want to leave open the possibility that a scroll widget could have an intermediate `GenericContainer` child (that gets filtered out) for the purpose of specifying the current scroll translation in just one place.