### PR TITLE
feat!: Support properties on text ranges

### DIFF
--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -20,7 +20,7 @@ pub(crate) mod iterators;
 
 pub(crate) mod text;
 pub use text::{
-    AttributeValue as TextAttributeValue, Position as TextPosition, Range as TextRange,
+    Position as TextPosition, Range as TextRange, RangePropertyValue as TextRangePropertyValue,
     WeakRange as WeakTextRange,
 };
 


### PR DESCRIPTION
I had done a little work on this 3 years ago when I first implemented text ranges, but it was just a generic function in the consumer crate that was never actually tested or used. I decided to change that function, make it internal, and use the term "property" rather than "attribute", for consistency. So that's why this is a breaking change (on the consumer crate only).