### PR TITLE
fix: Activate when an assistive technology is actually running on Unix

### DIFF
--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -151,7 +151,7 @@ async fn run_event_loop(
     );
 
     let status = StatusProxy::new(&session_bus).await?;
-    let changes = status.receive_is_enabled_changed().await.fuse();
+    let changes = status.receive_screen_reader_enabled_changed().await.fuse();
     pin!(changes);
 
     #[cfg(not(feature = "tokio"))]


### PR DESCRIPTION
We were previously initializing the Unix adapter when the accessibility was enabled on the system. It turns out that many distributions seem to start AT-SPI by default, thus we get initialized on many systems where no assistive technology is running.

The `ScreenReaderEnabled` D-Bus property has to be explicitly set by an assistive technology when it starts. As such, it is a far better indication for us that we should send a tree. A faulty AT could forget to set this property and get no tree from AccessKit at all, but I think it is easier to fix a handful of ATs on Unix rather than dealing with annoyed users who would have to pay an unnecessary performance hit for something they don't use.