### PR TITLE
feat(consumer): Expose `local_id` accessor on `NodeId`

### DIFF
--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -40,6 +40,11 @@ impl NodeId {
     pub(crate) fn to_components(self) -> (LocalNodeId, TreeIndex) {
         (self.1, self.0)
     }
+
+    /// Returns the local node ID, i.e. the [`accesskit::NodeId`].
+    pub fn local_id(self) -> LocalNodeId {
+        self.1
+    }
 }
 
 impl From<NodeId> for u128 {


### PR DESCRIPTION
Turns out one more change is required for https://github.com/emilk/egui/pull/7853 :sweat_smile: 