### PR TITLE
feat: Add GridCell role

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -141,6 +141,7 @@ pub enum Role {
     Footer,
     Form,
     Grid,
+    GridCell,
     Group,
     Header,
     Heading,

--- a/platforms/android/Cargo.toml
+++ b/platforms/android/Cargo.toml
@@ -19,3 +19,4 @@ accesskit = { version = "0.21.1", path = "../../common" }
 accesskit_consumer = { version = "0.31.0", path = "../../consumer" }
 jni = "0.21.1"
 log = "0.4.17"
+

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -87,7 +87,7 @@ impl NodeWrapper<'_> {
             Role::DefaultButton => AtspiRole::Button,
             Role::Canvas => AtspiRole::Canvas,
             Role::Caption => AtspiRole::Caption,
-            Role::Cell => AtspiRole::TableCell,
+            Role::Cell | Role::GridCell => AtspiRole::TableCell,
             Role::CheckBox => AtspiRole::CheckBox,
             Role::Switch => AtspiRole::ToggleButton,
             Role::ColorWell => AtspiRole::Button,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -39,7 +39,7 @@ fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
         match role {
             Role::Unknown => NSAccessibilityUnknownRole,
             Role::TextRun => NSAccessibilityUnknownRole,
-            Role::Cell => NSAccessibilityCellRole,
+            Role::Cell | Role::GridCell => NSAccessibilityCellRole,
             Role::Label => NSAccessibilityStaticTextRole,
             Role::Image => NSAccessibilityImageRole,
             Role::Link => NSAccessibilityLinkRole,

--- a/platforms/unix/Cargo.toml
+++ b/platforms/unix/Cargo.toml
@@ -36,3 +36,4 @@ tokio-stream = { version = "0.1.14", optional = true }
 version = "1.32.0"
 optional = true
 features = ["macros", "net", "rt", "sync", "time"]
+

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -53,7 +53,7 @@ impl NodeWrapper<'_> {
         match role {
             Role::Unknown => UIA_CustomControlTypeId,
             Role::TextRun => UIA_CustomControlTypeId,
-            Role::Cell => UIA_DataItemControlTypeId,
+            Role::Cell | Role::GridCell => UIA_DataItemControlTypeId,
             Role::Label => UIA_TextControlTypeId,
             Role::Image => UIA_ImageControlTypeId,
             Role::Link => UIA_HyperlinkControlTypeId,
@@ -436,6 +436,7 @@ impl NodeWrapper<'_> {
             | Role::MenuListOption
             | Role::Tab
             | Role::TreeItem => self.0.is_selected().is_some(),
+            Role::GridCell => true,
             _ => false,
         }
     }

--- a/platforms/winit/Cargo.toml
+++ b/platforms/winit/Cargo.toml
@@ -48,4 +48,3 @@ softbuffer = { version = "0.4.0", default-features = false, features = [
     "wayland",
     "wayland-dlopen",
 ] }
-


### PR DESCRIPTION
Support SelectionItem Control Pattern for this new role.

A follow-up will need to implement the GridItem and TableItem Control Patterns.

This was added to Chromium in https://chromium-review.googlesource.com/c/chromium/src/+/5512762

This can be focusable, editable and selectable, but I don't think AccessKit restricts this based on role currently.