### PR TITLE
fix: Redraw only when needed in the winit examples

### DIFF
--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -271,6 +271,7 @@ impl ApplicationHandler<AccessKitEvent> for Application {
                         _ => (),
                     }
                 }
+                window.window.request_redraw();
             }
             AccessKitWindowEvent::AccessibilityDeactivated => (),
         }

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -247,6 +247,7 @@ impl ApplicationHandler<AccessKitEvent> for Application {
                         _ => (),
                     }
                 }
+                window.window.request_redraw();
             }
             AccessKitWindowEvent::AccessibilityDeactivated => (),
         }


### PR DESCRIPTION
I did not test #625 on macOS where it actually make the example very unresponsive. This is because we  are constantly redrawing the screen, not giving much CPU time for accessibility calls to be handled on the main thread. Triggering a redraw only when needed (or when it would be needed in a real program) solves the issue.