### PR TITLE
fix: Only expose the `placeholder` property on empty text inputs

### DIFF
--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -868,7 +868,7 @@ fn character_index_at_point(node: &Node, point: Point) -> usize {
 }
 
 impl<'a> Node<'a> {
-    fn text_runs(
+    pub(crate) fn text_runs(
         &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
         let id = self.id();


### PR DESCRIPTION
It is currently necessary to set the `placeholder` property only if the text input it applies to is empty. This is what I did in Slint at the time but this is not how it was implemented in egui, resulting in some screen readers such as NVDA to report the placeholder and the value at the same time.

Following our philosophy of putting as much complexity into the adapters as possible, it is probably best to check for this invariant ourselves. This also aligns with ARIA.