### PR TITLE
refactor!: Migrate to 2024 Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 [workspace.package]
 authors = ["The AccessKit contributors"]
 categories = ["gui"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/AccessKit/accesskit"
 rust-version = "1.85"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,12 +19,12 @@ use core::fmt;
 #[cfg(feature = "pyo3")]
 use pyo3::pyclass;
 #[cfg(feature = "schemars")]
-use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 #[cfg(feature = "serde")]
 use serde::{
+    Deserialize, Serialize,
     de::{Deserializer, IgnoredAny, MapAccess, Visitor},
     ser::{SerializeMap, Serializer},
-    Deserialize, Serialize,
 };
 #[cfg(feature = "schemars")]
 use serde_json::{Map as SchemaMap, Value as SchemaValue};
@@ -2590,9 +2590,9 @@ impl JsonSchema for Properties {
         "Properties".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         let mut properties = SchemaMap::<String, SchemaValue>::new();
-        add_properties_to_schema!(gen, properties, {
+        add_properties_to_schema!(generator, properties, {
             Vec<NodeId> {
                 Children,
                 Controls,

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -104,8 +104,8 @@ mod tests {
     use alloc::vec;
 
     use super::{
-        common_filter, common_filter_with_root_exception,
         FilterResult::{self, *},
+        common_filter, common_filter_with_root_exception,
     };
     use crate::tests::nid;
 

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -266,25 +266,30 @@ fn next_filtered_sibling<'a>(
                 return next;
             }
             consider_children = result == FilterResult::ExcludeNode;
-        } else if let Some(sibling) = current.following_siblings().next() {
-            let result = filter(&sibling);
-            next = Some(sibling);
-            if result == FilterResult::Include {
-                return next;
-            }
-            if result == FilterResult::ExcludeNode {
-                consider_children = true;
-            }
         } else {
-            let parent = current.parent();
-            next = parent;
-            if let Some(parent) = parent {
-                if filter(&parent) != FilterResult::ExcludeNode {
-                    return None;
+            match current.following_siblings().next() {
+                Some(sibling) => {
+                    let result = filter(&sibling);
+                    next = Some(sibling);
+                    if result == FilterResult::Include {
+                        return next;
+                    }
+                    if result == FilterResult::ExcludeNode {
+                        consider_children = true;
+                    }
                 }
-                consider_children = false;
-            } else {
-                return None;
+                _ => {
+                    let parent = current.parent();
+                    next = parent;
+                    if let Some(parent) = parent {
+                        if filter(&parent) != FilterResult::ExcludeNode {
+                            return None;
+                        }
+                        consider_children = false;
+                    } else {
+                        return None;
+                    }
+                }
             }
         }
     }
@@ -305,25 +310,30 @@ fn previous_filtered_sibling<'a>(
                 return previous;
             }
             consider_children = result == FilterResult::ExcludeNode;
-        } else if let Some(sibling) = current.preceding_siblings().next() {
-            let result = filter(&sibling);
-            previous = Some(sibling);
-            if result == FilterResult::Include {
-                return previous;
-            }
-            if result == FilterResult::ExcludeNode {
-                consider_children = true;
-            }
         } else {
-            let parent = current.parent();
-            previous = parent;
-            if let Some(parent) = parent {
-                if filter(&parent) != FilterResult::ExcludeNode {
-                    return None;
+            match current.preceding_siblings().next() {
+                Some(sibling) => {
+                    let result = filter(&sibling);
+                    previous = Some(sibling);
+                    if result == FilterResult::Include {
+                        return previous;
+                    }
+                    if result == FilterResult::ExcludeNode {
+                        consider_children = true;
+                    }
                 }
-                consider_children = false;
-            } else {
-                return None;
+                _ => {
+                    let parent = current.parent();
+                    previous = parent;
+                    if let Some(parent) = parent {
+                        if filter(&parent) != FilterResult::ExcludeNode {
+                            return None;
+                        }
+                        consider_children = false;
+                    } else {
+                        return None;
+                    }
+                }
             }
         }
     }
@@ -583,10 +593,10 @@ impl<Filter: Fn(&Node) -> FilterResult> FusedIterator for LabelledBy<'_, Filter>
 #[cfg(test)]
 mod tests {
     use crate::{
+        NodeId,
         filters::common_filter,
         tests::*,
         tree::{ChangeHandler, TreeIndex},
-        NodeId,
     };
     use accesskit::{Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate, Uuid};
     use alloc::{vec, vec::Vec};
@@ -617,13 +627,14 @@ mod tests {
                 .following_siblings()
                 .len()
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
-            .unwrap()
-            .following_siblings()
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
+                .unwrap()
+                .following_siblings()
+                .next()
+                .is_none()
+        );
         assert_eq!(
             0,
             tree.state()
@@ -637,12 +648,13 @@ mod tests {
     #[test]
     fn following_siblings_reversed() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .following_siblings()
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .following_siblings()
+                .next_back()
+                .is_none()
+        );
         assert_eq!(
             [
                 PARAGRAPH_3_IGNORED_ID,
@@ -657,13 +669,14 @@ mod tests {
                 .map(|id| id.to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
-            .unwrap()
-            .following_siblings()
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
+                .unwrap()
+                .following_siblings()
+                .next_back()
+                .is_none()
+        );
     }
 
     #[test]
@@ -688,13 +701,14 @@ mod tests {
                 .preceding_siblings()
                 .len()
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .preceding_siblings()
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .preceding_siblings()
+                .next()
+                .is_none()
+        );
         assert_eq!(
             0,
             tree.state()
@@ -708,12 +722,13 @@ mod tests {
     #[test]
     fn preceding_siblings_reversed() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .preceding_siblings()
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .preceding_siblings()
+                .next_back()
+                .is_none()
+        );
         assert_eq!(
             [PARAGRAPH_0_ID, PARAGRAPH_1_IGNORED_ID, PARAGRAPH_2_ID],
             tree.state()
@@ -724,24 +739,26 @@ mod tests {
                 .map(|id| id.to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .preceding_siblings()
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .preceding_siblings()
+                .next_back()
+                .is_none()
+        );
     }
 
     #[test]
     fn following_filtered_siblings() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .following_filtered_siblings(test_tree_filter)
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .following_filtered_siblings(test_tree_filter)
+                .next()
+                .is_none()
+        );
         assert_eq!(
             [LABEL_1_1_ID, PARAGRAPH_2_ID, LABEL_3_1_0_ID, BUTTON_3_2_ID],
             tree.state()
@@ -760,24 +777,26 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
-            .unwrap()
-            .following_filtered_siblings(test_tree_filter)
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
+                .unwrap()
+                .following_filtered_siblings(test_tree_filter)
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
     fn following_filtered_siblings_reversed() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .following_filtered_siblings(test_tree_filter)
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .following_filtered_siblings(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
         assert_eq!(
             [BUTTON_3_2_ID, LABEL_3_1_0_ID, PARAGRAPH_2_ID, LABEL_1_1_ID],
             tree.state()
@@ -798,24 +817,26 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
-            .unwrap()
-            .following_filtered_siblings(test_tree_filter)
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_3_IGNORED_ID))
+                .unwrap()
+                .following_filtered_siblings(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
     }
 
     #[test]
     fn preceding_filtered_siblings() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .preceding_filtered_siblings(test_tree_filter)
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .preceding_filtered_siblings(test_tree_filter)
+                .next()
+                .is_none()
+        );
         assert_eq!(
             [PARAGRAPH_2_ID, LABEL_1_1_ID, PARAGRAPH_0_ID],
             tree.state()
@@ -834,24 +855,26 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .preceding_filtered_siblings(test_tree_filter)
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .preceding_filtered_siblings(test_tree_filter)
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
     fn preceding_filtered_siblings_reversed() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .preceding_filtered_siblings(test_tree_filter)
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .preceding_filtered_siblings(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
         assert_eq!(
             [PARAGRAPH_0_ID, LABEL_1_1_ID, PARAGRAPH_2_ID],
             tree.state()
@@ -872,13 +895,14 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .preceding_filtered_siblings(test_tree_filter)
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .preceding_filtered_siblings(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
     }
 
     #[test]
@@ -898,20 +922,22 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .filtered_children(test_tree_filter)
-            .next()
-            .is_none());
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .filtered_children(test_tree_filter)
-            .next()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .filtered_children(test_tree_filter)
+                .next()
+                .is_none()
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .filtered_children(test_tree_filter)
+                .next()
+                .is_none()
+        );
     }
 
     #[test]
@@ -932,20 +958,22 @@ mod tests {
                 .map(|node| node.id().to_components().0)
                 .collect::<Vec<LocalNodeId>>()[..]
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .filtered_children(test_tree_filter)
-            .next_back()
-            .is_none());
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .filtered_children(test_tree_filter)
-            .next_back()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .filtered_children(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .filtered_children(test_tree_filter)
+                .next_back()
+                .is_none()
+        );
     }
 
     #[test]

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) mod node;
 pub use node::{Node, NodeId};
 
 pub(crate) mod filters;
-pub use filters::{common_filter, common_filter_with_root_exception, FilterResult};
+pub use filters::{FilterResult, common_filter, common_filter_with_root_exception};
 
 pub(crate) mod iterators;
 
@@ -31,9 +31,9 @@ mod tests {
     };
     use alloc::vec;
 
+    use crate::FilterResult;
     use crate::node::NodeId;
     use crate::tree::TreeIndex;
-    use crate::FilterResult;
 
     pub fn nid(id: LocalNodeId) -> NodeId {
         NodeId::new(id, TreeIndex(0))

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -44,8 +44,8 @@ impl NodeId {
 
 impl From<NodeId> for u128 {
     fn from(id: NodeId) -> Self {
-        let tree_index = id.0 .0 as u128;
-        let local_id = id.1 .0 as u128;
+        let tree_index = id.0.0 as u128;
+        let local_id = id.1.0 as u128;
         (local_id << 64) | tree_index
     }
 }
@@ -150,9 +150,10 @@ impl<'a> Node<'a> {
     pub fn child_ids(
         &self,
     ) -> impl DoubleEndedIterator<Item = NodeId>
-           + ExactSizeIterator<Item = NodeId>
-           + FusedIterator<Item = NodeId>
-           + 'a {
+    + ExactSizeIterator<Item = NodeId>
+    + FusedIterator<Item = NodeId>
+    + 'a
+    + use<'a> {
         if self.is_graft() {
             ChildIds::Graft(self.graft_child_id())
         } else {
@@ -166,72 +167,80 @@ impl<'a> Node<'a> {
     pub fn children(
         &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
-           + ExactSizeIterator<Item = Node<'a>>
-           + FusedIterator<Item = Node<'a>>
-           + 'a {
+    + ExactSizeIterator<Item = Node<'a>>
+    + FusedIterator<Item = Node<'a>>
+    + 'a
+    + use<'a> {
         let state = self.tree_state;
         self.child_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn filtered_children(
+    pub fn filtered_children<F: Fn(&Node) -> FilterResult + 'a>(
         &self,
-        filter: impl Fn(&Node) -> FilterResult + 'a,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+        filter: F,
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + use<'a, F>
+    {
         FilteredChildren::new(*self, filter)
     }
 
     pub fn following_sibling_ids(
         &self,
     ) -> impl DoubleEndedIterator<Item = NodeId>
-           + ExactSizeIterator<Item = NodeId>
-           + FusedIterator<Item = NodeId>
-           + 'a {
+    + ExactSizeIterator<Item = NodeId>
+    + FusedIterator<Item = NodeId>
+    + 'a
+    + use<'a> {
         FollowingSiblings::new(*self)
     }
 
     pub fn following_siblings(
         &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
-           + ExactSizeIterator<Item = Node<'a>>
-           + FusedIterator<Item = Node<'a>>
-           + 'a {
+    + ExactSizeIterator<Item = Node<'a>>
+    + FusedIterator<Item = Node<'a>>
+    + 'a
+    + use<'a> {
         let state = self.tree_state;
         self.following_sibling_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn following_filtered_siblings(
+    pub fn following_filtered_siblings<F: Fn(&Node) -> FilterResult + 'a>(
         &self,
-        filter: impl Fn(&Node) -> FilterResult + 'a,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+        filter: F,
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + use<'a, F>
+    {
         FollowingFilteredSiblings::new(*self, filter)
     }
 
     pub fn preceding_sibling_ids(
         &self,
     ) -> impl DoubleEndedIterator<Item = NodeId>
-           + ExactSizeIterator<Item = NodeId>
-           + FusedIterator<Item = NodeId>
-           + 'a {
+    + ExactSizeIterator<Item = NodeId>
+    + FusedIterator<Item = NodeId>
+    + 'a
+    + use<'a> {
         PrecedingSiblings::new(*self)
     }
 
     pub fn preceding_siblings(
         &self,
     ) -> impl DoubleEndedIterator<Item = Node<'a>>
-           + ExactSizeIterator<Item = Node<'a>>
-           + FusedIterator<Item = Node<'a>>
-           + 'a {
+    + ExactSizeIterator<Item = Node<'a>>
+    + FusedIterator<Item = Node<'a>>
+    + 'a
+    + use<'a> {
         let state = self.tree_state;
         self.preceding_sibling_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn preceding_filtered_siblings(
+    pub fn preceding_filtered_siblings<F: Fn(&Node) -> FilterResult + 'a>(
         &self,
-        filter: impl Fn(&Node) -> FilterResult + 'a,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+        filter: F,
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + use<'a, F>
+    {
         PrecedingFilteredSiblings::new(*self, filter)
     }
 
@@ -697,7 +706,8 @@ fn descendant_label_filter(node: &Node) -> FilterResult {
 impl<'a> Node<'a> {
     pub fn labelled_by(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a + use<'a>
+    {
         let explicit = &self.state.data.labelled_by();
         if explicit.is_empty()
             && matches!(
@@ -916,7 +926,8 @@ impl<'a> Node<'a> {
 
     pub fn controls(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a + use<'a>
+    {
         let state = self.tree_state;
         let id = self.id;
         let data = &self.state.data;
@@ -1010,10 +1021,11 @@ impl<'a> Node<'a> {
         })
     }
 
-    pub fn items(
+    pub fn items<F: Fn(&Node) -> FilterResult + 'a>(
         &self,
-        filter: impl Fn(&Node) -> FilterResult + 'a,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+        filter: F,
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + use<'a, F>
+    {
         self.filtered_children(move |child| match filter(child) {
             FilterResult::Include if child.is_item_like() => FilterResult::Include,
             FilterResult::Include => FilterResult::ExcludeNode,
@@ -1113,12 +1125,13 @@ mod tests {
                 .to_components()
                 .0
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .deepest_first_child()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .deepest_first_child()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1135,11 +1148,12 @@ mod tests {
                 .to_components()
                 .0
         );
-        assert!(tree
-            .state()
-            .root()
-            .filtered_parent(&test_tree_filter)
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .filtered_parent(&test_tree_filter)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1155,18 +1169,20 @@ mod tests {
                 .to_components()
                 .0
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .deepest_first_filtered_child(&test_tree_filter)
-            .is_none());
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .deepest_first_filtered_child(&test_tree_filter)
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .deepest_first_filtered_child(&test_tree_filter)
+                .is_none()
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .deepest_first_filtered_child(&test_tree_filter)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1193,12 +1209,13 @@ mod tests {
                 .to_components()
                 .0
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(BUTTON_3_2_ID))
-            .unwrap()
-            .deepest_last_child()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(BUTTON_3_2_ID))
+                .unwrap()
+                .deepest_last_child()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1225,59 +1242,70 @@ mod tests {
                 .to_components()
                 .0
         );
-        assert!(tree
-            .state()
-            .node_by_id(nid(BUTTON_3_2_ID))
-            .unwrap()
-            .deepest_last_filtered_child(&test_tree_filter)
-            .is_none());
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .deepest_last_filtered_child(&test_tree_filter)
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(BUTTON_3_2_ID))
+                .unwrap()
+                .deepest_last_filtered_child(&test_tree_filter)
+                .is_none()
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .deepest_last_filtered_child(&test_tree_filter)
+                .is_none()
+        );
     }
 
     #[test]
     fn is_descendant_of() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .is_descendant_of(&tree.state().root()));
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .is_descendant_of(&tree.state().root()));
-        assert!(tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_0_ID)).unwrap()));
-        assert!(!tree
-            .state()
-            .node_by_id(nid(LABEL_0_0_IGNORED_ID))
-            .unwrap()
-            .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_2_ID)).unwrap()));
-        assert!(!tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_2_ID)).unwrap()));
+        assert!(
+            tree.state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .is_descendant_of(&tree.state().root())
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .is_descendant_of(&tree.state().root())
+        );
+        assert!(
+            tree.state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_0_ID)).unwrap())
+        );
+        assert!(
+            !tree
+                .state()
+                .node_by_id(nid(LABEL_0_0_IGNORED_ID))
+                .unwrap()
+                .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_2_ID)).unwrap())
+        );
+        assert!(
+            !tree
+                .state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .is_descendant_of(&tree.state().node_by_id(nid(PARAGRAPH_2_ID)).unwrap())
+        );
     }
 
     #[test]
     fn is_root() {
         let tree = test_tree();
         assert!(tree.state().node_by_id(nid(ROOT_ID)).unwrap().is_root());
-        assert!(!tree
-            .state()
-            .node_by_id(nid(PARAGRAPH_0_ID))
-            .unwrap()
-            .is_root());
+        assert!(
+            !tree
+                .state()
+                .node_by_id(nid(PARAGRAPH_0_ID))
+                .unwrap()
+                .is_root()
+        );
     }
 
     #[test]
@@ -1292,12 +1320,13 @@ mod tests {
     #[test]
     fn bounding_box() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .node_by_id(nid(ROOT_ID))
-            .unwrap()
-            .bounding_box()
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_id(nid(ROOT_ID))
+                .unwrap()
+                .bounding_box()
+                .is_none()
+        );
         assert_eq!(
             Some(Rect {
                 x0: 10.0,
@@ -1327,11 +1356,12 @@ mod tests {
     #[test]
     fn node_at_point() {
         let tree = test_tree();
-        assert!(tree
-            .state()
-            .root()
-            .node_at_point(Point::new(10.0, 40.0), &test_tree_filter)
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .node_at_point(Point::new(10.0, 40.0), &test_tree_filter)
+                .is_none()
+        );
         assert_eq!(
             Some(nid(LABEL_1_1_ID)),
             tree.state()
@@ -1346,11 +1376,12 @@ mod tests {
                 .node_at_point(Point::new(50.0, 60.0), &test_tree_filter)
                 .map(|node| node.id())
         );
-        assert!(tree
-            .state()
-            .root()
-            .node_at_point(Point::new(100.0, 70.0), &test_tree_filter)
-            .is_none());
+        assert!(
+            tree.state()
+                .root()
+                .node_at_point(Point::new(100.0, 70.0), &test_tree_filter)
+                .is_none()
+        );
     }
 
     #[test]
@@ -1856,11 +1887,12 @@ mod tests {
             focus: BUTTON_ID,
         };
         let tree = crate::Tree::new(update, true);
-        assert!(tree
-            .state()
-            .node_by_id(nid(BUTTON_ID))
-            .unwrap()
-            .is_focused());
+        assert!(
+            tree.state()
+                .node_by_id(nid(BUTTON_ID))
+                .unwrap()
+                .is_focused()
+        );
     }
 
     #[test]
@@ -1882,11 +1914,13 @@ mod tests {
             focus: ROOT_ID,
         };
         let tree = crate::Tree::new(update, true);
-        assert!(!tree
-            .state()
-            .node_by_id(nid(BUTTON_ID))
-            .unwrap()
-            .is_focused());
+        assert!(
+            !tree
+                .state()
+                .node_by_id(nid(BUTTON_ID))
+                .unwrap()
+                .is_focused()
+        );
     }
 
     #[test]
@@ -1944,10 +1978,12 @@ mod tests {
             focus: LISTBOX_ID,
         };
         let tree = crate::Tree::new(update, true);
-        assert!(!tree
-            .state()
-            .node_by_id(nid(LISTBOX_ID))
-            .unwrap()
-            .is_focused());
+        assert!(
+            !tree
+                .state()
+                .node_by_id(nid(LISTBOX_ID))
+                .unwrap()
+                .is_focused()
+        );
     }
 }

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -10,7 +10,7 @@ use accesskit::{
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, fmt, iter::FusedIterator};
 
-use crate::{node::NodeId, FilterResult, Node, TreeState};
+use crate::{FilterResult, Node, TreeState, node::NodeId};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct InnerPosition<'a> {
@@ -978,7 +978,7 @@ fn character_index_at_point(node: &Node, point: Point) -> usize {
 }
 
 macro_rules! inherited_properties {
-    ($(($getter:ident, $type:ty, $setter:ident, $test_value_1:expr, $test_value_2:expr)),+) => {
+    ($(($getter:ident, $type:ty, $setter:ident, $test_value_1:expr_2021, $test_value_2:expr_2021)),+) => {
         impl<'a> Node<'a> {
             $(pub fn $getter(&self) -> Option<$type> {
                 self.fetch_inherited_property(NodeData::$getter)
@@ -1380,7 +1380,8 @@ impl<'a> Node<'a> {
 
     pub(crate) fn text_runs(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a + use<'a>
+    {
         let id = self.id();
         self.filtered_children(move |node| text_node_filter(id, node))
     }
@@ -1388,7 +1389,8 @@ impl<'a> Node<'a> {
     fn following_text_runs(
         &self,
         root_node: &Node,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a + use<'a>
+    {
         let id = root_node.id();
         self.following_filtered_siblings(move |node| text_node_filter(id, node))
     }
@@ -1396,7 +1398,8 @@ impl<'a> Node<'a> {
     fn preceding_text_runs(
         &self,
         root_node: &Node,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a {
+    ) -> impl DoubleEndedIterator<Item = Node<'a>> + FusedIterator<Item = Node<'a>> + 'a + use<'a>
+    {
         let id = root_node.id();
         self.preceding_filtered_siblings(move |node| text_node_filter(id, node))
     }
@@ -1994,14 +1997,18 @@ mod tests {
     fn supports_text_ranges() {
         let tree = main_multiline_tree(None);
         let state = tree.state();
-        assert!(!state
-            .node_by_id(nid(NodeId(0)))
-            .unwrap()
-            .supports_text_ranges());
-        assert!(state
-            .node_by_id(nid(NodeId(1)))
-            .unwrap()
-            .supports_text_ranges());
+        assert!(
+            !state
+                .node_by_id(nid(NodeId(0)))
+                .unwrap()
+                .supports_text_ranges()
+        );
+        assert!(
+            state
+                .node_by_id(nid(NodeId(1)))
+                .unwrap()
+                .supports_text_ranges()
+        );
     }
 
     #[test]
@@ -2025,7 +2032,10 @@ mod tests {
         assert!(end.is_paragraph_start());
         assert!(!end.is_document_start());
         assert!(end.is_document_end());
-        assert_eq!(range.text(), "This paragraph is\u{a0}long enough to wrap to another line.\nAnother paragraph.\n\nLast non-blank line\u{1f44d}\u{1f3fb}\n");
+        assert_eq!(
+            range.text(),
+            "This paragraph is\u{a0}long enough to wrap to another line.\nAnother paragraph.\n\nLast non-blank line\u{1f44d}\u{1f3fb}\n"
+        );
         assert_eq!(
             range.bounding_boxes(),
             vec![
@@ -2364,9 +2374,11 @@ mod tests {
                 },
             ]
         );
-        assert!(paragraph_start
-            .forward_to_paragraph_start()
-            .is_paragraph_start());
+        assert!(
+            paragraph_start
+                .forward_to_paragraph_start()
+                .is_paragraph_start()
+        );
     }
 
     #[test]

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -1704,10 +1704,11 @@ mod tests {
         };
         let tree = super::Tree::new(update, false);
 
-        assert!(tree
-            .state()
-            .node_by_tree_local_id(LocalNodeId(0), subtree_id())
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_tree_local_id(LocalNodeId(0), subtree_id())
+                .is_none()
+        );
     }
 
     #[test]
@@ -1720,10 +1721,11 @@ mod tests {
         };
         let tree = super::Tree::new(update, false);
 
-        assert!(tree
-            .state()
-            .node_by_tree_local_id(LocalNodeId(999), TreeId::ROOT)
-            .is_none());
+        assert!(
+            tree.state()
+                .node_by_tree_local_id(LocalNodeId(999), TreeId::ROOT)
+                .is_none()
+        );
     }
 
     #[test]

--- a/platforms/android/src/action.rs
+++ b/platforms/android/src/action.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use jni::{objects::JObject, sys::jint, JNIEnv};
+use jni::{JNIEnv, objects::JObject, sys::jint};
 
 use crate::util::*;
 

--- a/platforms/android/src/adapter.rs
+++ b/platforms/android/src/adapter.rs
@@ -15,16 +15,16 @@ use accesskit::{
 };
 use accesskit_consumer::{FilterResult, Node, TextPosition, Tree, TreeChangeHandler};
 use jni::{
+    JNIEnv,
     objects::JObject,
     sys::{jfloat, jint},
-    JNIEnv,
 };
 
 use crate::{
     action::{PlatformAction, PlatformActionInner},
     event::{QueuedEvent, QueuedEvents, ScrollDimension},
     filters::filter,
-    node::{add_action, NodeWrapper},
+    node::{NodeWrapper, add_action},
     util::*,
 };
 
@@ -613,11 +613,7 @@ impl Adapter {
             self.set_text_selection_common(action_handler, &mut events, virtual_view_id, |node| {
                 let current = node.text_selection_focus().unwrap_or_else(|| {
                     let range = node.document_range();
-                    if forward {
-                        range.start()
-                    } else {
-                        range.end()
-                    }
+                    if forward { range.start() } else { range.end() }
                 });
                 if (forward && current.is_document_end())
                     || (!forward && current.is_document_start())
@@ -724,12 +720,10 @@ impl Adapter {
                 }
                 let focus = if forward { segment_end } else { segment_start };
                 let anchor = if extend_selection {
-                    node.text_selection_anchor().unwrap_or({
-                        if forward {
-                            segment_start
-                        } else {
-                            segment_end
-                        }
+                    node.text_selection_anchor().unwrap_or(if forward {
+                        segment_start
+                    } else {
+                        segment_end
                     })
                 } else {
                     focus

--- a/platforms/android/src/event.rs
+++ b/platforms/android/src/event.rs
@@ -8,7 +8,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE.chromium file.
 
-use jni::{objects::JObject, sys::jint, JNIEnv};
+use jni::{JNIEnv, objects::JObject, sys::jint};
 
 use crate::util::*;
 

--- a/platforms/android/src/inject.rs
+++ b/platforms/android/src/inject.rs
@@ -11,10 +11,10 @@
 
 use accesskit::{ActionHandler, ActivationHandler, TreeUpdate};
 use jni::{
+    JNIEnv, JavaVM, NativeMethod,
     errors::Result,
     objects::{GlobalRef, JClass, JObject, WeakRef},
-    sys::{jboolean, jfloat, jint, jlong, JNI_FALSE, JNI_TRUE},
-    JNIEnv, JavaVM, NativeMethod,
+    sys::{JNI_FALSE, JNI_TRUE, jboolean, jfloat, jint, jlong},
 };
 use log::debug;
 use std::{
@@ -22,8 +22,8 @@ use std::{
     ffi::c_void,
     fmt::{Debug, Formatter},
     sync::{
-        atomic::{AtomicI64, Ordering},
         Arc, Mutex, OnceLock, Weak,
+        atomic::{AtomicI64, Ordering},
     },
 };
 

--- a/platforms/android/src/node.rs
+++ b/platforms/android/src/node.rs
@@ -10,7 +10,7 @@
 
 use accesskit::{Action, Live, Role, Toggled};
 use accesskit_consumer::Node;
-use jni::{objects::JObject, sys::jint, JNIEnv};
+use jni::{JNIEnv, objects::JObject, sys::jint};
 
 use crate::{filters::filter, util::*};
 

--- a/platforms/android/src/util.rs
+++ b/platforms/android/src/util.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit_consumer::{Node, NodeId};
-use jni::{objects::JObject, sys::jint, JNIEnv};
+use jni::{JNIEnv, objects::JObject, sys::jint};
 use std::collections::HashMap;
 
 pub(crate) const ACTION_FOCUS: jint = 1 << 0;

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -9,11 +9,11 @@
 // found in the LICENSE.chromium file.
 
 use crate::{
+    AdapterCallback, Event, ObjectEvent, WindowEvent,
     context::{ActionHandlerNoMut, ActionHandlerWrapper, AppContext, Context},
     filters::filter,
     node::{NodeIdOrRoot, NodeWrapper, PlatformNode, PlatformRoot},
     util::WindowBounds,
-    AdapterCallback, Event, ObjectEvent, WindowEvent,
 };
 use accesskit::{ActionHandler, Role, TreeUpdate};
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler, TreeState};
@@ -22,8 +22,8 @@ use std::fmt::{Debug, Formatter};
 use std::{
     collections::HashSet,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc, RwLock,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 

--- a/platforms/atspi-common/src/lib.rs
+++ b/platforms/atspi-common/src/lib.rs
@@ -23,7 +23,7 @@ pub use atspi_common::{
 };
 
 pub use action::*;
-pub use adapter::{next_adapter_id, Adapter};
+pub use adapter::{Adapter, next_adapter_id};
 pub use callback::AdapterCallback;
 pub use context::{ActionHandlerNoMut, ActionHandlerWrapper, AppContext};
 pub use error::*;

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -25,12 +25,12 @@ use std::{
 };
 
 use crate::{
+    Action as AtspiAction, Error, ObjectEvent, Property, Rect as AtspiRect, Result,
     adapter::Adapter,
     context::{AppContext, Context},
     filters::filter,
     text_attributes::ATTRIBUTE_GETTERS,
     util::*,
-    Action as AtspiAction, Error, ObjectEvent, Property, Rect as AtspiRect, Result,
 };
 
 pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
@@ -465,11 +465,7 @@ impl NodeWrapper<'_> {
     }
 
     fn n_actions(&self) -> i32 {
-        if self.0.is_clickable(&filter) {
-            1
-        } else {
-            0
-        }
+        if self.0.is_clickable(&filter) { 1 } else { 0 }
     }
 
     fn get_action_name(&self, index: i32) -> String {

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     context::{ActionHandlerNoMut, ActionHandlerWrapper, Context},
-    event::{focus_event, EventGenerator, QueuedEvents},
+    event::{EventGenerator, QueuedEvents, focus_event},
     filters::filter,
     node::can_be_focused,
     util::*,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -15,17 +15,17 @@ use accesskit::{
 };
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree};
 use objc2::{
-    declare_class, msg_send_id,
+    ClassType, DeclaredClass, declare_class, msg_send_id,
     mutability::InteriorMutable,
     rc::Id,
     runtime::{AnyObject, Sel},
-    sel, ClassType, DeclaredClass,
+    sel,
 };
 use objc2_app_kit::*;
 use objc2_foundation::{
-    ns_string, NSArray, NSAttributedString, NSCopying, NSInteger, NSMutableAttributedString,
+    NSArray, NSAttributedString, NSCopying, NSInteger, NSMutableAttributedString,
     NSMutableDictionary, NSNumber, NSObject, NSObjectProtocol, NSPoint, NSRange, NSRect, NSString,
-    NSURL,
+    NSURL, ns_string,
 };
 use std::rc::{Rc, Weak};
 

--- a/platforms/macos/src/patch.rs
+++ b/platforms/macos/src/patch.rs
@@ -4,11 +4,12 @@
 // the LICENSE-MIT file), at your option.
 
 use objc2::{
+    Message,
     encode::{Encode, EncodeArguments, EncodeReturn, Encoding},
     ffi::class_addMethod,
     msg_send,
     runtime::{AnyClass, AnyObject, Bool, MethodImplementation, Sel},
-    sel, Message,
+    sel,
 };
 use objc2_app_kit::NSWindow;
 use std::{ffi::CString, ptr::null_mut};

--- a/platforms/macos/src/subclass.rs
+++ b/platforms/macos/src/subclass.rs
@@ -5,23 +5,24 @@
 
 use accesskit::{ActionHandler, ActivationHandler, TreeUpdate};
 use objc2::{
+    ClassType, DeclaredClass,
     declare::ClassBuilder,
     declare_class,
     ffi::{
-        objc_getAssociatedObject, objc_setAssociatedObject, object_setClass,
-        OBJC_ASSOCIATION_RETAIN_NONATOMIC,
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC, objc_getAssociatedObject, objc_setAssociatedObject,
+        object_setClass,
     },
     msg_send_id,
     mutability::InteriorMutable,
     rc::Id,
     runtime::{AnyClass, Sel},
-    sel, ClassType, DeclaredClass,
+    sel,
 };
 use objc2_app_kit::{NSView, NSWindow};
 use objc2_foundation::{NSArray, NSObject, NSPoint};
 use std::{cell::RefCell, ffi::c_void, sync::Mutex};
 
-use crate::{event::QueuedEvents, Adapter};
+use crate::{Adapter, event::QueuedEvents};
 
 static SUBCLASSES: Mutex<Vec<(&'static AnyClass, &'static AnyClass)>> = Mutex::new(Vec::new());
 

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -5,8 +5,8 @@
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, Rect, TreeUpdate};
 use accesskit_atspi_common::{
-    next_adapter_id, ActionHandlerNoMut, ActionHandlerWrapper, Adapter as AdapterImpl,
-    AdapterCallback, Event, NodeId, PlatformNode, WindowBounds,
+    ActionHandlerNoMut, ActionHandlerWrapper, Adapter as AdapterImpl, AdapterCallback, Event,
+    NodeId, PlatformNode, WindowBounds, next_adapter_id,
 };
 #[cfg(not(feature = "tokio"))]
 use async_channel::Sender;

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use crate::{
-    atspi::{interfaces::*, ObjectId},
+    atspi::{ObjectId, interfaces::*},
     context::get_or_init_app_context,
     executor::{Executor, Task},
 };
@@ -12,16 +12,16 @@ use accesskit_atspi_common::{
     NodeId, NodeIdOrRoot, ObjectEvent, PlatformNode, PlatformRoot, Property, WindowEvent,
 };
 use atspi::{
+    Interface, InterfaceSet,
     events::EventBodyBorrowed,
     proxy::{bus::BusProxy, socket::SocketProxy},
-    Interface, InterfaceSet,
 };
 use std::{env::var, io};
 use zbus::{
+    Address, Connection, Result,
     connection::Builder,
     names::{BusName, InterfaceName, MemberName, OwnedUniqueName},
     zvariant::{Str, Value},
-    Address, Connection, Result,
 };
 
 pub(crate) struct Bus {

--- a/platforms/unix/src/context.rs
+++ b/platforms/unix/src/context.rs
@@ -9,7 +9,7 @@ use accesskit_atspi_common::{Adapter as AdapterImpl, AppContext, Event};
 use async_channel::{Receiver, Sender};
 use atspi::proxy::bus::StatusProxy;
 #[cfg(not(feature = "tokio"))]
-use futures_util::{pin_mut as pin, select, StreamExt};
+use futures_util::{StreamExt, pin_mut as pin, select};
 use std::{
     sync::{Arc, Mutex, OnceLock, RwLock},
     thread,
@@ -20,12 +20,12 @@ use tokio::{
     sync::mpsc::{UnboundedReceiver as Receiver, UnboundedSender as Sender},
 };
 #[cfg(feature = "tokio")]
-use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
-use zbus::{connection::Builder, Connection};
+use tokio_stream::{StreamExt, wrappers::UnboundedReceiverStream};
+use zbus::{Connection, connection::Builder};
 
 use crate::{
     adapter::{AdapterState, Callback, Message},
-    atspi::{map_or_ignoring_broken_pipe, Bus},
+    atspi::{Bus, map_or_ignoring_broken_pipe},
     executor::Executor,
     util::block_on,
 };

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -8,13 +8,13 @@ use accesskit_windows::Adapter;
 use once_cell::sync::Lazy;
 use std::cell::RefCell;
 use windows::{
-    core::*,
     Win32::{
         Foundation::*,
         Graphics::Gdi::ValidateRect,
         System::LibraryLoader::GetModuleHandleW,
         UI::{Input::KeyboardAndMouse::*, WindowsAndMessaging::*},
     },
+    core::*,
 };
 
 static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
@@ -174,7 +174,7 @@ impl WindowState {
 }
 
 unsafe fn get_window_state(window: HWND) -> *const WindowState {
-    GetWindowLongPtrW(window, GWLP_USERDATA) as _
+    unsafe { GetWindowLongPtrW(window, GWLP_USERDATA) as _ }
 }
 
 fn update_window_focus_state(window: HWND, is_focused: bool) {
@@ -353,8 +353,12 @@ fn create_window(title: &str, initial_focus: NodeId) -> Result<HWND> {
 fn main() -> Result<()> {
     println!("This example has no visible GUI, and a keyboard interface:");
     println!("- [Tab] switches focus between two logical buttons.");
-    println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
-    println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
+    println!(
+        "- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed."
+    );
+    println!(
+        "Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows)."
+    );
 
     let window = create_window(WINDOW_TITLE, INITIAL_FOCUS)?;
     let _ = unsafe { ShowWindow(window, SW_SHOW) };

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -10,7 +10,7 @@ use accesskit::{
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler};
 use hashbrown::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::Ordering};
 use windows::Win32::{
     Foundation::*,
     UI::{Accessibility::*, WindowsAndMessaging::*},
@@ -488,7 +488,7 @@ impl Adapter {
         wparam: WPARAM,
         lparam: LPARAM,
         activation_handler: &mut H,
-    ) -> Option<impl Into<LRESULT>> {
+    ) -> Option<impl Into<LRESULT> + use<H>> {
         // Don't bother with MSAA object IDs that are asking for something other
         // than the client area of the window. DefWindowProc can handle those.
         // First, cast the lparam to i32, to handle inconsistent conversion

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -6,7 +6,7 @@
 use accesskit::{ActionHandler, ActionRequest, Point};
 use accesskit_consumer::Tree;
 use std::fmt::{Debug, Formatter};
-use std::sync::{atomic::AtomicBool, Arc, Mutex, RwLock, RwLockReadGuard};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, atomic::AtomicBool};
 
 use crate::{util::*, window_handle::WindowHandle};
 

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -17,15 +17,15 @@ use accesskit::{
 use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeState};
 use std::{
     fmt::Write,
-    sync::{atomic::Ordering, Arc, Weak},
+    sync::{Arc, Weak, atomic::Ordering},
 };
 use windows::{
-    core::*,
     Win32::{
         Foundation::*,
         System::{Com::*, Variant::*},
         UI::Accessibility::*,
     },
+    core::*,
 };
 
 use crate::{
@@ -1017,7 +1017,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode_Impl {
                             result = window_title(context.hwnd).into();
                         }
                         UIA_NativeWindowHandlePropertyId => {
-                            result = (context.hwnd.0 .0 as i32).into();
+                            result = (context.hwnd.0.0 as i32).into();
                         }
                         _ => (),
                     }

--- a/platforms/windows/src/subclass.rs
+++ b/platforms/windows/src/subclass.rs
@@ -10,8 +10,8 @@ use std::{
     mem::transmute,
 };
 use windows::{
-    core::*,
     Win32::{Foundation::*, UI::WindowsAndMessaging::*},
+    core::*,
 };
 
 use crate::{Adapter, QueuedEvents};
@@ -165,7 +165,9 @@ impl SubclassingAdapter {
         action_handler: impl 'static + ActionHandler + Send,
     ) -> Self {
         if unsafe { IsWindowVisible(hwnd) }.into() {
-            panic!("The AccessKit Windows subclassing adapter must be created before the window is shown (made visible) for the first time.");
+            panic!(
+                "The AccessKit Windows subclassing adapter must be created before the window is shown (made visible) for the first time."
+            );
         }
 
         let mut r#impl = SubclassImpl::new(hwnd, activation_handler, action_handler);

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -13,20 +13,20 @@ use std::{
 };
 use windows as Windows;
 use windows::{
-    core::*,
     Win32::{
         Foundation::*,
         Graphics::Gdi::ValidateRect,
         System::{Com::*, LibraryLoader::GetModuleHandleW},
         UI::{Accessibility::*, WindowsAndMessaging::*},
     },
+    core::*,
 };
 
 use crate::window_handle::WindowHandle;
 
 use super::{
-    context::{ActionHandlerNoMut, ActionHandlerWrapper},
     Adapter,
+    context::{ActionHandlerNoMut, ActionHandlerWrapper},
 };
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -56,13 +56,14 @@ struct WindowState {
 }
 
 unsafe fn get_window_state(window: HWND) -> *const WindowState {
-    GetWindowLongPtrW(window, GWLP_USERDATA) as _
+    unsafe { GetWindowLongPtrW(window, GWLP_USERDATA) as _ }
 }
 
 fn update_window_focus_state(window: HWND, is_focused: bool) {
     let state = unsafe { &*get_window_state(window) };
     let mut adapter = state.adapter.borrow_mut();
     if let Some(events) = adapter.update_window_focus_state(is_focused) {
+        drop(adapter);
         events.raise();
     }
 }

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -7,7 +7,7 @@ use accesskit::{
     Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, Tree, TreeId,
     TreeUpdate,
 };
-use windows::{core::*, Win32::UI::Accessibility::*};
+use windows::{Win32::UI::Accessibility::*, core::*};
 
 use super::*;
 

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -9,12 +9,12 @@ use accesskit::{
 };
 use once_cell::sync::Lazy;
 use windows::{
-    core::*,
     Win32::{
         Foundation::*,
         System::LibraryLoader::GetModuleHandleW,
         UI::{Accessibility::*, WindowsAndMessaging::*},
     },
+    core::*,
 };
 use winit::{
     application::ApplicationHandler,

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -11,11 +11,11 @@ use accesskit_consumer::{
 };
 use std::sync::{Arc, RwLock, Weak};
 use windows::{
-    core::*,
     Win32::{
         System::{Com::*, Variant::*},
         UI::Accessibility::*,
     },
+    core::*,
 };
 
 use crate::{context::Context, node::PlatformNode, util::*};

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -11,7 +11,6 @@ use std::{
     sync::{Arc, Weak},
 };
 use windows::{
-    core::*,
     Win32::{
         Foundation::*,
         Globalization::*,
@@ -19,6 +18,7 @@ use windows::{
         System::{Com::*, Ole::*, Variant::*},
         UI::{Accessibility::*, WindowsAndMessaging::*},
     },
+    core::*,
 };
 
 use crate::window_handle::WindowHandle;
@@ -351,10 +351,9 @@ pub(crate) fn toolkit_description(state: &TreeState) -> Option<WideString> {
 }
 
 pub(crate) fn upgrade<T>(weak: &Weak<T>) -> Result<Arc<T>> {
-    if let Some(strong) = weak.upgrade() {
-        Ok(strong)
-    } else {
-        Err(element_not_available())
+    match weak.upgrade() {
+        Some(strong) => Ok(strong),
+        _ => Err(element_not_available()),
     }
 }
 

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -303,9 +303,13 @@ impl ApplicationHandler<AccessKitEvent> for Application {
 fn main() -> Result<(), Box<dyn Error>> {
     println!("This example has no visible GUI, and a keyboard interface:");
     println!("- [Tab] switches focus between two logical buttons.");
-    println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
+    println!(
+        "- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed."
+    );
     #[cfg(target_os = "windows")]
-    println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
+    println!(
+        "Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows)."
+    );
     #[cfg(all(
         feature = "accesskit_unix",
         any(

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -278,9 +278,13 @@ impl ApplicationHandler<AccessKitEvent> for Application {
 fn main() -> Result<(), Box<dyn Error>> {
     println!("This example has no visible GUI, and a keyboard interface:");
     println!("- [Tab] switches focus between two logical buttons.");
-    println!("- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed.");
+    println!(
+        "- [Space] 'presses' the button, adding static text in a live region announcing that it was pressed."
+    );
     #[cfg(target_os = "windows")]
-    println!("Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows).");
+    println!(
+        "Enable Narrator with [Win]+[Ctrl]+[Enter] (or [Win]+[Enter] on older versions of Windows)."
+    );
     #[cfg(all(
         feature = "accesskit_unix",
         any(

--- a/platforms/winit/src/lib.rs
+++ b/platforms/winit/src/lib.rs
@@ -195,7 +195,9 @@ impl Adapter {
         deactivation_handler: impl 'static + DeactivationHandler + Send,
     ) -> Self {
         if window.is_visible() == Some(true) {
-            panic!("The AccessKit winit adapter must be created before the window is shown (made visible) for the first time.");
+            panic!(
+                "The AccessKit winit adapter must be created before the window is shown (made visible) for the first time."
+            );
         }
 
         let inner = platform_impl::Adapter::new(

--- a/platforms/winit/src/platform_impl/android.rs
+++ b/platforms/winit/src/platform_impl/android.rs
@@ -4,8 +4,8 @@
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, TreeUpdate};
 use accesskit_android::{
-    jni::{objects::JObject, JavaVM},
     InjectingAdapter,
+    jni::{JavaVM, objects::JObject},
 };
 use winit::{
     event::WindowEvent, event_loop::ActiveEventLoop, platform::android::ActiveEventLoopExtAndroid,

--- a/platforms/winit/src/platform_impl/windows.rs
+++ b/platforms/winit/src/platform_impl/windows.rs
@@ -7,7 +7,7 @@ use crate::raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 use crate::raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, TreeUpdate};
-use accesskit_windows::{SubclassingAdapter, HWND};
+use accesskit_windows::{HWND, SubclassingAdapter};
 use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::Window};
 
 pub struct Adapter {


### PR DESCRIPTION
`gen` is a reserved keyword now, lifetimes need to be more explicit and drop order changed. Formatting rules have changed slightly so I have kept them in a separate commit.