### PR TITLE
fix: Cast font size to `f64` on Windows

### DIFF
--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -452,9 +452,9 @@ impl ITextRangeProvider_Impl for PlatformRange_Impl {
             UIA_FontNameAttributeId => {
                 self.read(|range| Ok(Variant::from(range.font_family()).into()))
             }
-            UIA_FontSizeAttributeId => {
-                self.read(|range| Ok(Variant::from(range.font_size()).into()))
-            }
+            UIA_FontSizeAttributeId => self.read(|range| {
+                Ok(Variant::from(range.font_size().map(|value| value as f64)).into())
+            }),
             UIA_FontWeightAttributeId => self.read(|range| {
                 Ok(Variant::from(range.font_weight().map(|value| value as i32)).into())
             }),


### PR DESCRIPTION
I still believe using `f32` for the font size and weight in the public cross-platform API is best. But Windows needs it to be an `f64`.