### PR TITLE
feat: Implement the UIA `Culture` property

### DIFF
--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -26,6 +26,7 @@ windows-core = "0.61.0"
 version = "0.61.1"
 features = [
     "Win32_Foundation",
+    "Win32_Globalization",
     "Win32_Graphics_Gdi",
     "Win32_System_Com",
     "Win32_System_LibraryLoader",

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -95,6 +95,7 @@ impl InnerWindowState {
         if self.announcement.is_some() {
             node.push_child(ANNOUNCEMENT_ID);
         }
+        node.set_language("en");
         node
     }
 }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -276,6 +276,10 @@ impl NodeWrapper<'_> {
         self.0.description()
     }
 
+    fn culture(&self) -> Option<LocaleName<'_>> {
+        self.0.language().map(LocaleName)
+    }
+
     fn placeholder(&self) -> Option<&str> {
         self.0.placeholder()
     }
@@ -962,6 +966,7 @@ properties! {
     (UIA_LocalizedControlTypePropertyId, localized_control_type),
     (UIA_NamePropertyId, name),
     (UIA_FullDescriptionPropertyId, description),
+    (UIA_CulturePropertyId, culture),
     (UIA_HelpTextPropertyId, placeholder),
     (UIA_IsContentElementPropertyId, is_content_element),
     (UIA_IsControlElementPropertyId, is_content_element),

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -14,6 +14,7 @@ use windows::{
     core::*,
     Win32::{
         Foundation::*,
+        Globalization::*,
         Graphics::Gdi::*,
         System::{Com::*, Ole::*, Variant::*},
         UI::{Accessibility::*, WindowsAndMessaging::*},
@@ -40,6 +41,16 @@ impl Write for WideString {
 impl From<WideString> for BSTR {
     fn from(value: WideString) -> Self {
         Self::from_wide(&value.0)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LocaleName<'a>(pub(crate) &'a str);
+
+impl From<LocaleName<'_>> for Variant {
+    fn from(value: LocaleName) -> Self {
+        let lcid = unsafe { LocaleNameToLCID(&HSTRING::from(value.0), LOCALE_ALLOW_NEUTRAL_NAMES) };
+        (lcid != 0).then_some(lcid as i32).into()
     }
 }
 


### PR DESCRIPTION
The `LocaleName` newtype lets us lazily convert a language tag to a Win32 `LCID` only when actually returning a `VARIANT`, not when merely comparing property values for the sake of raising events.