### PR TITLE
fix: Impl `Clone` and `PartialEq` on `WindowEvent`

### DIFF
--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -71,7 +71,7 @@ pub struct Event {
     pub window_event: WindowEvent,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum WindowEvent {
     InitialTreeRequested,
     ActionRequested(ActionRequest),


### PR DESCRIPTION
Closes #610 