### PR TITLE
fix: Panic if the subclassing adapter is double-instantiated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown",
  "once_cell",
+ "parking_lot",
  "scopeguard",
  "static_assertions",
  "windows",
@@ -945,7 +946,7 @@ checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -959,6 +960,16 @@ name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1347,6 +1358,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.13",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -2588,7 +2631,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit",

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -146,6 +146,13 @@ impl SubclassingAdapter {
         action_handler: impl 'static + ActionHandler,
     ) -> Self {
         let view = Id::as_ptr(&retained_view) as *mut NSView;
+        if !unsafe {
+            objc_getAssociatedObject(view as *const NSView as *const _, associated_object_key())
+        }
+        .is_null()
+        {
+            panic!("subclassing adapter already instantiated on view {view:?}");
+        }
         let adapter = unsafe { Adapter::new(view as *mut c_void, false, action_handler) };
         // Cast to a pointer and back to force the lifetime to 'static
         // SAFETY: We know the class will live as long as the instance,

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -38,5 +38,6 @@ features = [
 
 [dev-dependencies]
 once_cell = "1.13.0"
+parking_lot = "0.12.4"
 scopeguard = "1.1.0"
 winit = "0.30"

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -93,6 +93,12 @@ impl SubclassImpl {
     }
 
     fn install(&mut self) {
+        if !unsafe { GetPropW(self.hwnd, PROP_NAME) }.0.is_null() {
+            panic!(
+                "subclassing adapter already instantiated on window {:?}",
+                self.hwnd.0
+            );
+        }
         unsafe {
             SetPropW(
                 self.hwnd,

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -180,7 +180,9 @@ impl Scope {
 }
 
 // It's not safe to run these UI-related tests concurrently.
-pub(crate) static MUTEX: Mutex<()> = Mutex::new(());
+// We need a non-poisoning mutex here because the subclassing adapter's
+// double-instantiation test intentionally panics.
+pub(crate) static MUTEX: parking_lot::Mutex<()> = parking_lot::const_mutex(());
 
 pub(crate) fn scope<F>(
     window_title: &str,
@@ -191,7 +193,7 @@ pub(crate) fn scope<F>(
 where
     F: FnOnce(&Scope) -> Result<()>,
 {
-    let _lock_guard = MUTEX.lock().unwrap();
+    let _lock_guard = MUTEX.lock();
 
     let window_mutex: Mutex<Option<WindowHandle>> = Mutex::new(None);
     let window_cv = Condvar::new();


### PR DESCRIPTION
This is in response to #595.