### PR TITLE
fix: Correctly register interfaces on Unix after Hyperlink was added

### DIFF
--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -124,21 +124,21 @@ impl Bus {
                 HyperlinkInterface::new(bus_name.clone(), node.clone()),
             )
             .await?;
-            if new_interfaces.contains(Interface::Selection) {
-                self.register_interface(
-                    &path,
-                    SelectionInterface::new(bus_name.clone(), node.clone()),
-                )
+        }
+        if new_interfaces.contains(Interface::Selection) {
+            self.register_interface(
+                &path,
+                SelectionInterface::new(bus_name.clone(), node.clone()),
+            )
+            .await?;
+        }
+        if new_interfaces.contains(Interface::Text) {
+            self.register_interface(&path, TextInterface::new(node.clone()))
                 .await?;
-            }
-            if new_interfaces.contains(Interface::Text) {
-                self.register_interface(&path, TextInterface::new(node.clone()))
-                    .await?;
-            }
-            if new_interfaces.contains(Interface::Value) {
-                self.register_interface(&path, ValueInterface::new(node.clone()))
-                    .await?;
-            }
+        }
+        if new_interfaces.contains(Interface::Value) {
+            self.register_interface(&path, ValueInterface::new(node.clone()))
+                .await?;
         }
 
         Ok(())


### PR DESCRIPTION
In #669 I inadvertently tied the registration of `Selection`, `Text` and `Value` interfaces to `Hyperlink` which obviously broke editable text support on Unix.