### PR TITLE
fix: Populate range info on Android

### DIFF
--- a/platforms/android/src/node.rs
+++ b/platforms/android/src/node.rs
@@ -389,6 +389,40 @@ impl NodeWrapper<'_> {
             add_action(env, node_info, ACTION_SCROLL_FORWARD);
         }
 
+        if self.0.data().value().is_none() {
+            if let (Some(current), Some(min), Some(max)) = (
+                self.0.numeric_value(),
+                self.0.min_numeric_value(),
+                self.0.max_numeric_value(),
+            ) {
+                let range_info_class = env
+                    .find_class("android/view/accessibility/AccessibilityNodeInfo$RangeInfo")
+                    .unwrap();
+                let range_info = env
+                    .call_static_method(
+                        &range_info_class,
+                        "obtain",
+                        "(IFFF)Landroid/view/accessibility/AccessibilityNodeInfo$RangeInfo;",
+                        &[
+                            RANGE_TYPE_FLOAT.into(),
+                            (min as f32).into(),
+                            (max as f32).into(),
+                            (current as f32).into(),
+                        ],
+                    )
+                    .unwrap()
+                    .l()
+                    .unwrap();
+                env.call_method(
+                    node_info,
+                    "setRangeInfo",
+                    "(Landroid/view/accessibility/AccessibilityNodeInfo$RangeInfo;)V",
+                    &[(&range_info).into()],
+                )
+                .unwrap();
+            }
+        }
+
         let live = match self.0.live() {
             Live::Off => LIVE_REGION_NONE,
             Live::Polite => LIVE_REGION_POLITE,

--- a/platforms/android/src/util.rs
+++ b/platforms/android/src/util.rs
@@ -27,6 +27,7 @@ pub(crate) const ACTION_ARGUMENT_SELECTION_END_INT: &str = "ACTION_ARGUMENT_SELE
 pub(crate) const CONTENT_CHANGE_TYPE_SUBTREE: jint = 1 << 0;
 
 pub(crate) const EVENT_VIEW_CLICKED: jint = 1;
+pub(crate) const EVENT_VIEW_SELECTED: jint = 1 << 2;
 pub(crate) const EVENT_VIEW_FOCUSED: jint = 1 << 3;
 pub(crate) const EVENT_VIEW_TEXT_CHANGED: jint = 1 << 4;
 pub(crate) const EVENT_VIEW_HOVER_ENTER: jint = 1 << 7;
@@ -55,6 +56,8 @@ pub(crate) const MOVEMENT_GRANULARITY_CHARACTER: jint = 1 << 0;
 pub(crate) const MOVEMENT_GRANULARITY_WORD: jint = 1 << 1;
 pub(crate) const MOVEMENT_GRANULARITY_LINE: jint = 1 << 2;
 pub(crate) const MOVEMENT_GRANULARITY_PARAGRAPH: jint = 1 << 3;
+
+pub(crate) const RANGE_TYPE_FLOAT: jint = 1;
 
 #[derive(Debug, Default)]
 pub(crate) struct NodeIdMap {


### PR DESCRIPTION
Allows reporting current value for slider, progressbars, spinboxes... TalkBack also does not send increment/decrement action requests if this is not set.

Chromium also only use the float range  type even though Android has integer and percentage ranges. We could get a better user experience by using these but I can't find of a good heristic that would work all the time. We can revisit this later anyway.