### PR TITLE
feat: Add `map` function to `TextRangePropertyValue<Option<T>>`

### DIFF
--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -501,6 +501,18 @@ pub enum RangePropertyValue<T: alloc::fmt::Debug + PartialEq> {
     Mixed,
 }
 
+impl<T: alloc::fmt::Debug + PartialEq> RangePropertyValue<Option<T>> {
+    pub fn map<U: alloc::fmt::Debug + PartialEq>(
+        self,
+        f: impl FnOnce(T) -> U,
+    ) -> RangePropertyValue<Option<U>> {
+        match self {
+            Self::Single(value) => RangePropertyValue::Single(value.map(f)),
+            Self::Mixed => RangePropertyValue::Mixed,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Range<'a> {
     pub(crate) node: Node<'a>,
@@ -2286,5 +2298,22 @@ mod tests {
         let state = tree.state();
         let node = state.node_by_id(NodeId(1)).unwrap();
         let _ = node.text_selection().unwrap();
+    }
+
+    #[test]
+    fn range_property_value_map() {
+        use super::RangePropertyValue;
+        assert_eq!(
+            RangePropertyValue::Single(Some(0)).map(|x| x + 1),
+            RangePropertyValue::Single(Some(1))
+        );
+        assert_eq!(
+            RangePropertyValue::<Option<usize>>::Single(None).map(|x| x + 1),
+            RangePropertyValue::Single(None)
+        );
+        assert_eq!(
+            RangePropertyValue::<Option<usize>>::Mixed.map(|x| x + 1),
+            RangePropertyValue::Mixed
+        );
     }
 }


### PR DESCRIPTION
I'll want this for the UIA `Culture` text attribute, and probably others.