### PR TITLE
Replace single thiserror usage with manual trait implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ dependencies = [
  "accesskit_consumer",
  "atspi-common",
  "serde",
- "thiserror",
  "zvariant",
 ]
 

--- a/platforms/atspi-common/Cargo.toml
+++ b/platforms/atspi-common/Cargo.toml
@@ -19,6 +19,5 @@ accesskit = { version = "0.21.1", path = "../../common" }
 accesskit_consumer = { version = "0.31.0", path = "../../consumer" }
 atspi-common = { version = "0.9", default-features = false }
 serde = "1.0"
-thiserror = "1.0"
 zvariant = { version = "5.4", default-features = false }
 

--- a/platforms/atspi-common/src/error.rs
+++ b/platforms/atspi-common/src/error.rs
@@ -3,20 +3,31 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-#[derive(Debug, thiserror::Error)]
+use std::fmt;
+
+#[derive(Debug)]
 pub enum Error {
-    #[error("defunct")]
     Defunct,
-    #[error("unsupported interface")]
     UnsupportedInterface,
-    #[error("too many children")]
     TooManyChildren,
-    #[error("index out of range")]
     IndexOutOfRange,
-    #[error("too many characters")]
     TooManyCharacters,
-    #[error("unsupported text granularity")]
     UnsupportedTextGranularity,
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Defunct => "defunct",
+            Self::UnsupportedInterface => "unsupported interface",
+            Self::TooManyChildren => "too many children",
+            Self::IndexOutOfRange => "index out of range",
+            Self::TooManyCharacters => "too many characters",
+            Self::UnsupportedTextGranularity => "unsupported text granularity",
+        })
+    }
+}
+
+impl std::error::Error for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
I was going to send a PR updating `thiserror` to 2.0, but noticed that with the current lockfile, all dependencies are on 1.0 and it's probably not easy to update everything to 2.0 for now. I also noticed that there's only a single use of `thiserror` though which was trivial to replace with a manual implementation of `std::fmt::Display` + `std::error::Error`.

If you prefer the derive though, no hard feelings :)