### PR TITLE
Add Send + Sync for SubclassingAdapter, remove visibility panics

### DIFF
--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -262,6 +262,13 @@ impl SubclassingAdapter {
 unsafe impl Send for SubclassingAdapter {}
 unsafe impl Sync for SubclassingAdapter {}
 
+const _: () = {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    fn _assert_all() {
+        _assert_send_sync::<SubclassingAdapter>();
+    }
+};
+
 impl Drop for SubclassingAdapter {
     fn drop(&mut self) {
         let prev_class = self.associated.ivars().prev_class;

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -199,6 +199,13 @@ impl SubclassingAdapter {
 unsafe impl Send for SubclassingAdapter {}
 unsafe impl Sync for SubclassingAdapter {}
 
+const _: () = {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    fn _assert_all() {
+        _assert_send_sync::<SubclassingAdapter>();
+    }
+};
+
 impl Drop for SubclassingAdapter {
     fn drop(&mut self) {
         self.0.uninstall();

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -143,9 +143,10 @@ impl Adapter {
     /// consider using [`Adapter::with_direct_handlers`] or
     /// [`Adapter::with_mixed_handlers`] instead.
     ///
-    /// # Panics
+    /// # Note
     ///
-    /// Panics if the window is already visible.
+    /// Ideally, this should be called before the window is shown for the first
+    /// time, but it will still work if the window is already visible.
     pub fn with_event_loop_proxy<T: From<Event> + Send + 'static>(
         event_loop: &ActiveEventLoop,
         window: &Window,
@@ -184,9 +185,10 @@ impl Adapter {
     /// the first update. However, remember that each of these handlers may be
     /// called on any thread, depending on the underlying platform adapter.
     ///
-    /// # Panics
+    /// # Note
     ///
-    /// Panics if the window is already visible.
+    /// Ideally, this should be called before the window is shown for the first
+    /// time, but it will still work if the window is already visible.
     pub fn with_direct_handlers(
         event_loop: &ActiveEventLoop,
         window: &Window,
@@ -194,10 +196,6 @@ impl Adapter {
         action_handler: impl 'static + ActionHandler + Send,
         deactivation_handler: impl 'static + DeactivationHandler + Send,
     ) -> Self {
-        if window.is_visible() == Some(true) {
-            panic!("The AccessKit winit adapter must be created before the window is shown (made visible) for the first time.");
-        }
-
         let inner = platform_impl::Adapter::new(
             event_loop,
             window,
@@ -221,9 +219,10 @@ impl Adapter {
     /// return the initial tree synchronously. Remember that the thread on which
     /// the activation handler is called is platform-dependent.
     ///
-    /// # Panics
+    /// # Note
     ///
-    /// Panics if the window is already visible.
+    /// Ideally, this should be called before the window is shown for the first
+    /// time, but it will still work if the window is already visible.
     pub fn with_mixed_handlers<T: From<Event> + Send + 'static>(
         event_loop: &ActiveEventLoop,
         window: &Window,


### PR DESCRIPTION
## Summary

Two issues affect frameworks that wrap AccessKit adapters in channel-based event loops (e.g. iced, Freya):

### 1. SubclassingAdapter is not Send + Sync

Frameworks like iced wrap the adapter in a channel (`Proxy<T>`), which requires `Send + Sync`. The adapter uses `RefCell` internally, so it doesn't satisfy these bounds. We add `unsafe impl Send + Sync` for both macOS and Windows, with the following justification:

**Windows:** The Win32 window message model guarantees that messages are dispatched to the window procedure on the thread that owns the window ([About Messages and Message Queues](https://learn.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues)). `WM_GETOBJECT` — the message that triggers accessibility queries — follows this rule: it is [sent to the window](https://learn.microsoft.com/en-us/windows/win32/winauto/wm-getobject) by the UI Automation core, and `SendMessage` to a same-thread window invokes the window procedure directly as a subroutine ([SendMessage](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessage)). Furthermore, `SetWindowSubclass` [cannot be used across threads](https://learn.microsoft.com/en-us/windows/win32/controls/subclassing-overview) — all subclass operations must occur on the owning thread. The adapter is therefore inherently single-threaded.

**macOS:** AppKit requires that all `NSView` operations occur on the main thread ([Threading Programming Guide: Thread Safety Summary](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html)). The `SubclassingAdapter` wraps an `NSView` and its accessibility callbacks are dispatched through AppKit's main-thread event loop. The adapter is never accessed from a secondary thread.

In both cases, the `Send + Sync` bounds come from the framework's channel infrastructure, not from actual cross-thread access.

### 2. Visibility panics are overly strict

`SubclassingAdapter::new()` on Windows and `Adapter::with_direct_handlers()` in the winit integration panic if the window is already visible. The panic was added in response to #255, where the concern was that `WM_GETOBJECT` might arrive before the adapter is ready.

In practice, this panic prevents legitimate use cases. Some frameworks (iced, and likely others) show the window before processing adapter initialization — this is normal event loop lifecycle behavior. The underlying mechanisms (window subclassing on Windows, dynamic Objective-C subclassing on macOS) work correctly on visible windows. If a `WM_GETOBJECT` arrives before the first tree update, the adapter returns the placeholder tree — which is the designed fallback behavior.

The maintainer's own investigation in #255 noted uncertainty about whether this restriction is actually necessary for `SubclassingAdapter`, marking it as a checklist item rather than a confirmed requirement. We propose relaxing it to a documentation note.

## Changes

- `platforms/macos/src/subclass.rs`: `unsafe impl Send + Sync` with safety comment and compile-time assertion
- `platforms/windows/src/subclass.rs`: `unsafe impl Send + Sync` with safety comment and compile-time assertion; remove `IsWindowVisible` panic
- `platforms/winit/src/lib.rs`: Remove visibility panic in `with_direct_handlers`; update docs on all three constructors from "# Panics" to "# Note"

## Checklist

- [x] Builds with MSRV (Rust 1.85) — verified on macOS
- [x] Builds on Windows — verified via Windows 11 ARM VM (Rust 1.93)
- [x] Compile-time `Send + Sync` assertions added for both platforms
- [x] Tested on macOS with iced (builds and runs with screen reader)
- [x] Tested on Windows with iced (builds and runs)
- [x] Documentation updated — all three winit constructor doc comments updated
- [x] Safety comments explain reasoning on both `unsafe impl` blocks

## Alternative considered

Rather than adding `Send + Sync` to the library type, consumers could wrap `SubclassingAdapter` in their own newtype with a local `unsafe impl`. We believe the library-level impl is more appropriate because the safety argument derives from platform guarantees (Win32 thread affinity, AppKit main-thread requirement) that are intrinsic to the adapter, not specific to any particular consumer.
