### PR TITLE
fix: Emit initial focus event for active descendant node

### DIFF
--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -424,7 +424,7 @@ impl Adapter {
         action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
     ) -> Self {
         let tree = Tree::new(initial_state, is_window_focused);
-        let focus_id = tree.state().focus_id();
+        let focus_id = tree.state().focus().map(|node| node.id());
         let context = Context::new(app_context, tree, action_handler, root_window_bounds);
         context.write_app_context().push_adapter(id, &context);
         let adapter = Self {

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -129,12 +129,9 @@ impl Adapter {
                     Rc::clone(action_handler),
                     placeholder_context.mtm,
                 );
-                let result = context
-                    .tree
-                    .borrow()
-                    .state()
-                    .focus_id()
-                    .map(|id| QueuedEvents::new(Rc::clone(&context), vec![focus_event(id)]));
+                let result = context.tree.borrow().state().focus().map(|node| {
+                    QueuedEvents::new(Rc::clone(&context), vec![focus_event(node.id())])
+                });
                 self.state = State::Active(context);
                 result
             }

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -426,8 +426,8 @@ impl Adapter {
                 let result = context
                     .read_tree()
                     .state()
-                    .focus_id()
-                    .map(|id| QueuedEvents(vec![focus_event(context, id)]));
+                    .focus()
+                    .map(|node| QueuedEvents(vec![focus_event(context, node.id())]));
                 self.state = State::Active(Arc::clone(context));
                 result
             }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -1094,14 +1094,14 @@ impl IRawElementProviderFragmentRoot_Impl for PlatformNode_Impl {
 
     fn GetFocus(&self) -> Result<IRawElementProviderFragment> {
         self.with_tree_state(|state| {
-            if let Some(id) = state.focus_id() {
+            if let Some(node) = state.focus() {
                 let self_id = if let Some(id) = self.node_id {
                     id
                 } else {
                     state.root_id()
                 };
-                if id != self_id {
-                    return Ok(self.relative(id).into());
+                if node.id() != self_id {
+                    return Ok(self.relative(node.id()).into());
                 }
             }
             Err(Error::empty())


### PR DESCRIPTION
This fixes an edge case where a first focus event would not be emitted if initial focus is on a node with `active_descendant` property set.