### PR TITLE
implement setting values on macOS

### DIFF
--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -548,9 +548,14 @@ declare_class!(
         }
 
         #[method(setAccessibilityValue:)]
-        fn set_value(&self, _value: &NSObject) {
-            // This isn't yet implemented. See the comment on this selector
-            // in `is_selector_allowed`.
+        fn set_value(&self, value: &NSString) {
+            self.resolve_with_context(|node, context| {
+                context.do_action(ActionRequest {
+                    action: Action::SetValue,
+                    target: node.id(),
+                    data: Some(ActionData::Value(value.to_string().into())),
+                });
+            });
         }
 
         #[method_id(accessibilityMinValue)]
@@ -1024,11 +1029,7 @@ declare_class!(
                     return node.supports_text_ranges();
                 }
                 if selector == sel!(setAccessibilityValue:) {
-                    // Our implementation of this currently does nothing,
-                    // and it's not clear if VoiceOver ever actually uses it,
-                    // but it must be allowed for editable text in order to get
-                    // the expected VoiceOver behavior.
-                    return node.supports_text_ranges() && !node.is_read_only();
+                    return node.supports_action(Action::SetValue, &filter) && !node.is_read_only();
                 }
                 if selector == sel!(isAccessibilitySelected) {
                     let wrapper = NodeWrapper(node);


### PR DESCRIPTION
this wasn't previously implemented apparently because VoiceOver doesn't support it directly. however, there are other tools (like the Accessibility Inspector) that are able to set values so i think it's useful for at least building UI automations.

tested manually and confirmed to work!

fixes #612 