### PR TITLE
feat: Add simple text attributes on Windows

### DIFF
--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -446,6 +446,18 @@ impl ITextRangeProvider_Impl for PlatformRange_Impl {
                 }
                 Ok(value.0.into())
             }),
+            UIA_CultureAttributeId => {
+                self.read(|range| Ok(Variant::from(range.language().map(LocaleName)).into()))
+            }
+            UIA_FontNameAttributeId => {
+                self.read(|range| Ok(Variant::from(range.font_family()).into()))
+            }
+            UIA_FontSizeAttributeId => {
+                self.read(|range| Ok(Variant::from(range.font_size()).into()))
+            }
+            UIA_FontWeightAttributeId => self.read(|range| {
+                Ok(Variant::from(range.font_weight().map(|value| value as i32)).into())
+            }),
             // TODO: implement more attributes
             _ => {
                 let value = unsafe { UiaGetReservedNotSupportedValue() }.unwrap();

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::Point;
-use accesskit_consumer::TreeState;
+use accesskit_consumer::{TextRangePropertyValue, TreeState};
 use std::{
     fmt::{self, Write},
     mem::ManuallyDrop,
@@ -155,6 +155,17 @@ impl From<bool> for Variant {
 impl<T: Into<Variant>> From<Option<T>> for Variant {
     fn from(value: Option<T>) -> Self {
         value.map_or_else(Self::empty, T::into)
+    }
+}
+
+impl<T: Into<Variant> + std::fmt::Debug + PartialEq> From<TextRangePropertyValue<T>> for Variant {
+    fn from(value: TextRangePropertyValue<T>) -> Self {
+        match value {
+            TextRangePropertyValue::Single(value) => value.into(),
+            TextRangePropertyValue::Mixed => unsafe { UiaGetReservedMixedAttributeValue() }
+                .unwrap()
+                .into(),
+        }
     }
 }
 


### PR DESCRIPTION
These are the attributes I can add immediately without doing any refactoring in `common` or implementing enum translation.