### PR TITLE
feat!: Implement refactored `ScrollIntoView` action across desktop platforms

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -313,9 +313,8 @@ pub enum Action {
     /// Scroll up by the specified unit.
     ScrollUp,
 
-    /// Scroll any scrollable containers to make the target object visible
-    /// on the screen.  Optionally set [`ActionRequest::data`] to
-    /// [`ActionData::ScrollTargetRect`].
+    /// Scroll any scrollable containers to make the target node visible.
+    /// Optionally set [`ActionRequest::data`] to [`ActionData::ScrollHint`].
     ScrollIntoView,
 
     /// Scroll the given object to a specified point in the tree's container
@@ -2658,6 +2657,26 @@ pub enum ScrollUnit {
     Page,
 }
 
+/// A suggestion about where the node being scrolled into view should be
+/// positioned relative to the edges of the scrollable container.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(JsonSchema))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(
+    feature = "pyo3",
+    pyclass(module = "accesskit", rename_all = "SCREAMING_SNAKE_CASE", eq)
+)]
+#[repr(u8)]
+pub enum ScrollHint {
+    TopLeft,
+    BottomRight,
+    TopEdge,
+    BottomEdge,
+    LeftEdge,
+    RightEdge,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
@@ -2668,9 +2687,10 @@ pub enum ActionData {
     Value(Box<str>),
     NumericValue(f64),
     ScrollUnit(ScrollUnit),
-    /// Optional target rectangle for [`Action::ScrollIntoView`], in
-    /// the coordinate space of the action's target node.
-    ScrollTargetRect(Rect),
+    /// Optional suggestion for [`ActionData::ScrollIntoView`], specifying
+    /// the preferred position of the target node relative to the scrollable
+    /// container's viewport.
+    ScrollHint(ScrollHint),
     /// Target for [`Action::ScrollToPoint`], in platform-native coordinates
     /// relative to the origin of the tree's container (e.g. window).
     ScrollToPoint(Point),

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -224,6 +224,13 @@ impl Accessible {
         }
     }
 
+    pub fn scroll_to(&self, scroll_type: ScrollType) -> Result<bool> {
+        match self {
+            Self::Node(node) => node.scroll_to(scroll_type),
+            Self::Root(_) => Err(Error::UnsupportedInterface),
+        }
+    }
+
     pub fn scroll_to_point(&self, coord_type: CoordType, x: i32, y: i32) -> Result<bool> {
         match self {
             Self::Node(node) => node.scroll_to_point(coord_type, x, y),

--- a/platforms/atspi-common/src/util.rs
+++ b/platforms/atspi-common/src/util.rs
@@ -3,9 +3,9 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{Point, Rect};
+use accesskit::{Point, Rect, ScrollHint};
 use accesskit_consumer::{Node, TextPosition, TextRange};
-use atspi_common::{CoordType, Granularity};
+use atspi_common::{CoordType, Granularity, ScrollType};
 
 use crate::Error;
 
@@ -119,4 +119,16 @@ pub(crate) fn text_range_bounds_from_offsets(
         .bounding_boxes()
         .into_iter()
         .reduce(|rect1, rect2| rect1.union(rect2))
+}
+
+pub(crate) fn atspi_scroll_type_to_scroll_hint(scroll_type: ScrollType) -> Option<ScrollHint> {
+    match scroll_type {
+        ScrollType::TopLeft => Some(ScrollHint::TopLeft),
+        ScrollType::BottomRight => Some(ScrollHint::BottomRight),
+        ScrollType::TopEdge => Some(ScrollHint::TopEdge),
+        ScrollType::BottomEdge => Some(ScrollHint::BottomEdge),
+        ScrollType::LeftEdge => Some(ScrollHint::LeftEdge),
+        ScrollType::RightEdge => Some(ScrollHint::RightEdge),
+        ScrollType::Anywhere => None,
+    }
 }

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -963,7 +963,7 @@ declare_class!(
             .flatten()
         }
 
-        // We discovered through epxerimentation that when mixing the newer
+        // We discovered through experimentation that when mixing the newer
         // NSAccessibility protocols with the older informal protocol,
         // the platform uses both protocols to discover which actions are
         // available and then perform actions. That means our implementation

--- a/platforms/unix/src/atspi/interfaces/component.rs
+++ b/platforms/unix/src/atspi/interfaces/component.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit_atspi_common::{PlatformNode, Rect};
-use atspi::{CoordType, Layer};
+use atspi::{CoordType, Layer, ScrollType};
 use zbus::{fdo, interface, names::OwnedUniqueName};
 
 use crate::atspi::{ObjectId, OwnedObjectAddress};
@@ -62,6 +62,10 @@ impl ComponentInterface {
 
     fn grab_focus(&self) -> fdo::Result<bool> {
         self.node.grab_focus().map_err(self.map_error())
+    }
+
+    fn scroll_to(&self, scroll_type: ScrollType) -> fdo::Result<bool> {
+        self.node.scroll_to(scroll_type).map_err(self.map_error())
     }
 
     fn scroll_to_point(&self, coord_type: CoordType, x: i32, y: i32) -> fdo::Result<bool> {

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -5,7 +5,7 @@
 
 #![allow(non_upper_case_globals)]
 
-use accesskit::{Action, ActionData, ActionRequest};
+use accesskit::{Action, ActionData, ActionRequest, ScrollHint};
 use accesskit_consumer::{
     Node, TextPosition as Position, TextRange as Range, TreeState, WeakTextRange as WeakRange,
 };
@@ -582,9 +582,13 @@ impl ITextRangeProvider_Impl for PlatformRange_Impl {
                 range.end()
             };
             ActionRequest {
-                action: Action::ScrollIntoView,
                 target: position.inner_node().id(),
-                data: None,
+                action: Action::ScrollIntoView,
+                data: Some(ActionData::ScrollHint(if align_to_top.into() {
+                    ScrollHint::TopEdge
+                } else {
+                    ScrollHint::BottomEdge
+                })),
             }
         })
     }


### PR DESCRIPTION
The old `ScrollTarget` action data wasn't a good fit for what any platform actually supported. So I replaced it with a new `ScrollHint` which is a copy of Chromium's `ScrollType` enum, which in turn is a copy of AT-SPI's `ScrollType`.

The Windows implementation is known to work with Narrator, and the macOS implementation is known to work with VoiceOver. I don't know if there's any way to get Orca to call the `ScrollTo` method outside of web content. I know that NVDA doesn't call `ScrollIntoView` outside of web content. All of this can be tested using my [virtual-scroll-a11y branch of xilem](https://github.com/linebender/xilem/tree/virtual-scroll-a11y). That's actually still using the scrolling-wip branch of AccessKit, but it's the same code. I'll delete that branch after this PR is merged and the Xilem branch is rebased.