### PR TITLE
refactor!: Rename some accesskit and accesskit_consumer types

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2790,7 +2790,7 @@ impl JsonSchema for Properties {
 #[cfg_attr(feature = "schemars", derive(JsonSchema))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct Tree {
+pub struct TreeInfo {
     /// The identifier of the tree's root node.
     pub root: NodeId,
     /// The name of the UI toolkit in use.
@@ -2799,10 +2799,10 @@ pub struct Tree {
     pub toolkit_version: Option<String>,
 }
 
-impl Tree {
+impl TreeInfo {
     #[inline]
-    pub fn new(root: NodeId) -> Tree {
-        Tree {
+    pub fn new(root: NodeId) -> TreeInfo {
+        TreeInfo {
             root,
             toolkit_name: None,
             toolkit_version: None,
@@ -2853,7 +2853,7 @@ pub struct TreeUpdate {
     /// if it has not changed since the previous update, but providing the same
     /// information again is also allowed. This is required when initializing
     /// a tree.
-    pub tree: Option<Tree>,
+    pub tree: Option<TreeInfo>,
 
     /// The identifier of the tree that this update applies to.
     ///
@@ -3240,7 +3240,7 @@ mod tests {
 
     #[test]
     fn new_tree_should_have_root_id() {
-        let tree = Tree::new(NodeId(1));
+        let tree = TreeInfo::new(NodeId(1));
         assert_eq!(tree.root, NodeId(1));
         assert_eq!(tree.toolkit_name, None);
         assert_eq!(tree.toolkit_version, None);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -734,7 +734,7 @@ impl fmt::Debug for NodeId {
     }
 }
 
-/// The stable identity of a [`Tree`].
+/// The stable identity of a [`TreeInfo`].
 ///
 /// Use [`TreeId::ROOT`] for the main/root tree. For subtrees, use a random
 /// UUID (version 4) to avoid collisions between independently created trees.
@@ -2799,6 +2799,9 @@ pub struct TreeInfo {
     pub toolkit_version: Option<String>,
 }
 
+#[deprecated(note = "Use TreeInfo instead")]
+pub type Tree = TreeInfo;
+
 impl TreeInfo {
     #[inline]
     pub fn new(root: NodeId) -> TreeInfo {
@@ -2810,7 +2813,7 @@ impl TreeInfo {
     }
 }
 
-/// A serializable representation of an atomic change to a [`Tree`].
+/// A serializable representation of an atomic change to a [`TreeInfo`].
 ///
 /// The sender and receiver must be in sync; the update is only meant
 /// to bring the tree from a specific previous state into its next state.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -734,7 +734,7 @@ impl fmt::Debug for NodeId {
     }
 }
 
-/// The stable identity of a [`TreeInfo`].
+/// The stable identity of a tree.
 ///
 /// Use [`TreeId::ROOT`] for the main/root tree. For subtrees, use a random
 /// UUID (version 4) to avoid collisions between independently created trees.
@@ -2813,7 +2813,7 @@ impl TreeInfo {
     }
 }
 
-/// A serializable representation of an atomic change to a [`TreeInfo`].
+/// A serializable representation of an atomic change to a tree.
 ///
 /// The sender and receiver must be in sync; the update is only meant
 /// to bring the tree from a specific previous state into its next state.

--- a/consumer/src/filters.rs
+++ b/consumer/src/filters.rs
@@ -5,7 +5,7 @@
 
 use accesskit::{Rect, Role};
 
-use crate::node::Node;
+use crate::node::NodeRef;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FilterResult {
@@ -14,7 +14,7 @@ pub enum FilterResult {
     ExcludeSubtree,
 }
 
-fn common_filter_base(node: &Node) -> Option<FilterResult> {
+fn common_filter_base(node: &NodeRef) -> Option<FilterResult> {
     if node.is_focused() {
         return Some(FilterResult::Include);
     }
@@ -36,12 +36,12 @@ fn common_filter_base(node: &Node) -> Option<FilterResult> {
     None
 }
 
-fn common_filter_without_parent_checks(node: &Node) -> FilterResult {
+fn common_filter_without_parent_checks(node: &NodeRef) -> FilterResult {
     common_filter_base(node).unwrap_or(FilterResult::Include)
 }
 
 fn is_first_sibling_in_parent_bbox<'a>(
-    mut siblings: impl Iterator<Item = Node<'a>>,
+    mut siblings: impl Iterator<Item = NodeRef<'a>>,
     parent_bbox: Rect,
 ) -> bool {
     siblings.next().is_some_and(|sibling| {
@@ -51,7 +51,7 @@ fn is_first_sibling_in_parent_bbox<'a>(
     })
 }
 
-pub fn common_filter(node: &Node) -> FilterResult {
+pub fn common_filter(node: &NodeRef) -> FilterResult {
     if let Some(result) = common_filter_base(node) {
         return result;
     }
@@ -91,7 +91,7 @@ pub fn common_filter(node: &Node) -> FilterResult {
     FilterResult::Include
 }
 
-pub fn common_filter_with_root_exception(node: &Node) -> FilterResult {
+pub fn common_filter_with_root_exception(node: &NodeRef) -> FilterResult {
     if node.is_root() {
         return FilterResult::Include;
     }
@@ -100,7 +100,7 @@ pub fn common_filter_with_root_exception(node: &Node) -> FilterResult {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{Node, NodeId, Rect, Role, Tree, TreeId, TreeUpdate};
+    use accesskit::{Node, NodeId, Rect, Role, TreeId, TreeInfo, TreeUpdate};
     use alloc::vec;
 
     use super::{
@@ -128,7 +128,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -151,7 +151,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -174,7 +174,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(1),
         };
@@ -193,7 +193,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -218,7 +218,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -239,7 +239,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(1),
         };
@@ -259,7 +259,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::TextRun)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -345,7 +345,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -411,7 +411,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };

--- a/consumer/src/iterators.rs
+++ b/consumer/src/iterators.rs
@@ -10,25 +10,25 @@
 
 use core::iter::FusedIterator;
 
-use accesskit::NodeId as LocalNodeId;
+use accesskit::NodeId;
 
 use crate::{
     filters::FilterResult,
-    node::{Node, NodeId},
-    tree::State as TreeState,
+    node::{FullNodeId, NodeRef},
+    tree::TreeState,
 };
 
 /// Iterator over child NodeIds, handling both normal nodes and graft nodes.
 pub enum ChildIds<'a> {
     Normal {
-        parent_id: NodeId,
-        children: core::slice::Iter<'a, LocalNodeId>,
+        parent_id: FullNodeId,
+        children: core::slice::Iter<'a, NodeId>,
     },
-    Graft(Option<NodeId>),
+    Graft(Option<FullNodeId>),
 }
 
 impl Iterator for ChildIds<'_> {
-    type Item = NodeId;
+    type Item = FullNodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -80,12 +80,12 @@ pub struct FollowingSiblings<'a> {
     back_position: usize,
     done: bool,
     front_position: usize,
-    parent: Option<Node<'a>>,
-    node_id: NodeId,
+    parent: Option<NodeRef<'a>>,
+    node_id: FullNodeId,
 }
 
 impl<'a> FollowingSiblings<'a> {
-    pub(crate) fn new(node: Node<'a>) -> Self {
+    pub(crate) fn new(node: NodeRef<'a>) -> Self {
         let parent_and_index = node.parent_and_index();
         let (back_position, front_position, done) =
             if let Some((ref parent, index)) = parent_and_index {
@@ -115,7 +115,7 @@ impl<'a> FollowingSiblings<'a> {
 }
 
 impl Iterator for FollowingSiblings<'_> {
-    type Item = NodeId;
+    type Item = FullNodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -171,12 +171,12 @@ pub struct PrecedingSiblings<'a> {
     back_position: usize,
     done: bool,
     front_position: usize,
-    parent: Option<Node<'a>>,
-    node_id: NodeId,
+    parent: Option<NodeRef<'a>>,
+    node_id: FullNodeId,
 }
 
 impl<'a> PrecedingSiblings<'a> {
-    pub(crate) fn new(node: Node<'a>) -> Self {
+    pub(crate) fn new(node: NodeRef<'a>) -> Self {
         let parent_and_index = node.parent_and_index();
         let (back_position, front_position, done) =
             if let Some((ref parent, index)) = parent_and_index {
@@ -201,7 +201,7 @@ impl<'a> PrecedingSiblings<'a> {
 }
 
 impl Iterator for PrecedingSiblings<'_> {
-    type Item = NodeId;
+    type Item = FullNodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -253,9 +253,9 @@ impl ExactSizeIterator for PrecedingSiblings<'_> {}
 impl FusedIterator for PrecedingSiblings<'_> {}
 
 fn next_filtered_sibling<'a>(
-    node: Option<Node<'a>>,
-    filter: &impl Fn(&Node) -> FilterResult,
-) -> Option<Node<'a>> {
+    node: Option<NodeRef<'a>>,
+    filter: &impl Fn(&NodeRef) -> FilterResult,
+) -> Option<NodeRef<'a>> {
     let mut next = node;
     let mut consider_children = false;
     while let Some(current) = next {
@@ -294,9 +294,9 @@ fn next_filtered_sibling<'a>(
 }
 
 fn previous_filtered_sibling<'a>(
-    node: Option<Node<'a>>,
-    filter: &impl Fn(&Node) -> FilterResult,
-) -> Option<Node<'a>> {
+    node: Option<NodeRef<'a>>,
+    filter: &impl Fn(&NodeRef) -> FilterResult,
+) -> Option<NodeRef<'a>> {
     let mut previous = node;
     let mut consider_children = false;
     while let Some(current) = previous {
@@ -338,15 +338,15 @@ fn previous_filtered_sibling<'a>(
 /// specified filter.
 ///
 /// This struct is created by the [`following_filtered_siblings`](Node::following_filtered_siblings) method on [`Node`].
-pub struct FollowingFilteredSiblings<'a, Filter: Fn(&Node) -> FilterResult> {
+pub struct FollowingFilteredSiblings<'a, Filter: Fn(&NodeRef) -> FilterResult> {
     filter: Filter,
-    back: Option<Node<'a>>,
+    back: Option<NodeRef<'a>>,
     done: bool,
-    front: Option<Node<'a>>,
+    front: Option<NodeRef<'a>>,
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> FollowingFilteredSiblings<'a, Filter> {
-    pub(crate) fn new(node: Node<'a>, filter: Filter) -> Self {
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> FollowingFilteredSiblings<'a, Filter> {
+    pub(crate) fn new(node: NodeRef<'a>, filter: Filter) -> Self {
         let front = next_filtered_sibling(Some(node), &filter);
         let back = node
             .filtered_parent(&filter)
@@ -360,8 +360,8 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> FollowingFilteredSiblings<'a, Filter
     }
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for FollowingFilteredSiblings<'a, Filter> {
-    type Item = Node<'a>;
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> Iterator for FollowingFilteredSiblings<'a, Filter> {
+    type Item = NodeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -380,7 +380,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for FollowingFilteredSiblin
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator
+impl<Filter: Fn(&NodeRef) -> FilterResult> DoubleEndedIterator
     for FollowingFilteredSiblings<'_, Filter>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -400,21 +400,21 @@ impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> FusedIterator for FollowingFilteredSiblings<'_, Filter> {}
+impl<Filter: Fn(&NodeRef) -> FilterResult> FusedIterator for FollowingFilteredSiblings<'_, Filter> {}
 
 /// An iterator that yields preceding siblings of a node according to the
 /// specified filter.
 ///
 /// This struct is created by the [`preceding_filtered_siblings`](Node::preceding_filtered_siblings) method on [`Node`].
-pub struct PrecedingFilteredSiblings<'a, Filter: Fn(&Node) -> FilterResult> {
+pub struct PrecedingFilteredSiblings<'a, Filter: Fn(&NodeRef) -> FilterResult> {
     filter: Filter,
-    back: Option<Node<'a>>,
+    back: Option<NodeRef<'a>>,
     done: bool,
-    front: Option<Node<'a>>,
+    front: Option<NodeRef<'a>>,
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> PrecedingFilteredSiblings<'a, Filter> {
-    pub(crate) fn new(node: Node<'a>, filter: Filter) -> Self {
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> PrecedingFilteredSiblings<'a, Filter> {
+    pub(crate) fn new(node: NodeRef<'a>, filter: Filter) -> Self {
         let front = previous_filtered_sibling(Some(node), &filter);
         let back = node
             .filtered_parent(&filter)
@@ -428,8 +428,8 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> PrecedingFilteredSiblings<'a, Filter
     }
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for PrecedingFilteredSiblings<'a, Filter> {
-    type Item = Node<'a>;
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> Iterator for PrecedingFilteredSiblings<'a, Filter> {
+    type Item = NodeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -448,7 +448,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for PrecedingFilteredSiblin
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator
+impl<Filter: Fn(&NodeRef) -> FilterResult> DoubleEndedIterator
     for PrecedingFilteredSiblings<'_, Filter>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -468,21 +468,21 @@ impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> FusedIterator for PrecedingFilteredSiblings<'_, Filter> {}
+impl<Filter: Fn(&NodeRef) -> FilterResult> FusedIterator for PrecedingFilteredSiblings<'_, Filter> {}
 
 /// An iterator that yields children of a node according to the specified
 /// filter.
 ///
 /// This struct is created by the [`filtered_children`](Node::filtered_children) method on [`Node`].
-pub struct FilteredChildren<'a, Filter: Fn(&Node) -> FilterResult> {
+pub struct FilteredChildren<'a, Filter: Fn(&NodeRef) -> FilterResult> {
     filter: Filter,
-    back: Option<Node<'a>>,
+    back: Option<NodeRef<'a>>,
     done: bool,
-    front: Option<Node<'a>>,
+    front: Option<NodeRef<'a>>,
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> FilteredChildren<'a, Filter> {
-    pub(crate) fn new(node: Node<'a>, filter: Filter) -> Self {
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> FilteredChildren<'a, Filter> {
+    pub(crate) fn new(node: NodeRef<'a>, filter: Filter) -> Self {
         let front = node.first_filtered_child(&filter);
         let back = node.last_filtered_child(&filter);
         Self {
@@ -494,8 +494,8 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> FilteredChildren<'a, Filter> {
     }
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for FilteredChildren<'a, Filter> {
-    type Item = Node<'a>;
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> Iterator for FilteredChildren<'a, Filter> {
+    type Item = NodeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done {
@@ -514,7 +514,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for FilteredChildren<'a, Fi
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator for FilteredChildren<'_, Filter> {
+impl<Filter: Fn(&NodeRef) -> FilterResult> DoubleEndedIterator for FilteredChildren<'_, Filter> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.done {
             None
@@ -532,19 +532,19 @@ impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator for FilteredChildren
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> FusedIterator for FilteredChildren<'_, Filter> {}
+impl<Filter: Fn(&NodeRef) -> FilterResult> FusedIterator for FilteredChildren<'_, Filter> {}
 
-pub(crate) enum LabelledBy<'a, Filter: Fn(&Node) -> FilterResult> {
+pub(crate) enum LabelledBy<'a, Filter: Fn(&NodeRef) -> FilterResult> {
     FromDescendants(FilteredChildren<'a, Filter>),
     Explicit {
-        ids: core::slice::Iter<'a, LocalNodeId>,
+        ids: core::slice::Iter<'a, NodeId>,
         tree_state: &'a TreeState,
-        node_id: NodeId,
+        node_id: FullNodeId,
     },
 }
 
-impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for LabelledBy<'a, Filter> {
-    type Item = Node<'a>;
+impl<'a, Filter: Fn(&NodeRef) -> FilterResult> Iterator for LabelledBy<'a, Filter> {
+    type Item = NodeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -567,7 +567,7 @@ impl<'a, Filter: Fn(&Node) -> FilterResult> Iterator for LabelledBy<'a, Filter> 
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator for LabelledBy<'_, Filter> {
+impl<Filter: Fn(&NodeRef) -> FilterResult> DoubleEndedIterator for LabelledBy<'_, Filter> {
     fn next_back(&mut self) -> Option<Self::Item> {
         match self {
             Self::FromDescendants(iter) => iter.next_back(),
@@ -582,17 +582,17 @@ impl<Filter: Fn(&Node) -> FilterResult> DoubleEndedIterator for LabelledBy<'_, F
     }
 }
 
-impl<Filter: Fn(&Node) -> FilterResult> FusedIterator for LabelledBy<'_, Filter> {}
+impl<Filter: Fn(&NodeRef) -> FilterResult> FusedIterator for LabelledBy<'_, Filter> {}
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        NodeId,
+        FullNodeId,
         filters::common_filter,
         tests::*,
         tree::{ChangeHandler, TreeIndex},
     };
-    use accesskit::{Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate, Uuid};
+    use accesskit::{Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate, Uuid};
     use alloc::{vec, vec::Vec};
 
     #[test]
@@ -611,7 +611,7 @@ mod tests {
                 .unwrap()
                 .following_sibling_ids()
                 .map(|id| id.to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             3,
@@ -661,7 +661,7 @@ mod tests {
                 .following_sibling_ids()
                 .rev()
                 .map(|id| id.to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -685,7 +685,7 @@ mod tests {
                 .unwrap()
                 .preceding_sibling_ids()
                 .map(|id| id.to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             3,
@@ -731,7 +731,7 @@ mod tests {
                 .preceding_sibling_ids()
                 .rev()
                 .map(|id| id.to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -760,7 +760,7 @@ mod tests {
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             [BUTTON_3_2_ID],
@@ -769,7 +769,7 @@ mod tests {
                 .unwrap()
                 .following_filtered_siblings(test_tree_filter)
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -799,7 +799,7 @@ mod tests {
                 .following_filtered_siblings(test_tree_filter)
                 .rev()
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             [BUTTON_3_2_ID,],
@@ -809,7 +809,7 @@ mod tests {
                 .following_filtered_siblings(test_tree_filter)
                 .rev()
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -838,7 +838,7 @@ mod tests {
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             [PARAGRAPH_2_ID, LABEL_1_1_ID, PARAGRAPH_0_ID],
@@ -847,7 +847,7 @@ mod tests {
                 .unwrap()
                 .preceding_filtered_siblings(test_tree_filter)
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -877,7 +877,7 @@ mod tests {
                 .preceding_filtered_siblings(test_tree_filter)
                 .rev()
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert_eq!(
             [PARAGRAPH_0_ID, LABEL_1_1_ID, PARAGRAPH_2_ID],
@@ -887,7 +887,7 @@ mod tests {
                 .preceding_filtered_siblings(test_tree_filter)
                 .rev()
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -914,7 +914,7 @@ mod tests {
                 .root()
                 .filtered_children(test_tree_filter)
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -950,7 +950,7 @@ mod tests {
                 .filtered_children(test_tree_filter)
                 .rev()
                 .map(|node| node.id().to_components().0)
-                .collect::<Vec<LocalNodeId>>()[..]
+                .collect::<Vec<NodeId>>()[..]
         );
         assert!(
             tree.state()
@@ -976,24 +976,24 @@ mod tests {
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id);
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = crate::Tree::new(update, false);
 
-        let graft_node_id = NodeId::new(LocalNodeId(1), TreeIndex(0));
+        let graft_node_id = FullNodeId::new(NodeId(1), TreeIndex(0));
         let graft_node = tree.state().node_by_id(graft_node_id).unwrap();
         assert!(graft_node.filtered_children(common_filter).next().is_none());
     }
@@ -1002,45 +1002,45 @@ mod tests {
     fn filtered_children_crosses_subtree_boundary() {
         struct NoOpHandler;
         impl ChangeHandler for NoOpHandler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let subtree_id = TreeId(Uuid::from_u128(1));
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id);
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = crate::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -1048,13 +1048,13 @@ mod tests {
         let filtered_children: Vec<_> = root.filtered_children(common_filter).collect();
 
         assert_eq!(1, filtered_children.len());
-        let subtree_root_id = NodeId::new(LocalNodeId(0), TreeIndex(1));
+        let subtree_root_id = FullNodeId::new(NodeId(0), TreeIndex(1));
         assert_eq!(subtree_root_id, filtered_children[0].id());
 
         let document = &filtered_children[0];
         let doc_children: Vec<_> = document.filtered_children(common_filter).collect();
         assert_eq!(1, doc_children.len());
-        let button_id = NodeId::new(LocalNodeId(1), TreeIndex(1));
+        let button_id = FullNodeId::new(NodeId(1), TreeIndex(1));
         assert_eq!(button_id, doc_children[0].id());
     }
 }

--- a/consumer/src/lib.rs
+++ b/consumer/src/lib.rs
@@ -8,10 +8,10 @@
 extern crate alloc;
 
 pub(crate) mod tree;
-pub use tree::{ChangeHandler as TreeChangeHandler, State as TreeState, Tree};
+pub use tree::{ChangeHandler as TreeChangeHandler, Tree, TreeState};
 
 pub(crate) mod node;
-pub use node::{Node, NodeId};
+pub use node::{FullNodeId, NodeRef};
 
 pub(crate) mod filters;
 pub use filters::{FilterResult, common_filter, common_filter_with_root_exception};
@@ -26,36 +26,34 @@ pub use text::{
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{
-        Affine, Node, NodeId as LocalNodeId, Rect, Role, Tree, TreeId, TreeUpdate, Vec2,
-    };
+    use accesskit::{Affine, Node, NodeId, Rect, Role, TreeId, TreeInfo, TreeUpdate, Vec2};
     use alloc::vec;
 
     use crate::FilterResult;
-    use crate::node::NodeId;
+    use crate::node::FullNodeId;
     use crate::tree::TreeIndex;
 
-    pub fn nid(id: LocalNodeId) -> NodeId {
-        NodeId::new(id, TreeIndex(0))
+    pub fn nid(id: NodeId) -> FullNodeId {
+        FullNodeId::new(id, TreeIndex(0))
     }
 
-    pub const ROOT_ID: LocalNodeId = LocalNodeId(0);
-    pub const PARAGRAPH_0_ID: LocalNodeId = LocalNodeId(1);
-    pub const LABEL_0_0_IGNORED_ID: LocalNodeId = LocalNodeId(2);
-    pub const PARAGRAPH_1_IGNORED_ID: LocalNodeId = LocalNodeId(3);
-    pub const BUTTON_1_0_HIDDEN_ID: LocalNodeId = LocalNodeId(4);
-    pub const CONTAINER_1_0_0_HIDDEN_ID: LocalNodeId = LocalNodeId(5);
-    pub const LABEL_1_1_ID: LocalNodeId = LocalNodeId(6);
-    pub const BUTTON_1_2_HIDDEN_ID: LocalNodeId = LocalNodeId(7);
-    pub const CONTAINER_1_2_0_HIDDEN_ID: LocalNodeId = LocalNodeId(8);
-    pub const PARAGRAPH_2_ID: LocalNodeId = LocalNodeId(9);
-    pub const LABEL_2_0_ID: LocalNodeId = LocalNodeId(10);
-    pub const PARAGRAPH_3_IGNORED_ID: LocalNodeId = LocalNodeId(11);
-    pub const EMPTY_CONTAINER_3_0_IGNORED_ID: LocalNodeId = LocalNodeId(12);
-    pub const LINK_3_1_IGNORED_ID: LocalNodeId = LocalNodeId(13);
-    pub const LABEL_3_1_0_ID: LocalNodeId = LocalNodeId(14);
-    pub const BUTTON_3_2_ID: LocalNodeId = LocalNodeId(15);
-    pub const EMPTY_CONTAINER_3_3_IGNORED_ID: LocalNodeId = LocalNodeId(16);
+    pub const ROOT_ID: NodeId = NodeId(0);
+    pub const PARAGRAPH_0_ID: NodeId = NodeId(1);
+    pub const LABEL_0_0_IGNORED_ID: NodeId = NodeId(2);
+    pub const PARAGRAPH_1_IGNORED_ID: NodeId = NodeId(3);
+    pub const BUTTON_1_0_HIDDEN_ID: NodeId = NodeId(4);
+    pub const CONTAINER_1_0_0_HIDDEN_ID: NodeId = NodeId(5);
+    pub const LABEL_1_1_ID: NodeId = NodeId(6);
+    pub const BUTTON_1_2_HIDDEN_ID: NodeId = NodeId(7);
+    pub const CONTAINER_1_2_0_HIDDEN_ID: NodeId = NodeId(8);
+    pub const PARAGRAPH_2_ID: NodeId = NodeId(9);
+    pub const LABEL_2_0_ID: NodeId = NodeId(10);
+    pub const PARAGRAPH_3_IGNORED_ID: NodeId = NodeId(11);
+    pub const EMPTY_CONTAINER_3_0_IGNORED_ID: NodeId = NodeId(12);
+    pub const LINK_3_1_IGNORED_ID: NodeId = NodeId(13);
+    pub const LABEL_3_1_0_ID: NodeId = NodeId(14);
+    pub const BUTTON_3_2_ID: NodeId = NodeId(15);
+    pub const EMPTY_CONTAINER_3_3_IGNORED_ID: NodeId = NodeId(16);
 
     pub fn test_tree() -> crate::tree::Tree {
         let root = {
@@ -186,14 +184,14 @@ mod tests {
                 (BUTTON_3_2_ID, button_3_2),
                 (EMPTY_CONTAINER_3_3_IGNORED_ID, empty_container_3_3_ignored),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
         crate::tree::Tree::new(initial_update, false)
     }
 
-    pub fn test_tree_filter(node: &crate::Node) -> FilterResult {
+    pub fn test_tree_filter(node: &crate::NodeRef) -> FilterResult {
         let id = node.id();
         if node.is_hidden() {
             FilterResult::ExcludeSubtree

--- a/consumer/src/node.rs
+++ b/consumer/src/node.rs
@@ -9,8 +9,8 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    Action, Affine, AriaCurrent, HasPopup, Live, Node as NodeData, NodeId as LocalNodeId,
-    Orientation, Point, Rect, Role, SortDirection, TextSelection, Toggled, TreeId,
+    Action, Affine, AriaCurrent, HasPopup, Live, Node, NodeId, Orientation, Point, Rect, Role,
+    SortDirection, TextSelection, Toggled, TreeId,
 };
 use alloc::{
     string::{String, ToString},
@@ -24,27 +24,27 @@ use crate::iterators::{
     ChildIds, FilteredChildren, FollowingFilteredSiblings, FollowingSiblings, LabelledBy,
     PrecedingFilteredSiblings, PrecedingSiblings,
 };
-use crate::tree::{State as TreeState, TreeIndex};
+use crate::tree::{TreeIndex, TreeState};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct NodeId(TreeIndex, LocalNodeId);
+pub struct FullNodeId(TreeIndex, NodeId);
 
-impl NodeId {
-    pub(crate) fn new(local_id: LocalNodeId, tree_index: TreeIndex) -> Self {
+impl FullNodeId {
+    pub(crate) fn new(local_id: NodeId, tree_index: TreeIndex) -> Self {
         Self(tree_index, local_id)
     }
 
-    pub(crate) fn with_same_tree(&self, local_id: LocalNodeId) -> Self {
+    pub(crate) fn with_same_tree(&self, local_id: NodeId) -> Self {
         Self(self.0, local_id)
     }
 
-    pub(crate) fn to_components(self) -> (LocalNodeId, TreeIndex) {
+    pub(crate) fn to_components(self) -> (NodeId, TreeIndex) {
         (self.1, self.0)
     }
 }
 
-impl From<NodeId> for u128 {
-    fn from(id: NodeId) -> Self {
+impl From<FullNodeId> for u128 {
+    fn from(id: FullNodeId) -> Self {
         let tree_index = id.0.0 as u128;
         let local_id = id.1.0 as u128;
         (local_id << 64) | tree_index
@@ -52,23 +52,23 @@ impl From<NodeId> for u128 {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) struct ParentAndIndex(pub(crate) NodeId, pub(crate) usize);
+pub(crate) struct ParentAndIndex(pub(crate) FullNodeId, pub(crate) usize);
 
 #[derive(Clone, Debug)]
 pub(crate) struct NodeState {
     pub(crate) parent_and_index: Option<ParentAndIndex>,
-    pub(crate) data: NodeData,
+    pub(crate) data: Node,
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct Node<'a> {
+pub struct NodeRef<'a> {
     pub tree_state: &'a TreeState,
-    pub(crate) id: NodeId,
+    pub(crate) id: FullNodeId,
     pub(crate) state: &'a NodeState,
 }
 
-impl<'a> Node<'a> {
-    pub fn data(&self) -> &'a NodeData {
+impl<'a> NodeRef<'a> {
+    pub fn data(&self) -> &'a Node {
         &self.state.data
     }
 
@@ -94,7 +94,7 @@ impl<'a> Node<'a> {
         self.tree_state.focus == self.id()
     }
 
-    pub fn is_focusable(&self, parent_filter: &impl Fn(&Node) -> FilterResult) -> bool {
+    pub fn is_focusable(&self, parent_filter: &impl Fn(&NodeRef) -> FilterResult) -> bool {
         self.supports_action(Action::Focus, parent_filter) || self.is_focused_in_tree()
     }
 
@@ -109,19 +109,22 @@ impl<'a> Node<'a> {
         self.state.data.tree_id().is_some()
     }
 
-    pub fn parent_id(&self) -> Option<NodeId> {
+    pub fn parent_id(&self) -> Option<FullNodeId> {
         self.state
             .parent_and_index
             .as_ref()
             .map(|ParentAndIndex(id, _)| *id)
     }
 
-    pub fn parent(&self) -> Option<Node<'a>> {
+    pub fn parent(&self) -> Option<NodeRef<'a>> {
         self.parent_id()
             .map(|id| self.tree_state.node_by_id(id).unwrap())
     }
 
-    pub fn filtered_parent(&self, filter: &impl Fn(&Node) -> FilterResult) -> Option<Node<'a>> {
+    pub fn filtered_parent(
+        &self,
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         let mut current = self.parent()?;
         loop {
             if filter(&current) == FilterResult::Include {
@@ -131,7 +134,7 @@ impl<'a> Node<'a> {
         }
     }
 
-    pub fn parent_and_index(self) -> Option<(Node<'a>, usize)> {
+    pub fn parent_and_index(self) -> Option<(NodeRef<'a>, usize)> {
         self.state
             .parent_and_index
             .as_ref()
@@ -141,7 +144,7 @@ impl<'a> Node<'a> {
     }
 
     /// Returns the single child of a graft node (the subtree root), if available.
-    fn graft_child_id(&self) -> Option<NodeId> {
+    fn graft_child_id(&self) -> Option<FullNodeId> {
         self.state
             .data
             .tree_id()
@@ -150,7 +153,7 @@ impl<'a> Node<'a> {
 
     pub fn child_ids(
         &self,
-    ) -> impl DoubleEndedIterator<Item = NodeId> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = FullNodeId> + ExactSizeIterator + use<'a> {
         if self.is_graft() {
             ChildIds::Graft(self.graft_child_id())
         } else {
@@ -163,62 +166,62 @@ impl<'a> Node<'a> {
 
     pub fn children(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + ExactSizeIterator + use<'a> {
         let state = self.tree_state;
         self.child_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn filtered_children<F: Fn(&Node) -> FilterResult>(
+    pub fn filtered_children<F: Fn(&NodeRef) -> FilterResult>(
         &self,
         filter: F,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a, F> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a, F> {
         FilteredChildren::new(*self, filter)
     }
 
     pub fn following_sibling_ids(
         &self,
-    ) -> impl DoubleEndedIterator<Item = NodeId> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = FullNodeId> + ExactSizeIterator + use<'a> {
         FollowingSiblings::new(*self)
     }
 
     pub fn following_siblings(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + ExactSizeIterator + use<'a> {
         let state = self.tree_state;
         self.following_sibling_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn following_filtered_siblings<F: Fn(&Node) -> FilterResult>(
+    pub fn following_filtered_siblings<F: Fn(&NodeRef) -> FilterResult>(
         &self,
         filter: F,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a, F> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a, F> {
         FollowingFilteredSiblings::new(*self, filter)
     }
 
     pub fn preceding_sibling_ids(
         &self,
-    ) -> impl DoubleEndedIterator<Item = NodeId> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = FullNodeId> + ExactSizeIterator + use<'a> {
         PrecedingSiblings::new(*self)
     }
 
     pub fn preceding_siblings(
         &self,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + ExactSizeIterator + use<'a> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + ExactSizeIterator + use<'a> {
         let state = self.tree_state;
         self.preceding_sibling_ids()
             .map(move |id| state.node_by_id(id).unwrap())
     }
 
-    pub fn preceding_filtered_siblings<F: Fn(&Node) -> FilterResult>(
+    pub fn preceding_filtered_siblings<F: Fn(&NodeRef) -> FilterResult>(
         &self,
         filter: F,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a, F> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a, F> {
         PrecedingFilteredSiblings::new(*self, filter)
     }
 
-    pub fn deepest_first_child(self) -> Option<Node<'a>> {
+    pub fn deepest_first_child(self) -> Option<NodeRef<'a>> {
         let mut deepest_child = self.children().next()?;
         while let Some(first_child) = deepest_child.children().next() {
             deepest_child = first_child;
@@ -228,8 +231,8 @@ impl<'a> Node<'a> {
 
     pub fn deepest_first_filtered_child(
         &self,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<Node<'a>> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         let mut deepest_child = self.first_filtered_child(filter)?;
         while let Some(first_child) = deepest_child.first_filtered_child(filter) {
             deepest_child = first_child;
@@ -237,7 +240,7 @@ impl<'a> Node<'a> {
         Some(deepest_child)
     }
 
-    pub fn deepest_last_child(self) -> Option<Node<'a>> {
+    pub fn deepest_last_child(self) -> Option<NodeRef<'a>> {
         let mut deepest_child = self.children().next_back()?;
         while let Some(last_child) = deepest_child.children().next_back() {
             deepest_child = last_child;
@@ -247,8 +250,8 @@ impl<'a> Node<'a> {
 
     pub fn deepest_last_filtered_child(
         &self,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<Node<'a>> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         let mut deepest_child = self.last_filtered_child(filter)?;
         while let Some(last_child) = deepest_child.last_filtered_child(filter) {
             deepest_child = last_child;
@@ -256,7 +259,7 @@ impl<'a> Node<'a> {
         Some(deepest_child)
     }
 
-    pub fn is_descendant_of(&self, ancestor: &Node) -> bool {
+    pub fn is_descendant_of(&self, ancestor: &NodeRef) -> bool {
         let mut current = *self;
         loop {
             if current.id() == ancestor.id() {
@@ -289,7 +292,7 @@ impl<'a> Node<'a> {
         acc
     }
 
-    pub(crate) fn relative_transform(&self, stop_at: &Node) -> Affine {
+    pub(crate) fn relative_transform(&self, stop_at: &NodeRef) -> Affine {
         let mut acc = self.direct_transform();
         let mut current = *self;
         while let Some(parent) = current.parent() {
@@ -318,7 +321,7 @@ impl<'a> Node<'a> {
             .map(|rect| self.transform().transform_rect_bbox(*rect))
     }
 
-    pub(crate) fn bounding_box_in_coordinate_space(&self, other: &Node) -> Option<Rect> {
+    pub(crate) fn bounding_box_in_coordinate_space(&self, other: &NodeRef) -> Option<Rect> {
         self.raw_bounds()
             .as_ref()
             .map(|rect| self.relative_transform(other).transform_rect_bbox(*rect))
@@ -327,14 +330,14 @@ impl<'a> Node<'a> {
     pub(crate) fn hit_test(
         &self,
         point: Point,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<(Node<'a>, Point)> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<(NodeRef<'a>, Point)> {
         // A node's `Test` frame is pushed before its children, then children in
         // forward order, so that children are searched last-to-first and the
         // node's own bounds are tested only after all descendants miss.
         enum Frame<'n> {
-            Visit(Node<'n>, Point),
-            Test(Node<'n>, Point),
+            Visit(NodeRef<'n>, Point),
+            Test(NodeRef<'n>, Point),
         }
 
         let mut stack = Vec::with_capacity(self.children().len() + 1);
@@ -372,16 +375,16 @@ impl<'a> Node<'a> {
     pub fn node_at_point(
         &self,
         point: Point,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<Node<'a>> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         self.hit_test(point, filter).map(|(node, _)| node)
     }
 
-    pub fn id(&self) -> NodeId {
+    pub fn id(&self) -> FullNodeId {
         self.id
     }
 
-    pub fn locate(&self) -> (LocalNodeId, TreeId) {
+    pub fn locate(&self) -> (NodeId, TreeId) {
         self.tree_state.locate_node(self.id).unwrap()
     }
 
@@ -438,7 +441,7 @@ impl<'a> Node<'a> {
     }
 
     pub fn is_hidden(&self) -> bool {
-        self.fetch_inherited_flag(NodeData::is_hidden)
+        self.fetch_inherited_flag(Node::is_hidden)
     }
 
     pub fn level(&self) -> Option<usize> {
@@ -516,7 +519,7 @@ impl<'a> Node<'a> {
 
     pub(crate) fn fetch_inherited_property<T>(
         &self,
-        getter: fn(&'a NodeData) -> Option<T>,
+        getter: fn(&'a Node) -> Option<T>,
     ) -> Option<T> {
         let mut node = *self;
         loop {
@@ -528,7 +531,7 @@ impl<'a> Node<'a> {
         }
     }
 
-    pub(crate) fn fetch_inherited_flag(&self, getter: fn(&'a NodeData) -> bool) -> bool {
+    pub(crate) fn fetch_inherited_flag(&self, getter: fn(&'a Node) -> bool) -> bool {
         let mut node = *self;
         loop {
             if getter(node.data()) {
@@ -596,7 +599,7 @@ impl<'a> Node<'a> {
     // and we assume that it will based on the role, the attempted action
     // does nothing. This stance is a departure from Chromium.
 
-    pub fn is_clickable(&self, parent_filter: &impl Fn(&Node) -> FilterResult) -> bool {
+    pub fn is_clickable(&self, parent_filter: &impl Fn(&NodeRef) -> FilterResult) -> bool {
         self.supports_action(Action::Click, parent_filter)
     }
 
@@ -611,7 +614,7 @@ impl<'a> Node<'a> {
 
     pub fn size_of_set_from_container(
         &self,
-        filter: &impl Fn(&Node) -> FilterResult,
+        filter: &impl Fn(&NodeRef) -> FilterResult,
     ) -> Option<usize> {
         let mut parent = self.filtered_parent(filter);
         while let Some(node) = parent {
@@ -650,7 +653,7 @@ impl<'a> Node<'a> {
             )
     }
 
-    pub fn is_invocable(&self, parent_filter: &impl Fn(&Node) -> FilterResult) -> bool {
+    pub fn is_invocable(&self, parent_filter: &impl Fn(&NodeRef) -> FilterResult) -> bool {
         // A control is "invocable" if it initiates an action when activated but
         // does not maintain any state. A control that maintains state
         // when activated would be considered a toggle or expand-collapse
@@ -670,7 +673,7 @@ impl<'a> Node<'a> {
     pub fn supports_action(
         &self,
         action: Action,
-        parent_filter: &impl Fn(&Node) -> FilterResult,
+        parent_filter: &impl Fn(&NodeRef) -> FilterResult,
     ) -> bool {
         if self.data().supports_action(action) {
             return true;
@@ -681,16 +684,16 @@ impl<'a> Node<'a> {
         false
     }
 
-    pub fn supports_increment(&self, parent_filter: &impl Fn(&Node) -> FilterResult) -> bool {
+    pub fn supports_increment(&self, parent_filter: &impl Fn(&NodeRef) -> FilterResult) -> bool {
         self.supports_action(Action::Increment, parent_filter)
     }
 
-    pub fn supports_decrement(&self, parent_filter: &impl Fn(&Node) -> FilterResult) -> bool {
+    pub fn supports_decrement(&self, parent_filter: &impl Fn(&NodeRef) -> FilterResult) -> bool {
         self.supports_action(Action::Decrement, parent_filter)
     }
 }
 
-fn descendant_label_filter(node: &Node) -> FilterResult {
+fn descendant_label_filter(node: &NodeRef) -> FilterResult {
     match node.role() {
         Role::Label | Role::Image => FilterResult::Include,
         Role::GenericContainer => FilterResult::ExcludeNode,
@@ -698,8 +701,8 @@ fn descendant_label_filter(node: &Node) -> FilterResult {
     }
 }
 
-impl<'a> Node<'a> {
-    pub fn labelled_by(&self) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a> {
+impl<'a> NodeRef<'a> {
+    pub fn labelled_by(&self) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a> {
         let explicit = &self.state.data.labelled_by();
         if explicit.is_empty()
             && matches!(
@@ -937,7 +940,7 @@ impl<'a> Node<'a> {
         )
     }
 
-    pub fn controls(&self) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a> {
+    pub fn controls(&self) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a> {
         let state = self.tree_state;
         let id = self.id;
         let data = &self.state.data;
@@ -946,7 +949,7 @@ impl<'a> Node<'a> {
             .map(move |control_id| state.node_by_id(id.with_same_tree(*control_id)).unwrap())
     }
 
-    pub fn active_descendant(&self) -> Option<Node<'a>> {
+    pub fn active_descendant(&self) -> Option<NodeRef<'a>> {
         self.state
             .data
             .active_descendant()
@@ -973,7 +976,7 @@ impl<'a> Node<'a> {
         self.relative_index_path(self.tree_state.root_id())
     }
 
-    pub fn relative_index_path(&self, ancestor_id: NodeId) -> Vec<usize> {
+    pub fn relative_index_path(&self, ancestor_id: FullNodeId) -> Vec<usize> {
         let mut result = Vec::new();
         let mut current = *self;
         while current.id() != ancestor_id {
@@ -987,8 +990,8 @@ impl<'a> Node<'a> {
 
     pub(crate) fn first_filtered_child(
         &self,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<Node<'a>> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         let mut stack = vec![self.children()];
         while let Some(iter) = stack.last_mut() {
             if let Some(child) = iter.next() {
@@ -1006,8 +1009,8 @@ impl<'a> Node<'a> {
 
     pub(crate) fn last_filtered_child(
         &self,
-        filter: &impl Fn(&Node) -> FilterResult,
-    ) -> Option<Node<'a>> {
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         let mut stack = vec![self.children().rev()];
         while let Some(iter) = stack.last_mut() {
             if let Some(child) = iter.next() {
@@ -1023,7 +1026,10 @@ impl<'a> Node<'a> {
         None
     }
 
-    pub fn selection_container(&self, filter: &impl Fn(&Node) -> FilterResult) -> Option<Node<'a>> {
+    pub fn selection_container(
+        &self,
+        filter: &impl Fn(&NodeRef) -> FilterResult,
+    ) -> Option<NodeRef<'a>> {
         self.filtered_parent(&|parent| match filter(parent) {
             FilterResult::Include if parent.is_container_with_selectable_children() => {
                 FilterResult::Include
@@ -1033,10 +1039,10 @@ impl<'a> Node<'a> {
         })
     }
 
-    pub fn items<F: Fn(&Node) -> FilterResult>(
+    pub fn items<F: Fn(&NodeRef) -> FilterResult>(
         &self,
         filter: F,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a, F> {
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a, F> {
         self.filtered_children(move |child| match filter(child) {
             FilterResult::Include if child.is_item_like() => FilterResult::Include,
             FilterResult::Include => FilterResult::ExcludeNode,
@@ -1076,7 +1082,7 @@ impl<W: fmt::Write> fmt::Write for SpacePrefixingWriter<W> {
 mod tests {
     use accesskit::{
         Action, Affine, Node, NodeId, Point, Rect, Role, TextDirection, TextPosition,
-        TextSelection, Tree, TreeId, TreeUpdate, Vec2,
+        TextSelection, TreeId, TreeInfo, TreeUpdate, Vec2,
     };
     use alloc::vec;
 
@@ -1498,7 +1504,7 @@ mod tests {
                 }),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -1544,7 +1550,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         };
@@ -1695,7 +1701,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
@@ -1803,7 +1809,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: TEXT_INPUT_ID,
         };
@@ -1872,7 +1878,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: TEXT_INPUT_ID,
         };
@@ -1911,7 +1917,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
@@ -1920,15 +1926,15 @@ mod tests {
     }
 
     mod node_id {
-        use super::NodeId as LocalNodeId;
-        use crate::node::NodeId;
+        use super::NodeId;
+        use crate::node::FullNodeId;
         use crate::tree::TreeIndex;
 
         #[test]
         fn new_and_to_components_round_trip() {
-            let node_id = LocalNodeId(42);
+            let node_id = NodeId(42);
             let tree_index = TreeIndex(7);
-            let id = NodeId::new(node_id, tree_index);
+            let id = FullNodeId::new(node_id, tree_index);
             let (extracted_node_id, extracted_tree_index) = id.to_components();
             assert_eq!(node_id, extracted_node_id);
             assert_eq!(tree_index, extracted_tree_index);
@@ -1936,11 +1942,11 @@ mod tests {
 
         #[test]
         fn with_same_tree_preserves_tree_index() {
-            let original_node_id = LocalNodeId(100);
+            let original_node_id = NodeId(100);
             let tree_index = TreeIndex(5);
-            let id = NodeId::new(original_node_id, tree_index);
+            let id = FullNodeId::new(original_node_id, tree_index);
 
-            let new_node_id = LocalNodeId(200);
+            let new_node_id = NodeId(200);
             let new_id = id.with_same_tree(new_node_id);
 
             let (extracted_node_id, extracted_tree_index) = new_id.to_components();
@@ -1950,9 +1956,9 @@ mod tests {
 
         #[test]
         fn into_u128() {
-            let node_id = LocalNodeId(12345);
+            let node_id = NodeId(12345);
             let tree_index = TreeIndex(67);
-            let id = NodeId::new(node_id, tree_index);
+            let id = FullNodeId::new(node_id, tree_index);
             let (extracted_node_id, extracted_tree_index) = id.to_components();
             assert_eq!(node_id, extracted_node_id);
             assert_eq!(tree_index, extracted_tree_index);
@@ -1960,10 +1966,10 @@ mod tests {
 
         #[test]
         fn equality() {
-            let id1 = NodeId::new(LocalNodeId(1), TreeIndex(2));
-            let id2 = NodeId::new(LocalNodeId(1), TreeIndex(2));
-            let id3 = NodeId::new(LocalNodeId(1), TreeIndex(3));
-            let id4 = NodeId::new(LocalNodeId(2), TreeIndex(2));
+            let id1 = FullNodeId::new(NodeId(1), TreeIndex(2));
+            let id2 = FullNodeId::new(NodeId(1), TreeIndex(2));
+            let id3 = FullNodeId::new(NodeId(1), TreeIndex(3));
+            let id4 = FullNodeId::new(NodeId(2), TreeIndex(2));
 
             assert_eq!(id1, id2);
             assert_ne!(id1, id3);
@@ -1985,7 +1991,7 @@ mod tests {
                 }),
                 (BUTTON_ID, Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: BUTTON_ID,
         };
@@ -2012,7 +2018,7 @@ mod tests {
                 }),
                 (BUTTON_ID, Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
@@ -2047,7 +2053,7 @@ mod tests {
                 }),
                 (ITEM_ID, Node::new(Role::ListBoxOption)),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: LISTBOX_ID,
         };
@@ -2076,7 +2082,7 @@ mod tests {
                 }),
                 (ITEM_ID, Node::new(Role::ListBoxOption)),
             ],
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: LISTBOX_ID,
         };

--- a/consumer/src/text.rs
+++ b/consumer/src/text.rs
@@ -4,22 +4,22 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Color, Node as NodeData, Point, Rect, Role, TextAlign, TextDecoration, TextDirection,
+    Color, Node, Point, Rect, Role, TextAlign, TextDecoration, TextDirection,
     TextPosition as WeakPosition, TextSelection, VerticalOffset,
 };
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, fmt};
 
-use crate::{FilterResult, Node, TreeState, node::NodeId};
+use crate::{FilterResult, NodeRef, TreeState, node::FullNodeId};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct InnerPosition<'a> {
-    pub(crate) node: Node<'a>,
+    pub(crate) node: NodeRef<'a>,
     pub(crate) character_index: usize,
 }
 
 impl<'a> InnerPosition<'a> {
-    fn upgrade(tree_state: &'a TreeState, weak: WeakPosition, node_id: NodeId) -> Option<Self> {
+    fn upgrade(tree_state: &'a TreeState, weak: WeakPosition, node_id: FullNodeId) -> Option<Self> {
         let node = tree_state.node_by_id(node_id.with_same_tree(weak.node))?;
         if node.role() != Role::TextRun {
             return None;
@@ -37,7 +37,7 @@ impl<'a> InnerPosition<'a> {
     fn clamped_upgrade(
         tree_state: &'a TreeState,
         weak: WeakPosition,
-        node_id: NodeId,
+        node_id: FullNodeId,
     ) -> Option<Self> {
         let node = tree_state.node_by_id(node_id.with_same_tree(weak.node))?;
         if node.role() != Role::TextRun {
@@ -72,15 +72,15 @@ impl<'a> InnerPosition<'a> {
         self.is_line_end() && self.node.data().value().unwrap().ends_with('\n')
     }
 
-    fn is_document_start(&self, root_node: &Node) -> bool {
+    fn is_document_start(&self, root_node: &NodeRef) -> bool {
         self.is_run_start() && self.node.preceding_text_runs(root_node).next().is_none()
     }
 
-    fn is_document_end(&self, root_node: &Node) -> bool {
+    fn is_document_end(&self, root_node: &NodeRef) -> bool {
         self.is_run_end() && self.node.following_text_runs(root_node).next().is_none()
     }
 
-    fn biased_to_start(&self, root_node: &Node) -> Self {
+    fn biased_to_start(&self, root_node: &NodeRef) -> Self {
         if self.is_run_end() {
             if let Some(node) = self.node.following_text_runs(root_node).next() {
                 return Self {
@@ -92,7 +92,7 @@ impl<'a> InnerPosition<'a> {
         *self
     }
 
-    fn biased_to_end(&self, root_node: &Node) -> Self {
+    fn biased_to_end(&self, root_node: &NodeRef) -> Self {
         if self.is_run_start() {
             if let Some(node) = self.node.preceding_text_runs(root_node).next() {
                 return Self {
@@ -104,7 +104,7 @@ impl<'a> InnerPosition<'a> {
         *self
     }
 
-    fn comparable(&self, root_node: &Node) -> (Vec<usize>, usize) {
+    fn comparable(&self, root_node: &NodeRef) -> (Vec<usize>, usize) {
         let normalized = self.biased_to_start(root_node);
         (
             normalized.node.relative_index_path(root_node.id()),
@@ -159,7 +159,7 @@ impl Eq for InnerPosition<'_> {}
 
 #[derive(Clone, Copy, Debug)]
 pub struct Position<'a> {
-    root_node: Node<'a>,
+    root_node: NodeRef<'a>,
     pub(crate) inner: InnerPosition<'a>,
 }
 
@@ -168,7 +168,7 @@ impl<'a> Position<'a> {
         self.inner.downgrade()
     }
 
-    pub fn inner_node(&self) -> &Node<'a> {
+    pub fn inner_node(&self) -> &NodeRef<'a> {
         &self.inner.node
     }
 
@@ -611,20 +611,20 @@ impl<T: alloc::fmt::Debug + PartialEq> RangePropertyValue<Option<T>> {
 
 #[derive(Clone, Copy)]
 pub struct Range<'a> {
-    pub(crate) node: Node<'a>,
+    pub(crate) node: NodeRef<'a>,
     pub(crate) start: InnerPosition<'a>,
     pub(crate) end: InnerPosition<'a>,
 }
 
 impl<'a> Range<'a> {
-    fn new(node: Node<'a>, mut start: InnerPosition<'a>, mut end: InnerPosition<'a>) -> Self {
+    fn new(node: NodeRef<'a>, mut start: InnerPosition<'a>, mut end: InnerPosition<'a>) -> Self {
         if start.comparable(&node) > end.comparable(&node) {
             core::mem::swap(&mut start, &mut end);
         }
         Self { node, start, end }
     }
 
-    pub fn node(&self) -> &Node<'a> {
+    pub fn node(&self) -> &NodeRef<'a> {
         &self.node
     }
 
@@ -648,7 +648,7 @@ impl<'a> Range<'a> {
 
     fn walk<F, T>(&self, mut f: F) -> Option<T>
     where
-        F: FnMut(&Node<'a>) -> Option<T>,
+        F: FnMut(&NodeRef<'a>) -> Option<T>,
     {
         // If the range is degenerate, we don't want to normalize it.
         // This is important e.g. when getting the bounding rectangle
@@ -679,7 +679,7 @@ impl<'a> Range<'a> {
 
     pub fn traverse_text<F, T>(&self, mut f: F) -> Option<T>
     where
-        F: FnMut(&Node<'a>, &str) -> Option<T>,
+        F: FnMut(&NodeRef<'a>, &str) -> Option<T>,
     {
         self.walk(|node| {
             let character_lengths = node.data().character_lengths();
@@ -822,7 +822,7 @@ impl<'a> Range<'a> {
 
     fn fetch_property<T: alloc::fmt::Debug + PartialEq>(
         &self,
-        getter: fn(&Node<'a>) -> T,
+        getter: fn(&NodeRef<'a>) -> T,
     ) -> RangePropertyValue<T> {
         let mut value = None;
         self.walk(|node| {
@@ -895,7 +895,7 @@ impl Eq for Range<'_> {}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WeakRange {
-    node_id: NodeId,
+    node_id: FullNodeId,
     start: WeakPosition,
     end: WeakPosition,
     start_comparable: (Vec<usize>, usize),
@@ -903,7 +903,7 @@ pub struct WeakRange {
 }
 
 impl WeakRange {
-    pub fn node_id(&self) -> NodeId {
+    pub fn node_id(&self) -> FullNodeId {
         self.node_id
     }
 
@@ -915,10 +915,10 @@ impl WeakRange {
         &self.end_comparable
     }
 
-    pub fn upgrade_node<'a>(&self, tree_state: &'a TreeState) -> Option<Node<'a>> {
+    pub fn upgrade_node<'a>(&self, tree_state: &'a TreeState) -> Option<NodeRef<'a>> {
         tree_state
             .node_by_id(self.node_id)
-            .filter(Node::supports_text_ranges)
+            .filter(NodeRef::supports_text_ranges)
     }
 
     pub fn upgrade<'a>(&self, tree_state: &'a TreeState) -> Option<Range<'a>> {
@@ -929,7 +929,7 @@ impl WeakRange {
     }
 }
 
-fn text_node_filter(root_id: NodeId, node: &Node) -> FilterResult {
+fn text_node_filter(root_id: FullNodeId, node: &NodeRef) -> FilterResult {
     if node.id() == root_id || node.role() == Role::TextRun {
         FilterResult::Include
     } else {
@@ -937,7 +937,7 @@ fn text_node_filter(root_id: NodeId, node: &Node) -> FilterResult {
     }
 }
 
-fn character_index_at_point(node: &Node, point: Point) -> usize {
+fn character_index_at_point(node: &NodeRef, point: Point) -> usize {
     // We know the node has a bounding rectangle because it was returned
     // by a hit test.
     let rect = node.data().bounds().unwrap();
@@ -979,9 +979,9 @@ fn character_index_at_point(node: &Node, point: Point) -> usize {
 
 macro_rules! inherited_properties {
     ($(($getter:ident, $type:ty, $setter:ident, $test_value_1:expr_2021, $test_value_2:expr_2021)),+) => {
-        impl<'a> Node<'a> {
+        impl<'a> NodeRef<'a> {
             $(pub fn $getter(&self) -> Option<$type> {
-                self.fetch_inherited_property(NodeData::$getter)
+                self.fetch_inherited_property(Node::$getter)
             })*
         }
         impl<'a> Position<'a> {
@@ -991,12 +991,12 @@ macro_rules! inherited_properties {
         }
         impl<'a> Range<'a> {
             $(pub fn $getter(&self) -> RangePropertyValue<Option<$type>> {
-                self.fetch_property(Node::$getter)
+                self.fetch_property(NodeRef::$getter)
             })*
         }
         $(#[cfg(test)]
         mod $getter {
-            use accesskit::{Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+            use accesskit::{Node, NodeId, Role, TreeInfo, TreeId, TreeUpdate};
             use alloc::vec;
             use super::RangePropertyValue;
             use crate::tests::nid;
@@ -1017,7 +1017,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1046,7 +1046,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1076,7 +1076,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1105,7 +1105,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1140,7 +1140,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1174,7 +1174,7 @@ macro_rules! inherited_properties {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1214,9 +1214,9 @@ inherited_properties! {
 
 macro_rules! inherited_flags {
     ($(($getter:ident, $setter:ident)),+) => {
-        impl<'a> Node<'a> {
+        impl<'a> NodeRef<'a> {
             $(pub fn $getter(&self) -> bool {
-                self.fetch_inherited_flag(NodeData::$getter)
+                self.fetch_inherited_flag(Node::$getter)
             })*
         }
         impl<'a> Position<'a> {
@@ -1226,12 +1226,12 @@ macro_rules! inherited_flags {
         }
         impl<'a> Range<'a> {
             $(pub fn $getter(&self) -> RangePropertyValue<bool> {
-                self.fetch_property(Node::$getter)
+                self.fetch_property(NodeRef::$getter)
             })*
         }
         $(#[cfg(test)]
         mod $getter {
-            use accesskit::{Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+            use accesskit::{Node, NodeId, Role, TreeInfo, TreeId, TreeUpdate};
             use alloc::vec;
             use super::RangePropertyValue;
             use crate::tests::nid;
@@ -1252,7 +1252,7 @@ macro_rules! inherited_flags {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1281,7 +1281,7 @@ macro_rules! inherited_flags {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1309,7 +1309,7 @@ macro_rules! inherited_flags {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1344,7 +1344,7 @@ macro_rules! inherited_flags {
                             node
                         }),
                     ],
-                    tree: Some(Tree::new(NodeId(0))),
+                    tree: Some(TreeInfo::new(NodeId(0))),
                     tree_id: TreeId::ROOT,
                     focus: NodeId(0),
                 };
@@ -1362,7 +1362,7 @@ inherited_flags! {
     (is_italic, set_italic)
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     fn text_attributes_differ(&self, other: &Self) -> bool {
         self.font_family() != other.font_family()
             || self.language() != other.language()
@@ -1378,23 +1378,23 @@ impl<'a> Node<'a> {
         // TODO: more attributes
     }
 
-    pub(crate) fn text_runs(&self) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a> {
+    pub(crate) fn text_runs(&self) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a> {
         let id = self.id();
         self.filtered_children(move |node| text_node_filter(id, node))
     }
 
     fn following_text_runs(
         &self,
-        root_node: &Node,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a> {
+        root_node: &NodeRef,
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a> {
         let id = root_node.id();
         self.following_filtered_siblings(move |node| text_node_filter(id, node))
     }
 
     fn preceding_text_runs(
         &self,
-        root_node: &Node,
-    ) -> impl DoubleEndedIterator<Item = Node<'a>> + use<'a> {
+        root_node: &NodeRef,
+    ) -> impl DoubleEndedIterator<Item = NodeRef<'a>> + use<'a> {
         let id = root_node.id();
         self.preceding_filtered_siblings(move |node| text_node_filter(id, node))
     }
@@ -1695,7 +1695,7 @@ mod tests {
     // This was originally based on an actual tree produced by egui but
     // has since been heavily modified by hand to cover various test cases.
     fn main_multiline_tree(selection: Option<TextSelection>) -> crate::Tree {
-        use accesskit::{Action, Affine, Node, Role, TextDirection, Tree, TreeId, TreeUpdate};
+        use accesskit::{Action, Affine, Node, Role, TextDirection, TreeId, TreeInfo, TreeUpdate};
 
         let update = TreeUpdate {
             nodes: vec![
@@ -1905,7 +1905,7 @@ mod tests {
                     node
                 }),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(1),
         };

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3,12 +3,12 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit::{Node as NodeData, NodeId as LocalNodeId, Tree as TreeData, TreeId, TreeUpdate};
+use accesskit::{Node, NodeId, TreeId, TreeInfo, TreeUpdate};
 use alloc::{vec, vec::Vec};
 use core::fmt;
 use hashbrown::{HashMap, HashSet};
 
-use crate::node::{Node, NodeId, NodeState, ParentAndIndex};
+use crate::node::{FullNodeId, NodeRef, NodeState, ParentAndIndex};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -43,33 +43,33 @@ impl TreeIndexMap {
 /// State for a subtree, including its root node and current focus.
 #[derive(Clone, Debug)]
 pub(crate) struct SubtreeState {
-    pub(crate) root: NodeId,
-    pub(crate) focus: NodeId,
+    pub(crate) root: FullNodeId,
+    pub(crate) focus: FullNodeId,
 }
 
 #[derive(Clone, Debug)]
-pub struct State {
-    pub(crate) nodes: HashMap<NodeId, NodeState>,
-    pub(crate) data: TreeData,
-    pub(crate) root: NodeId,
-    pub(crate) focus: NodeId,
+pub struct TreeState {
+    pub(crate) nodes: HashMap<FullNodeId, NodeState>,
+    pub(crate) info: TreeInfo,
+    pub(crate) root: FullNodeId,
+    pub(crate) focus: FullNodeId,
     is_host_focused: bool,
     pub(crate) subtrees: HashMap<TreeId, SubtreeState>,
-    pub(crate) graft_parents: HashMap<TreeId, NodeId>,
+    pub(crate) graft_parents: HashMap<TreeId, FullNodeId>,
     tree_index_map: TreeIndexMap,
 }
 
 #[derive(Default)]
 struct InternalChanges {
-    added_node_ids: HashSet<NodeId>,
-    updated_node_ids: HashSet<NodeId>,
-    removed_node_ids: HashSet<NodeId>,
+    added_node_ids: HashSet<FullNodeId>,
+    updated_node_ids: HashSet<FullNodeId>,
+    removed_node_ids: HashSet<FullNodeId>,
 }
 
-impl State {
+impl TreeState {
     fn validate_global(&self) {
         if !self.nodes.contains_key(&self.root) {
-            panic!("Root ID {:?} is not in the node list", self.data.root);
+            panic!("Root ID {:?} is not in the node list", self.info.root);
         }
         if !self.nodes.contains_key(&self.focus) {
             panic!(
@@ -82,7 +82,7 @@ impl State {
     /// Computes the effective focus by following the graft chain from ROOT.
     /// If ROOT's focus is on a graft node, follows through to that subtree's focus,
     /// and continues recursively until reaching a non-graft node.
-    fn compute_effective_focus(&self) -> NodeId {
+    fn compute_effective_focus(&self) -> FullNodeId {
         let Some(root_subtree) = self.subtrees.get(&TreeId::ROOT) else {
             return self.focus;
         };
@@ -112,7 +112,7 @@ impl State {
         mut changes: Option<&mut InternalChanges>,
     ) {
         let tree_index = self.tree_index_map.get_or_create_index(update.tree_id);
-        let map_id = |id: LocalNodeId| NodeId::new(id, tree_index);
+        let map_id = |id: NodeId| FullNodeId::new(id, tree_index);
 
         let mut unreachable = HashSet::new();
         let mut seen_child_ids = HashSet::new();
@@ -139,11 +139,11 @@ impl State {
         let new_tree_root = if let Some(tree) = update.tree {
             let new_root = map_id(tree.root);
             if tree_id == TreeId::ROOT {
-                if tree.root != self.data.root {
+                if tree.root != self.info.root {
                     unreachable.insert(self.root);
                 }
                 self.root = new_root;
-                self.data = tree;
+                self.info = tree;
             } else if let Some(subtree) = self.subtrees.get(&tree_id) {
                 if subtree.root != new_root {
                     unreachable.insert(subtree.root);
@@ -160,18 +160,18 @@ impl State {
                 self.subtrees
                     .get(&tree_id)
                     .map(|s| s.root.to_components().0)
-                    .unwrap_or(self.data.root)
+                    .unwrap_or(self.info.root)
             });
 
-        let mut pending_nodes: HashMap<NodeId, _> = HashMap::new();
+        let mut pending_nodes: HashMap<FullNodeId, _> = HashMap::new();
         let mut pending_children = HashMap::new();
-        let mut pending_grafts: HashMap<TreeId, NodeId> = HashMap::new();
+        let mut pending_grafts: HashMap<TreeId, FullNodeId> = HashMap::new();
         let mut grafts_to_remove: HashSet<TreeId> = HashSet::new();
 
         fn record_graft(
-            pending_grafts: &mut HashMap<TreeId, NodeId>,
+            pending_grafts: &mut HashMap<TreeId, FullNodeId>,
             subtree_id: TreeId,
-            graft_node_id: NodeId,
+            graft_node_id: FullNodeId,
         ) {
             if subtree_id == TreeId::ROOT {
                 panic!("Cannot graft the root tree");
@@ -188,12 +188,12 @@ impl State {
         }
 
         fn add_node(
-            nodes: &mut HashMap<NodeId, NodeState>,
-            pending_grafts: &mut HashMap<TreeId, NodeId>,
+            nodes: &mut HashMap<FullNodeId, NodeState>,
+            pending_grafts: &mut HashMap<TreeId, FullNodeId>,
             changes: &mut Option<&mut InternalChanges>,
             parent_and_index: Option<ParentAndIndex>,
-            id: NodeId,
-            data: NodeData,
+            id: FullNodeId,
+            data: Node,
         ) {
             if let Some(subtree_id) = data.tree_id() {
                 if !data.children().is_empty() {
@@ -343,12 +343,12 @@ impl State {
 
         if !unreachable.is_empty() {
             fn traverse_unreachable(
-                nodes: &mut HashMap<NodeId, NodeState>,
+                nodes: &mut HashMap<FullNodeId, NodeState>,
                 grafts_to_remove: &mut HashSet<TreeId>,
                 changes: &mut Option<&mut InternalChanges>,
-                seen_child_ids: &HashSet<NodeId>,
-                new_tree_root: Option<NodeId>,
-                root: NodeId,
+                seen_child_ids: &HashSet<FullNodeId>,
+                new_tree_root: Option<FullNodeId>,
+                root: FullNodeId,
             ) {
                 let mut stack = vec![root];
                 while let Some(id) = stack.pop() {
@@ -361,7 +361,7 @@ impl State {
                     }
                     let (_, tree_index) = id.to_components();
                     for child_id in node.data.children().iter() {
-                        let child_node_id = NodeId::new(*child_id, tree_index);
+                        let child_node_id = FullNodeId::new(*child_id, tree_index);
                         if !seen_child_ids.contains(&child_node_id)
                             && new_tree_root != Some(child_node_id)
                         {
@@ -384,11 +384,11 @@ impl State {
         }
 
         fn traverse_subtree(
-            nodes: &mut HashMap<NodeId, NodeState>,
+            nodes: &mut HashMap<FullNodeId, NodeState>,
             subtrees_to_remove: &mut Vec<TreeId>,
             subtrees_queued: &mut HashSet<TreeId>,
             changes: &mut Option<&mut InternalChanges>,
-            root: NodeId,
+            root: FullNodeId,
         ) {
             let mut stack = vec![root];
             while let Some(id) = stack.pop() {
@@ -405,7 +405,7 @@ impl State {
                 }
                 let (_, tree_index) = id.to_components();
                 for child_id in node.data.children().iter() {
-                    stack.push(NodeId::new(*child_id, tree_index));
+                    stack.push(FullNodeId::new(*child_id, tree_index));
                 }
             }
         }
@@ -491,12 +491,12 @@ impl State {
         self.update(update, is_host_focused, changes);
     }
 
-    pub fn has_node(&self, id: NodeId) -> bool {
+    pub fn has_node(&self, id: FullNodeId) -> bool {
         self.nodes.contains_key(&id)
     }
 
-    pub fn node_by_id(&self, id: NodeId) -> Option<Node<'_>> {
-        self.nodes.get(&id).map(|node_state| Node {
+    pub fn node_by_id(&self, id: FullNodeId) -> Option<NodeRef<'_>> {
+        self.nodes.get(&id).map(|node_state| NodeRef {
             tree_state: self,
             id,
             state: node_state,
@@ -505,23 +505,23 @@ impl State {
 
     pub fn node_by_tree_local_id(
         &self,
-        local_node_id: LocalNodeId,
+        local_node_id: NodeId,
         tree_id: TreeId,
-    ) -> Option<Node<'_>> {
+    ) -> Option<NodeRef<'_>> {
         let tree_index = self.tree_index_map.get_index(tree_id)?;
-        self.node_by_id(NodeId::new(local_node_id, tree_index))
+        self.node_by_id(FullNodeId::new(local_node_id, tree_index))
     }
 
-    pub fn root_id(&self) -> NodeId {
+    pub fn root_id(&self) -> FullNodeId {
         self.root
     }
 
-    pub fn root(&self) -> Node<'_> {
+    pub fn root(&self) -> NodeRef<'_> {
         self.node_by_id(self.root_id()).unwrap()
     }
 
     /// Returns the root NodeId of the subtree with the given TreeId, if it exists.
-    pub fn subtree_root(&self, tree_id: TreeId) -> Option<NodeId> {
+    pub fn subtree_root(&self, tree_id: TreeId) -> Option<FullNodeId> {
         self.subtrees.get(&tree_id).map(|s| s.root)
     }
 
@@ -529,26 +529,26 @@ impl State {
         self.is_host_focused
     }
 
-    pub fn focus_id_in_tree(&self) -> NodeId {
+    pub fn focus_id_in_tree(&self) -> FullNodeId {
         self.focus
     }
 
-    pub fn focus_in_tree(&self) -> Node<'_> {
+    pub fn focus_in_tree(&self) -> NodeRef<'_> {
         self.node_by_id(self.focus_id_in_tree()).unwrap()
     }
 
-    pub fn focus_id(&self) -> Option<NodeId> {
+    pub fn focus_id(&self) -> Option<FullNodeId> {
         self.is_host_focused.then_some(self.focus)
     }
 
-    pub fn focus(&self) -> Option<Node<'_>> {
+    pub fn focus(&self) -> Option<NodeRef<'_>> {
         self.focus_id().map(|id| {
             let focused = self.node_by_id(id).unwrap();
             focused.active_descendant().unwrap_or(focused)
         })
     }
 
-    pub fn active_dialog(&self) -> Option<Node<'_>> {
+    pub fn active_dialog(&self) -> Option<NodeRef<'_>> {
         let mut node = self.focus();
         while let Some(candidate) = node {
             if candidate.is_dialog() {
@@ -560,17 +560,17 @@ impl State {
     }
 
     pub fn toolkit_name(&self) -> &str {
-        self.data.toolkit_name.as_deref().unwrap_or("AccessKit")
+        self.info.toolkit_name.as_deref().unwrap_or("AccessKit")
     }
 
     pub fn toolkit_version(&self) -> Option<&str> {
-        self.data
+        self.info
             .toolkit_version
             .as_deref()
-            .filter(|_| self.data.toolkit_name.is_some())
+            .filter(|_| self.info.toolkit_name.is_some())
     }
 
-    pub fn locate_node(&self, node_id: NodeId) -> Option<(LocalNodeId, TreeId)> {
+    pub fn locate_node(&self, node_id: FullNodeId) -> Option<(NodeId, TreeId)> {
         if !self.has_node(node_id) {
             return None;
         }
@@ -582,16 +582,16 @@ impl State {
 }
 
 pub trait ChangeHandler {
-    fn node_added(&mut self, node: &Node);
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node);
-    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>);
-    fn node_removed(&mut self, node: &Node);
+    fn node_added(&mut self, node: &NodeRef);
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef);
+    fn focus_moved(&mut self, old_node: Option<&NodeRef>, new_node: Option<&NodeRef>);
+    fn node_removed(&mut self, node: &NodeRef);
 }
 
 #[derive(Debug)]
 pub struct Tree {
-    state: State,
-    next_state: State,
+    state: TreeState,
+    next_state: TreeState,
 }
 
 impl Tree {
@@ -606,11 +606,11 @@ impl Tree {
         }
         let mut tree_index_map = TreeIndexMap::default();
         let tree_index = tree_index_map.get_or_create_index(initial_state.tree_id);
-        let mut state = State {
+        let mut state = TreeState {
             nodes: HashMap::new(),
-            root: NodeId::new(tree.root, tree_index),
-            data: tree,
-            focus: NodeId::new(initial_state.focus, tree_index),
+            root: FullNodeId::new(tree.root, tree_index),
+            info: tree,
+            focus: FullNodeId::new(initial_state.focus, tree_index),
             is_host_focused,
             subtrees: HashMap::new(),
             graft_parents: HashMap::new(),
@@ -698,8 +698,8 @@ impl Tree {
         for id in changes.removed_node_ids {
             self.state.nodes.remove(&id);
         }
-        if self.state.data != self.next_state.data {
-            self.state.data.clone_from(&self.next_state.data);
+        if self.state.info != self.next_state.info {
+            self.state.info.clone_from(&self.next_state.info);
         }
         self.state.root = self.next_state.root;
         self.state.focus = self.next_state.focus;
@@ -713,12 +713,12 @@ impl Tree {
             .clone_from(&self.next_state.tree_index_map);
     }
 
-    pub fn state(&self) -> &State {
+    pub fn state(&self) -> &TreeState {
         &self.state
     }
 }
 
-struct ShortNodeList<'a, T>(&'a HashMap<NodeId, T>);
+struct ShortNodeList<'a, T>(&'a HashMap<FullNodeId, T>);
 
 impl<T> fmt::Display for ShortNodeList<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -742,22 +742,22 @@ impl<T> fmt::Display for ShortNodeList<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use accesskit::{Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate, Uuid};
+    use accesskit::{Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate, Uuid};
     use alloc::{vec, vec::Vec};
 
     use super::{TreeIndex, TreeIndexMap};
-    use crate::node::NodeId;
+    use crate::node::FullNodeId;
 
     struct NoOpHandler;
     impl super::ChangeHandler for NoOpHandler {
-        fn node_added(&mut self, _: &crate::Node) {}
-        fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-        fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-        fn node_removed(&mut self, _: &crate::Node) {}
+        fn node_added(&mut self, _: &crate::NodeRef) {}
+        fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+        fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+        fn node_removed(&mut self, _: &crate::NodeRef) {}
     }
 
-    fn node_id(n: u64) -> NodeId {
-        NodeId::new(LocalNodeId(n), TreeIndex(0))
+    fn node_id(n: u64) -> FullNodeId {
+        FullNodeId::new(NodeId(n), TreeIndex(0))
     }
 
     #[test]
@@ -842,10 +842,10 @@ mod tests {
     #[test]
     fn init_tree_with_root_node() {
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
         assert_eq!(node_id(0), tree.state().root().id());
@@ -859,10 +859,10 @@ mod tests {
     )]
     fn init_tree_with_non_root_tree_id_panics() {
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId(Uuid::from_u128(1)),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let _ = super::Tree::new(update, false);
     }
@@ -871,17 +871,17 @@ mod tests {
     fn root_node_has_children() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
         let state = tree.state();
@@ -900,25 +900,25 @@ mod tests {
     fn add_child_to_root_node() {
         let root_node = Node::new(Role::Window);
         let first_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), root_node.clone())],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), root_node.clone())],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(first_update, false);
         assert_eq!(0, tree.state().root().children().count());
         let second_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = root_node;
-                    node.push_child(LocalNodeId(1));
+                    node.push_child(NodeId(1));
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::RootWebArea)),
+                (NodeId(1), Node::new(Role::RootWebArea)),
             ],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         struct Handler {
             got_new_child_node: bool,
@@ -928,17 +928,17 @@ mod tests {
             panic!("expected only new child node and updated root node");
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 if node.id() == node_id(1) {
                     self.got_new_child_node = true;
                     return;
                 }
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::NodeRef, new_node: &crate::NodeRef) {
                 if new_node.id() == node_id(0)
                     && old_node.data().children().is_empty()
-                    && new_node.data().children() == [LocalNodeId(1)]
+                    && new_node.data().children() == [NodeId(1)]
                 {
                     self.got_updated_root_node = true;
                     return;
@@ -947,12 +947,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::Node>,
-                _new_node: Option<&crate::Node>,
+                _old_node: Option<&crate::NodeRef>,
+                _new_node: Option<&crate::NodeRef>,
             ) {
                 unexpected_change();
             }
-            fn node_removed(&mut self, _node: &crate::Node) {
+            fn node_removed(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
         }
@@ -977,24 +977,24 @@ mod tests {
         let root_node = Node::new(Role::Window);
         let first_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = root_node.clone();
-                    node.push_child(LocalNodeId(1));
+                    node.push_child(NodeId(1));
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::RootWebArea)),
+                (NodeId(1), Node::new(Role::RootWebArea)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(first_update, false);
         assert_eq!(1, tree.state().root().children().count());
         let second_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), root_node)],
+            nodes: vec![(NodeId(0), root_node)],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         struct Handler {
             got_updated_root_node: bool,
@@ -1004,12 +1004,12 @@ mod tests {
             panic!("expected only removed child node and updated root node");
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _node: &crate::Node) {
+            fn node_added(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::NodeRef, new_node: &crate::NodeRef) {
                 if new_node.id() == node_id(0)
-                    && old_node.data().children() == [LocalNodeId(1)]
+                    && old_node.data().children() == [NodeId(1)]
                     && new_node.data().children().is_empty()
                 {
                     self.got_updated_root_node = true;
@@ -1019,12 +1019,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::Node>,
-                _new_node: Option<&crate::Node>,
+                _old_node: Option<&crate::NodeRef>,
+                _new_node: Option<&crate::NodeRef>,
             ) {
                 unexpected_change();
             }
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 if node.id() == node_id(1) {
                     self.got_removed_child_node = true;
                     return;
@@ -1047,17 +1047,17 @@ mod tests {
     fn move_focus_between_siblings() {
         let first_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         let mut tree = super::Tree::new(first_update, true);
         assert!(tree.state().node_by_id(node_id(1)).unwrap().is_focused());
@@ -1065,7 +1065,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(2),
+            focus: NodeId(2),
         };
         struct Handler {
             got_old_focus_node_update: bool,
@@ -1076,10 +1076,10 @@ mod tests {
             panic!("expected only focus change");
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _node: &crate::Node) {
+            fn node_added(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::NodeRef, new_node: &crate::NodeRef) {
                 if old_node.id() == node_id(1)
                     && new_node.id() == node_id(1)
                     && old_node.is_focused()
@@ -1100,8 +1100,8 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                old_node: Option<&crate::Node>,
-                new_node: Option<&crate::Node>,
+                old_node: Option<&crate::NodeRef>,
+                new_node: Option<&crate::NodeRef>,
             ) {
                 if let (Some(old_node), Some(new_node)) = (old_node, new_node) {
                     if old_node.id() == node_id(1) && new_node.id() == node_id(2) {
@@ -1111,7 +1111,7 @@ mod tests {
                 }
                 unexpected_change();
             }
-            fn node_removed(&mut self, _node: &crate::Node) {
+            fn node_removed(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
         }
@@ -1133,20 +1133,20 @@ mod tests {
         let child_node = Node::new(Role::Button);
         let first_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = child_node.clone();
                     node.set_label("foo");
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(first_update, false);
         assert_eq!(
@@ -1154,14 +1154,14 @@ mod tests {
             tree.state().node_by_id(node_id(1)).unwrap().label()
         );
         let second_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), {
+            nodes: vec![(NodeId(1), {
                 let mut node = child_node;
                 node.set_label("bar");
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         struct Handler {
             got_updated_child_node: bool,
@@ -1170,10 +1170,10 @@ mod tests {
             panic!("expected only updated child node");
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _node: &crate::Node) {
+            fn node_added(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::NodeRef, new_node: &crate::NodeRef) {
                 if new_node.id() == node_id(1)
                     && old_node.label() == Some("foo".into())
                     && new_node.label() == Some("bar".into())
@@ -1185,12 +1185,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::Node>,
-                _new_node: Option<&crate::Node>,
+                _old_node: Option<&crate::NodeRef>,
+                _new_node: Option<&crate::NodeRef>,
             ) {
                 unexpected_change();
             }
-            fn node_removed(&mut self, _node: &crate::Node) {
+            fn node_removed(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
         }
@@ -1213,20 +1213,20 @@ mod tests {
     fn no_change_update() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::Button);
                     node.set_label("foo");
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update.clone(), false);
         struct Handler;
@@ -1234,20 +1234,20 @@ mod tests {
             panic!("expected no changes");
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _node: &crate::Node) {
+            fn node_added(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, _old_node: &crate::Node, _new_node: &crate::Node) {
+            fn node_updated(&mut self, _old_node: &crate::NodeRef, _new_node: &crate::NodeRef) {
                 unexpected_change();
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::Node>,
-                _new_node: Option<&crate::Node>,
+                _old_node: Option<&crate::NodeRef>,
+                _new_node: Option<&crate::NodeRef>,
             ) {
                 unexpected_change();
             }
-            fn node_removed(&mut self, _node: &crate::Node) {
+            fn node_removed(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
         }
@@ -1268,13 +1268,13 @@ mod tests {
         }
 
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _node: &crate::Node) {
+            fn node_added(&mut self, _node: &crate::NodeRef) {
                 unexpected_change();
             }
-            fn node_updated(&mut self, old_node: &crate::Node, new_node: &crate::Node) {
+            fn node_updated(&mut self, old_node: &crate::NodeRef, new_node: &crate::NodeRef) {
                 if new_node.id() == node_id(0)
-                    && old_node.child_ids().collect::<Vec<NodeId>>() == vec![node_id(1)]
-                    && new_node.child_ids().collect::<Vec<NodeId>>() == vec![node_id(2)]
+                    && old_node.child_ids().collect::<Vec<FullNodeId>>() == vec![node_id(1)]
+                    && new_node.child_ids().collect::<Vec<FullNodeId>>() == vec![node_id(2)]
                 {
                     self.got_updated_root = true;
                     return;
@@ -1290,12 +1290,12 @@ mod tests {
             }
             fn focus_moved(
                 &mut self,
-                _old_node: Option<&crate::Node>,
-                _new_node: Option<&crate::Node>,
+                _old_node: Option<&crate::NodeRef>,
+                _new_node: Option<&crate::NodeRef>,
             ) {
                 unexpected_change();
             }
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 if node.id() == node_id(1) {
                     self.got_removed_container = true;
                     return;
@@ -1305,21 +1305,21 @@ mod tests {
         }
 
         let mut root = Node::new(Role::Window);
-        root.set_children([LocalNodeId(1)]);
+        root.set_children([NodeId(1)]);
         let mut container = Node::new(Role::GenericContainer);
-        container.set_children([LocalNodeId(2)]);
+        container.set_children([NodeId(2)]);
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), root.clone()),
-                (LocalNodeId(1), container),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(0), root.clone()),
+                (NodeId(1), container),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = crate::Tree::new(update, false);
-        root.set_children([LocalNodeId(2)]);
+        root.set_children([NodeId(2)]);
         let mut handler = Handler {
             got_updated_root: false,
             got_updated_child: false,
@@ -1327,10 +1327,10 @@ mod tests {
         };
         tree.update_and_process_changes(
             TreeUpdate {
-                nodes: vec![(LocalNodeId(0), root)],
+                nodes: vec![(NodeId(0), root)],
                 tree: None,
                 tree_id: TreeId::ROOT,
-                focus: LocalNodeId(0),
+                focus: NodeId(0),
             },
             &mut handler,
         );
@@ -1342,7 +1342,7 @@ mod tests {
                 .node_by_id(node_id(0))
                 .unwrap()
                 .child_ids()
-                .collect::<Vec<NodeId>>(),
+                .collect::<Vec<FullNodeId>>(),
             vec![node_id(2)]
         );
         assert!(tree.state().node_by_id(node_id(1)).is_none());
@@ -1360,20 +1360,20 @@ mod tests {
     fn graft_node_tracks_subtree() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
         assert_eq!(
@@ -1387,25 +1387,25 @@ mod tests {
     fn duplicate_graft_parent_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
-                (LocalNodeId(2), {
+                (NodeId(2), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let _ = super::Tree::new(update, false);
     }
@@ -1414,21 +1414,21 @@ mod tests {
     fn reparent_subtree_by_removing_old_graft() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::GenericContainer)),
+                (NodeId(2), Node::new(Role::GenericContainer)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
         assert_eq!(
@@ -1438,12 +1438,12 @@ mod tests {
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(2), {
+                (NodeId(2), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
@@ -1451,7 +1451,7 @@ mod tests {
             ],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
         assert_eq!(
@@ -1464,21 +1464,21 @@ mod tests {
     fn reparent_subtree_by_clearing_old_graft_tree_id() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::GenericContainer)),
+                (NodeId(2), Node::new(Role::GenericContainer)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
         assert_eq!(
@@ -1488,8 +1488,8 @@ mod tests {
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(1), Node::new(Role::GenericContainer)),
-                (LocalNodeId(2), {
+                (NodeId(1), Node::new(Role::GenericContainer)),
+                (NodeId(2), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
@@ -1497,7 +1497,7 @@ mod tests {
             ],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
         assert_eq!(
@@ -1511,33 +1511,33 @@ mod tests {
     fn duplicate_graft_parent_on_update_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::GenericContainer)),
+                (NodeId(2), Node::new(Role::GenericContainer)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(2), {
+            nodes: vec![(NodeId(2), {
                 let mut node = Node::new(Role::GenericContainer);
                 node.set_tree_id(subtree_id());
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
     }
@@ -1547,20 +1547,20 @@ mod tests {
     fn graft_root_tree_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(TreeId::ROOT);
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let _ = super::Tree::new(update, false);
     }
@@ -1570,63 +1570,63 @@ mod tests {
     fn graft_root_tree_on_update_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::GenericContainer)),
+                (NodeId(1), Node::new(Role::GenericContainer)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), {
+            nodes: vec![(NodeId(1), {
                 let mut node = Node::new(Role::GenericContainer);
                 node.set_tree_id(TreeId::ROOT);
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
     }
 
-    fn subtree_node_id(id: u64) -> NodeId {
-        NodeId::new(LocalNodeId(id), TreeIndex(1))
+    fn subtree_node_id(id: u64) -> FullNodeId {
+        FullNodeId::new(NodeId(id), TreeIndex(1))
     }
 
     #[test]
     fn node_by_tree_local_id_finds_root_tree_node() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
 
         let root = tree
             .state()
-            .node_by_tree_local_id(LocalNodeId(0), TreeId::ROOT)
+            .node_by_tree_local_id(NodeId(0), TreeId::ROOT)
             .unwrap();
         assert_eq!(root.id(), node_id(0));
         assert_eq!(root.role(), Role::Window);
 
         let child = tree
             .state()
-            .node_by_tree_local_id(LocalNodeId(1), TreeId::ROOT)
+            .node_by_tree_local_id(NodeId(1), TreeId::ROOT)
             .unwrap();
         assert_eq!(child.id(), node_id(1));
         assert_eq!(child.role(), Role::Button);
@@ -1636,55 +1636,55 @@ mod tests {
     fn node_by_tree_local_id_finds_subtree_node() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let sub_root = tree
             .state()
-            .node_by_tree_local_id(LocalNodeId(0), subtree_id())
+            .node_by_tree_local_id(NodeId(0), subtree_id())
             .unwrap();
         assert_eq!(sub_root.id(), subtree_node_id(0));
         assert_eq!(sub_root.role(), Role::Document);
 
         let sub_child = tree
             .state()
-            .node_by_tree_local_id(LocalNodeId(1), subtree_id())
+            .node_by_tree_local_id(NodeId(1), subtree_id())
             .unwrap();
         assert_eq!(sub_child.id(), subtree_node_id(1));
         assert_eq!(sub_child.role(), Role::Paragraph);
 
         let graft = tree
             .state()
-            .node_by_tree_local_id(LocalNodeId(1), TreeId::ROOT)
+            .node_by_tree_local_id(NodeId(1), TreeId::ROOT)
             .unwrap();
         assert_eq!(graft.id(), node_id(1));
         assert_eq!(graft.role(), Role::GenericContainer);
@@ -1693,16 +1693,16 @@ mod tests {
     #[test]
     fn node_by_tree_local_id_returns_none_for_unknown_tree_id() {
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
 
         assert!(
             tree.state()
-                .node_by_tree_local_id(LocalNodeId(0), subtree_id())
+                .node_by_tree_local_id(NodeId(0), subtree_id())
                 .is_none()
         );
     }
@@ -1710,16 +1710,16 @@ mod tests {
     #[test]
     fn node_by_tree_local_id_returns_none_for_unknown_local_id() {
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
 
         assert!(
             tree.state()
-                .node_by_tree_local_id(LocalNodeId(999), TreeId::ROOT)
+                .node_by_tree_local_id(NodeId(999), TreeId::ROOT)
                 .is_none()
         );
     }
@@ -1728,28 +1728,28 @@ mod tests {
     fn subtree_root_parent_is_graft_when_graft_exists_first() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Document))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Document))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -1766,18 +1766,18 @@ mod tests {
     #[should_panic(expected = "no graft node exists for this tree")]
     fn subtree_push_without_graft_panics() {
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Document))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Document))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
     }
@@ -1787,28 +1787,28 @@ mod tests {
     fn subtree_update_without_tree_data_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Document))],
+            nodes: vec![(NodeId(0), Node::new(Role::Document))],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
     }
@@ -1817,54 +1817,54 @@ mod tests {
     fn subtree_nodes_removed_when_graft_removed() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(nested_subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let nested_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(nested_update, &mut NoOpHandler);
 
@@ -1874,14 +1874,14 @@ mod tests {
         assert!(tree.state().node_by_id(nested_subtree_node_id(1)).is_some());
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), {
+            nodes: vec![(NodeId(0), {
                 let mut node = Node::new(Role::Window);
                 node.set_children(vec![]);
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -1897,35 +1897,35 @@ mod tests {
     fn subtree_nodes_removed_when_graft_tree_id_cleared() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -1933,10 +1933,10 @@ mod tests {
         assert!(tree.state().node_by_id(subtree_node_id(1)).is_some());
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), Node::new(Role::GenericContainer))],
+            nodes: vec![(NodeId(1), Node::new(Role::GenericContainer))],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -1949,20 +1949,20 @@ mod tests {
     fn graft_node_has_no_children_when_subtree_not_pushed() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let tree = super::Tree::new(update, false);
 
@@ -1976,22 +1976,22 @@ mod tests {
     fn graft_node_with_children_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
-                    node.set_children(vec![LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         super::Tree::new(update, false);
     }
@@ -1999,33 +1999,33 @@ mod tests {
     #[test]
     fn node_added_called_when_subtree_pushed() {
         struct Handler {
-            added_nodes: Vec<NodeId>,
+            added_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 self.added_nodes.push(node.id());
             }
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
@@ -2035,17 +2035,17 @@ mod tests {
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -2058,48 +2058,48 @@ mod tests {
     #[test]
     fn node_removed_called_when_graft_removed() {
         struct Handler {
-            removed_nodes: Vec<NodeId>,
+            removed_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 self.removed_nodes.push(node.id());
             }
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2111,14 +2111,14 @@ mod tests {
         };
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), {
+            nodes: vec![(NodeId(0), {
                 let mut node = Node::new(Role::Window);
                 node.set_children(vec![]);
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut handler);
 
@@ -2131,42 +2131,42 @@ mod tests {
     #[test]
     fn node_updated_called_when_subtree_reparented() {
         struct Handler {
-            updated_nodes: Vec<NodeId>,
+            updated_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _old: &crate::Node, new: &crate::Node) {
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _old: &crate::NodeRef, new: &crate::NodeRef) {
                 self.updated_nodes.push(new.id());
             }
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::GenericContainer)),
+                (NodeId(2), Node::new(Role::GenericContainer)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Document))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Document))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2179,8 +2179,8 @@ mod tests {
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(1), Node::new(Role::GenericContainer)),
-                (LocalNodeId(2), {
+                (NodeId(1), Node::new(Role::GenericContainer)),
+                (NodeId(2), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
@@ -2188,7 +2188,7 @@ mod tests {
             ],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(update, &mut handler);
 
@@ -2201,49 +2201,49 @@ mod tests {
     #[test]
     fn focus_moved_called_when_focus_moves_to_subtree() {
         struct Handler {
-            focus_moves: Vec<(Option<NodeId>, Option<NodeId>)>,
+            focus_moves: Vec<(Option<FullNodeId>, Option<FullNodeId>)>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, old: Option<&crate::Node>, new: Option<&crate::Node>) {
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, old: Option<&crate::NodeRef>, new: Option<&crate::NodeRef>) {
                 self.focus_moves
                     .push((old.map(|n| n.id()), new.map(|n| n.id())));
             }
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2255,7 +2255,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(update, &mut handler);
 
@@ -2268,49 +2268,49 @@ mod tests {
     #[test]
     fn focus_moved_called_when_subtree_focus_changes() {
         struct Handler {
-            focus_moves: Vec<(Option<NodeId>, Option<NodeId>)>,
+            focus_moves: Vec<(Option<FullNodeId>, Option<FullNodeId>)>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, old: Option<&crate::Node>, new: Option<&crate::Node>) {
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, old: Option<&crate::NodeRef>, new: Option<&crate::NodeRef>) {
                 self.focus_moves
                     .push((old.map(|n| n.id()), new.map(|n| n.id())));
             }
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2318,7 +2318,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(root_update, &mut NoOpHandler);
 
@@ -2330,7 +2330,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -2344,62 +2344,62 @@ mod tests {
         TreeId(Uuid::from_u128(2))
     }
 
-    fn nested_subtree_node_id(n: u64) -> NodeId {
-        NodeId::new(LocalNodeId(n), TreeIndex(2))
+    fn nested_subtree_node_id(n: u64) -> FullNodeId {
+        FullNodeId::new(NodeId(n), TreeIndex(2))
     }
 
     #[test]
     fn nested_subtree_focus_follows_graft_chain() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(nested_subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let nested_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Group);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(nested_update, &mut NoOpHandler);
 
@@ -2407,7 +2407,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -2415,7 +2415,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -2426,55 +2426,55 @@ mod tests {
     fn nested_subtree_focus_update_changes_effective_focus() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(nested_subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let nested_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Group);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(nested_update, &mut NoOpHandler);
 
@@ -2482,7 +2482,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(root_update, &mut NoOpHandler);
 
@@ -2492,7 +2492,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(2),
+            focus: NodeId(2),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -2504,55 +2504,55 @@ mod tests {
     fn removing_nested_subtree_while_intermediate_focus_on_graft_panics() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(nested_subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let nested_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Button))],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            nodes: vec![(NodeId(0), Node::new(Role::Button))],
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(nested_update, &mut NoOpHandler);
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), Node::new(Role::GenericContainer))],
+            nodes: vec![(NodeId(1), Node::new(Role::GenericContainer))],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
     }
@@ -2561,55 +2561,55 @@ mod tests {
     fn nested_subtree_root_lookup_for_focus_only_update() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, true);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1), LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(1), NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(nested_subtree_id());
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
         let nested_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Group);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: nested_subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(nested_update, &mut NoOpHandler);
 
@@ -2617,7 +2617,7 @@ mod tests {
             nodes: vec![],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(2),
+            focus: NodeId(2),
         };
         tree.update_and_process_changes(update, &mut NoOpHandler);
 
@@ -2630,54 +2630,54 @@ mod tests {
     #[test]
     fn subtree_root_change_updates_graft_and_parent() {
         struct Handler {
-            updated_nodes: Vec<NodeId>,
-            added_nodes: Vec<NodeId>,
-            removed_nodes: Vec<NodeId>,
+            updated_nodes: Vec<FullNodeId>,
+            added_nodes: Vec<FullNodeId>,
+            removed_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 self.added_nodes.push(node.id());
             }
-            fn node_updated(&mut self, _old: &crate::Node, new: &crate::Node) {
+            fn node_updated(&mut self, _old: &crate::NodeRef, new: &crate::NodeRef) {
                 self.updated_nodes.push(new.id());
             }
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 self.removed_nodes.push(node.id());
             }
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2689,16 +2689,16 @@ mod tests {
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(2), {
+                (NodeId(2), {
                     let mut node = Node::new(Role::Article);
-                    node.set_children(vec![LocalNodeId(3)]);
+                    node.set_children(vec![NodeId(3)]);
                     node
                 }),
-                (LocalNodeId(3), Node::new(Role::Button)),
+                (NodeId(3), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(2))),
+            tree: Some(TreeInfo::new(NodeId(2))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(2),
+            focus: NodeId(2),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -2726,59 +2726,59 @@ mod tests {
     #[test]
     fn subtree_root_change_to_existing_child() {
         struct Handler {
-            updated_nodes: Vec<NodeId>,
-            added_nodes: Vec<NodeId>,
-            removed_nodes: Vec<NodeId>,
+            updated_nodes: Vec<FullNodeId>,
+            added_nodes: Vec<FullNodeId>,
+            removed_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 self.added_nodes.push(node.id());
             }
-            fn node_updated(&mut self, _old: &crate::Node, new: &crate::Node) {
+            fn node_updated(&mut self, _old: &crate::NodeRef, new: &crate::NodeRef) {
                 self.updated_nodes.push(new.id());
             }
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 self.removed_nodes.push(node.id());
             }
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::Article);
-                    node.set_children(vec![LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::Paragraph)),
+                (NodeId(2), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2804,16 +2804,16 @@ mod tests {
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::Article);
-                    node.set_children(vec![LocalNodeId(2)]);
+                    node.set_children(vec![NodeId(2)]);
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::Paragraph)),
+                (NodeId(2), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(1))),
+            tree: Some(TreeInfo::new(NodeId(1))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -2840,54 +2840,54 @@ mod tests {
     #[test]
     fn subtree_root_change_to_new_parent_of_old_root() {
         struct Handler {
-            updated_nodes: Vec<NodeId>,
-            added_nodes: Vec<NodeId>,
-            removed_nodes: Vec<NodeId>,
+            updated_nodes: Vec<FullNodeId>,
+            added_nodes: Vec<FullNodeId>,
+            removed_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 self.added_nodes.push(node.id());
             }
-            fn node_updated(&mut self, _old: &crate::Node, new: &crate::Node) {
+            fn node_updated(&mut self, _old: &crate::NodeRef, new: &crate::NodeRef) {
                 self.updated_nodes.push(new.id());
             }
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 self.removed_nodes.push(node.id());
             }
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -2899,21 +2899,21 @@ mod tests {
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(2), {
+                (NodeId(2), {
                     let mut node = Node::new(Role::Article);
-                    node.set_children(vec![LocalNodeId(0)]);
+                    node.set_children(vec![NodeId(0)]);
                     node
                 }),
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Paragraph)),
+                (NodeId(1), Node::new(Role::Paragraph)),
             ],
-            tree: Some(Tree::new(LocalNodeId(2))),
+            tree: Some(TreeInfo::new(NodeId(2))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(2),
+            focus: NodeId(2),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -2942,58 +2942,58 @@ mod tests {
     #[test]
     fn subtree_update_without_tree_preserves_root() {
         struct Handler {
-            updated_nodes: Vec<NodeId>,
-            added_nodes: Vec<NodeId>,
-            removed_nodes: Vec<NodeId>,
+            updated_nodes: Vec<FullNodeId>,
+            added_nodes: Vec<FullNodeId>,
+            removed_nodes: Vec<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, node: &crate::Node) {
+            fn node_added(&mut self, node: &crate::NodeRef) {
                 self.added_nodes.push(node.id());
             }
-            fn node_updated(&mut self, _old: &crate::Node, new: &crate::Node) {
+            fn node_updated(&mut self, _old: &crate::NodeRef, new: &crate::NodeRef) {
                 self.updated_nodes.push(new.id());
             }
-            fn focus_moved(&mut self, _: Option<&crate::Node>, _: Option<&crate::Node>) {}
-            fn node_removed(&mut self, node: &crate::Node) {
+            fn focus_moved(&mut self, _: Option<&crate::NodeRef>, _: Option<&crate::NodeRef>) {}
+            fn node_removed(&mut self, node: &crate::NodeRef) {
                 self.removed_nodes.push(node.id());
             }
         }
 
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::GenericContainer);
                     node.set_tree_id(subtree_id());
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let mut tree = super::Tree::new(update, false);
 
         let subtree_update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Document);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::Paragraph);
                     node.set_label("original");
                     node
                 }),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut NoOpHandler);
 
@@ -3004,14 +3004,14 @@ mod tests {
         };
 
         let subtree_update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), {
+            nodes: vec![(NodeId(1), {
                 let mut node = Node::new(Role::Paragraph);
                 node.set_label("modified");
                 node
             })],
             tree: None,
             tree_id: subtree_id(),
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         tree.update_and_process_changes(subtree_update, &mut handler);
 
@@ -3035,16 +3035,16 @@ mod tests {
     fn focus_returns_focused_node() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         let tree = super::Tree::new(update, true);
         assert_eq!(tree.state().focus().unwrap().id(), node_id(1));
@@ -3054,22 +3054,22 @@ mod tests {
     fn focus_returns_active_descendant() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::ListBox);
-                    node.set_children(vec![LocalNodeId(2)]);
-                    node.set_active_descendant(LocalNodeId(2));
+                    node.set_children(vec![NodeId(2)]);
+                    node.set_active_descendant(NodeId(2));
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::ListBoxOption)),
+                (NodeId(2), Node::new(Role::ListBoxOption)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         let tree = super::Tree::new(update, true);
         assert_eq!(tree.state().focus().unwrap().id(), node_id(2));
@@ -3079,40 +3079,40 @@ mod tests {
     fn focus_moved_when_active_descendant_changes() {
         let update = TreeUpdate {
             nodes: vec![
-                (LocalNodeId(0), {
+                (NodeId(0), {
                     let mut node = Node::new(Role::Window);
-                    node.set_children(vec![LocalNodeId(1)]);
+                    node.set_children(vec![NodeId(1)]);
                     node
                 }),
-                (LocalNodeId(1), {
+                (NodeId(1), {
                     let mut node = Node::new(Role::ListBox);
-                    node.set_children(vec![LocalNodeId(2), LocalNodeId(3)]);
-                    node.set_active_descendant(LocalNodeId(2));
+                    node.set_children(vec![NodeId(2), NodeId(3)]);
+                    node.set_active_descendant(NodeId(2));
                     node
                 }),
-                (LocalNodeId(2), Node::new(Role::ListBoxOption)),
-                (LocalNodeId(3), Node::new(Role::ListBoxOption)),
+                (NodeId(2), Node::new(Role::ListBoxOption)),
+                (NodeId(3), Node::new(Role::ListBoxOption)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         let mut tree = super::Tree::new(update, true);
 
         struct Handler {
             focus_moved_called: bool,
-            old_focus: Option<NodeId>,
-            new_focus: Option<NodeId>,
+            old_focus: Option<FullNodeId>,
+            new_focus: Option<FullNodeId>,
         }
         impl super::ChangeHandler for Handler {
-            fn node_added(&mut self, _: &crate::Node) {}
-            fn node_updated(&mut self, _: &crate::Node, _: &crate::Node) {}
-            fn focus_moved(&mut self, old: Option<&crate::Node>, new: Option<&crate::Node>) {
+            fn node_added(&mut self, _: &crate::NodeRef) {}
+            fn node_updated(&mut self, _: &crate::NodeRef, _: &crate::NodeRef) {}
+            fn focus_moved(&mut self, old: Option<&crate::NodeRef>, new: Option<&crate::NodeRef>) {
                 self.focus_moved_called = true;
                 self.old_focus = old.map(|n| n.id());
                 self.new_focus = new.map(|n| n.id());
             }
-            fn node_removed(&mut self, _: &crate::Node) {}
+            fn node_removed(&mut self, _: &crate::NodeRef) {}
         }
 
         let mut handler = Handler {
@@ -3122,15 +3122,15 @@ mod tests {
         };
 
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(1), {
+            nodes: vec![(NodeId(1), {
                 let mut node = Node::new(Role::ListBox);
-                node.set_children(vec![LocalNodeId(2), LocalNodeId(3)]);
-                node.set_active_descendant(LocalNodeId(3));
+                node.set_children(vec![NodeId(2), NodeId(3)]);
+                node.set_active_descendant(NodeId(3));
                 node
             })],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(1),
+            focus: NodeId(1),
         };
         tree.update_and_process_changes(update, &mut handler);
 

--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -3140,14 +3140,14 @@ mod tests {
     }
 
     fn tree_with_toolkit_info(name: Option<&str>, version: Option<&str>) -> super::Tree {
-        let mut tree_data = Tree::new(LocalNodeId(0));
-        tree_data.toolkit_name = name.map(Into::into);
-        tree_data.toolkit_version = version.map(Into::into);
+        let mut tree_info = TreeInfo::new(NodeId(0));
+        tree_info.toolkit_name = name.map(Into::into);
+        tree_info.toolkit_version = version.map(Into::into);
         let update = TreeUpdate {
-            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
-            tree: Some(tree_data),
+            nodes: vec![(NodeId(0), Node::new(Role::Window))],
+            tree: Some(tree_info),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         super::Tree::new(update, false)
     }

--- a/platforms/android/src/adapter.rs
+++ b/platforms/android/src/adapter.rs
@@ -9,11 +9,10 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    Action, ActionData, ActionHandler, ActionRequest, ActivationHandler, Node as NodeData,
-    NodeId as LocalNodeId, Orientation, Point, Role, ScrollUnit, TextSelection, Tree as TreeData,
-    TreeId, TreeUpdate,
+    Action, ActionData, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Orientation,
+    Point, Role, ScrollUnit, TextSelection, TreeId, TreeInfo, TreeUpdate,
 };
-use accesskit_consumer::{FilterResult, Node, TextPosition, Tree, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, NodeRef, TextPosition, Tree, TreeChangeHandler};
 use jni::{
     JNIEnv,
     objects::JObject,
@@ -37,7 +36,7 @@ fn enqueue_window_content_changed(events: &mut Vec<QueuedEvent>) {
 fn enqueue_focus_event_if_applicable(
     events: &mut Vec<QueuedEvent>,
     node_id_map: &mut NodeIdMap,
-    node: &Node,
+    node: &NodeRef,
 ) {
     if node.is_root() && node.role() == Role::Window {
         return;
@@ -82,12 +81,12 @@ impl AdapterChangeHandler<'_> {
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
-    fn node_added(&mut self, _node: &Node) {
+    fn node_added(&mut self, _node: &NodeRef) {
         self.enqueue_window_content_changed_if_needed();
         // TODO: live regions?
     }
 
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         self.enqueue_window_content_changed_if_needed();
         if filter(new_node) != FilterResult::Include {
             return;
@@ -173,19 +172,19 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         // TODO: other events
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
+    fn focus_moved(&mut self, _old_node: Option<&NodeRef>, new_node: Option<&NodeRef>) {
         if let Some(new_node) = new_node {
             enqueue_focus_event_if_applicable(self.events, self.node_id_map, new_node);
         }
     }
 
-    fn node_removed(&mut self, _node: &Node) {
+    fn node_removed(&mut self, _node: &NodeRef) {
         self.enqueue_window_content_changed_if_needed();
         // TODO: other events?
     }
 }
 
-const PLACEHOLDER_ROOT_ID: LocalNodeId = LocalNodeId(0);
+const PLACEHOLDER_ROOT_ID: NodeId = NodeId(0);
 
 #[derive(Debug, Default)]
 enum State {
@@ -206,8 +205,8 @@ impl State {
                     Some(initial_state) => Self::Active(Tree::new(initial_state, true)),
                     None => {
                         let placeholder_update = TreeUpdate {
-                            nodes: vec![(PLACEHOLDER_ROOT_ID, NodeData::new(Role::Window))],
-                            tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
+                            nodes: vec![(PLACEHOLDER_ROOT_ID, Node::new(Role::Window))],
+                            tree: Some(TreeInfo::new(PLACEHOLDER_ROOT_ID)),
                             tree_id: TreeId::ROOT,
                             focus: PLACEHOLDER_ROOT_ID,
                         };
@@ -522,7 +521,7 @@ impl Adapter {
         selection_factory: F,
     ) -> Option<Extra>
     where
-        for<'a> F: FnOnce(&'a Node<'a>) -> Option<(TextPosition<'a>, TextPosition<'a>, Extra)>,
+        for<'a> F: FnOnce(&'a NodeRef<'a>) -> Option<(TextPosition<'a>, TextPosition<'a>, Extra)>,
     {
         let tree = self.state.get_full_tree()?;
         let tree_state = tree.state();

--- a/platforms/android/src/node.rs
+++ b/platforms/android/src/node.rs
@@ -9,7 +9,7 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{Action, Live, Role, Toggled};
-use accesskit_consumer::Node;
+use accesskit_consumer::NodeRef;
 use jni::{JNIEnv, objects::JObject, sys::jint};
 
 use crate::{filters::filter, util::*};
@@ -24,7 +24,7 @@ pub(crate) fn add_action(env: &mut JNIEnv, node_info: &JObject, action: jint) {
         .unwrap();
 }
 
-pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a NodeRef<'a>);
 
 impl NodeWrapper<'_> {
     fn is_editable(&self) -> bool {

--- a/platforms/android/src/util.rs
+++ b/platforms/android/src/util.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit_consumer::{Node, NodeId};
+use accesskit_consumer::{FullRefdeId, NodeId};
 use jni::{JNIEnv, objects::JObject, sys::jint};
 use std::collections::HashMap;
 
@@ -61,17 +61,17 @@ pub(crate) const RANGE_TYPE_FLOAT: jint = 1;
 
 #[derive(Debug, Default)]
 pub(crate) struct NodeIdMap {
-    java_to_accesskit: HashMap<jint, NodeId>,
-    accesskit_to_java: HashMap<NodeId, jint>,
+    java_to_accesskit: HashMap<jint, FullNodeId>,
+    accesskit_to_java: HashMap<FullNodeId, jint>,
     next_java_id: jint,
 }
 
 impl NodeIdMap {
-    pub(crate) fn get_accesskit_id(&self, java_id: jint) -> Option<NodeId> {
+    pub(crate) fn get_accesskit_id(&self, java_id: jint) -> Option<FullNodeId> {
         self.java_to_accesskit.get(&java_id).copied()
     }
 
-    pub(crate) fn get_or_create_java_id(&mut self, node: &Node) -> jint {
+    pub(crate) fn get_or_create_java_id(&mut self, node: &NodeRef) -> jint {
         if node.is_root() {
             return HOST_VIEW_ID;
         }

--- a/platforms/android/src/util.rs
+++ b/platforms/android/src/util.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit_consumer::{FullRefdeId, NodeId};
+use accesskit_consumer::{FullNodeId, NodeRef};
 use jni::{JNIEnv, objects::JObject, sys::jint};
 use std::collections::HashMap;
 

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -16,7 +16,7 @@ use crate::{
     util::WindowBounds,
 };
 use accesskit::{ActionHandler, Role, TreeUpdate};
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree, TreeChangeHandler, TreeState};
 use atspi_common::{InterfaceSet, Politeness, State};
 use std::fmt::{Debug, Formatter};
 use std::{
@@ -29,10 +29,10 @@ use std::{
 
 struct AdapterChangeHandler<'a> {
     adapter: &'a Adapter,
-    added_nodes: HashSet<NodeId>,
-    removed_nodes: HashSet<NodeId>,
-    checked_text_change: HashSet<NodeId>,
-    selection_changed: HashSet<NodeId>,
+    added_nodes: HashSet<FullNodeId>,
+    removed_nodes: HashSet<FullNodeId>,
+    checked_text_change: HashSet<FullNodeId>,
+    selection_changed: HashSet<FullNodeId>,
 }
 
 impl<'a> AdapterChangeHandler<'a> {
@@ -46,7 +46,7 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn add_node(&mut self, node: &Node) {
+    fn add_node(&mut self, node: &NodeRef) {
         let id = node.id();
         if self.added_nodes.contains(&id) {
             return;
@@ -81,14 +81,14 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn add_subtree(&mut self, node: &Node) {
+    fn add_subtree(&mut self, node: &NodeRef) {
         self.add_node(node);
         for child in node.filtered_children(&filter) {
             self.add_subtree(&child);
         }
     }
 
-    fn remove_node(&mut self, node: &Node) {
+    fn remove_node(&mut self, node: &NodeRef) {
         let id = node.id();
         if self.removed_nodes.contains(&id) {
             return;
@@ -111,14 +111,14 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn remove_subtree(&mut self, node: &Node) {
+    fn remove_subtree(&mut self, node: &NodeRef) {
         for child in node.filtered_children(&filter) {
             self.remove_subtree(&child);
         }
         self.remove_node(node);
     }
 
-    fn emit_text_change_if_needed_parent(&mut self, old_node: &Node, new_node: &Node) {
+    fn emit_text_change_if_needed_parent(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         if !new_node.supports_text_ranges() || !old_node.supports_text_ranges() {
             return;
         }
@@ -181,7 +181,7 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn emit_text_change_if_needed(&mut self, old_node: &Node, new_node: &Node) {
+    fn emit_text_change_if_needed(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         if let Role::TextRun | Role::GenericContainer = new_node.role() {
             if let (Some(old_parent), Some(new_parent)) = (
                 old_node.filtered_parent(&filter),
@@ -194,7 +194,7 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn emit_text_selection_change(&self, old_node: Option<&Node>, new_node: &Node) {
+    fn emit_text_selection_change(&self, old_node: Option<&NodeRef>, new_node: &NodeRef) {
         if !new_node.supports_text_ranges() {
             return;
         }
@@ -246,7 +246,7 @@ impl<'a> AdapterChangeHandler<'a> {
         }
     }
 
-    fn enqueue_selection_changed_if_needed_parent(&mut self, node: Node) {
+    fn enqueue_selection_changed_if_needed_parent(&mut self, node: NodeRef) {
         if !node.is_container_with_selectable_children() {
             return;
         }
@@ -257,7 +257,7 @@ impl<'a> AdapterChangeHandler<'a> {
         self.selection_changed.insert(id);
     }
 
-    fn enqueue_selection_changed_if_needed(&mut self, node: &Node) {
+    fn enqueue_selection_changed_if_needed(&mut self, node: &NodeRef) {
         if !node.is_item_like() {
             return;
         }
@@ -278,13 +278,13 @@ impl<'a> AdapterChangeHandler<'a> {
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
-    fn node_added(&mut self, node: &Node) {
+    fn node_added(&mut self, node: &NodeRef) {
         if filter(node) == FilterResult::Include {
             self.add_node(node);
         }
     }
 
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         self.emit_text_change_if_needed(old_node, new_node);
         let filter_old = filter(old_node);
         let filter_new = filter(new_node);
@@ -321,7 +321,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(&mut self, old_node: Option<&Node>, new_node: Option<&Node>) {
+    fn focus_moved(&mut self, old_node: Option<&NodeRef>, new_node: Option<&NodeRef>) {
         if let (None, Some(new_node)) = (old_node, new_node) {
             if let Some(root_window) = root_window(new_node.tree_state) {
                 self.adapter.window_activated(&NodeWrapper(&root_window));
@@ -342,7 +342,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_removed(&mut self, node: &Node) {
+    fn node_removed(&mut self, node: &NodeRef) {
         if filter(node) == FilterResult::Include {
             self.remove_node(node);
         }
@@ -442,7 +442,7 @@ impl Adapter {
     }
 
     fn register_tree(&self) {
-        fn add_children(node: Node<'_>, to_add: &mut Vec<(NodeId, InterfaceSet)>) {
+        fn add_children(node: NodeRef<'_>, to_add: &mut Vec<(FullNodeId, InterfaceSet)>) {
             for child in node.filtered_children(&filter) {
                 let child_id = child.id();
                 let wrapper = NodeWrapper(&child);
@@ -477,11 +477,11 @@ impl Adapter {
         }
     }
 
-    pub fn platform_node(&self, id: NodeId) -> PlatformNode {
+    pub fn platform_node(&self, id: FullNodeId) -> PlatformNode {
         PlatformNode::new(&self.context, self.id, id)
     }
 
-    pub fn root_id(&self) -> NodeId {
+    pub fn root_id(&self) -> FullNodeId {
         self.context.read_tree().state().root_id()
     }
 
@@ -489,16 +489,16 @@ impl Adapter {
         PlatformRoot::new(&self.context.app_context)
     }
 
-    fn register_interfaces(&self, id: NodeId, new_interfaces: InterfaceSet) {
+    fn register_interfaces(&self, id: FullNodeId, new_interfaces: InterfaceSet) {
         self.callback.register_interfaces(self, id, new_interfaces);
     }
 
-    fn unregister_interfaces(&self, id: NodeId, old_interfaces: InterfaceSet) {
+    fn unregister_interfaces(&self, id: FullNodeId, old_interfaces: InterfaceSet) {
         self.callback
             .unregister_interfaces(self, id, old_interfaces);
     }
 
-    pub(crate) fn emit_object_event(&self, target: NodeId, event: ObjectEvent) {
+    pub(crate) fn emit_object_event(&self, target: FullNodeId, event: ObjectEvent) {
         let target = NodeIdOrRoot::Node(target);
         self.callback
             .emit_event(self, Event::Object { target, event });
@@ -510,12 +510,12 @@ impl Adapter {
             .emit_event(self, Event::Object { target, event });
     }
 
-    fn emit_cache_added(&self, target: NodeId) {
+    fn emit_cache_added(&self, target: FullNodeId) {
         self.callback
             .emit_event(self, Event::Cache(CacheEvent::Added(target)));
     }
 
-    fn emit_cache_removed(&self, target: NodeId) {
+    fn emit_cache_removed(&self, target: FullNodeId) {
         self.callback
             .emit_event(self, Event::Cache(CacheEvent::Removed(target)));
     }
@@ -539,7 +539,7 @@ impl Adapter {
         tree.update_host_focus_state_and_process_changes(is_focused, &mut handler);
     }
 
-    fn window_created(&self, adapter_index: usize, window: NodeId) {
+    fn window_created(&self, adapter_index: usize, window: FullNodeId) {
         self.emit_root_object_event(ObjectEvent::ChildAdded(adapter_index, window));
     }
 
@@ -568,7 +568,7 @@ impl Adapter {
         self.emit_object_event(window.id(), ObjectEvent::StateChanged(State::Active, false));
     }
 
-    fn window_destroyed(&self, window: NodeId) {
+    fn window_destroyed(&self, window: FullNodeId) {
         self.emit_root_object_event(ObjectEvent::ChildRemoved(window));
     }
 
@@ -591,7 +591,7 @@ impl Adapter {
     }
 }
 
-fn root_window(current_state: &TreeState) -> Option<Node<'_>> {
+fn root_window(current_state: &TreeState) -> Option<NodeRef<'_>> {
     const WINDOW_ROLES: &[Role] = &[Role::AlertDialog, Role::Dialog, Role::Window];
     let root = current_state.root();
     if WINDOW_ROLES.contains(&root.role()) {
@@ -617,15 +617,15 @@ mod tests {
     use super::Adapter;
     use crate::{AdapterCallback, AppContext, CacheEvent, Event, InterfaceSet, WindowBounds};
     use accesskit::{
-        ActionHandler, ActionRequest, Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate,
+        ActionHandler, ActionRequest, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate,
     };
-    use accesskit_consumer::NodeId;
+    use accesskit_consumer::FullNodeId;
     use std::sync::{Arc, Mutex};
 
     #[derive(Clone, Copy, Debug, PartialEq)]
     enum CacheOp {
-        Added(NodeId),
-        Removed(NodeId),
+        Added(FullNodeId),
+        Removed(FullNodeId),
     }
 
     struct CapturingCallback {
@@ -633,8 +633,8 @@ mod tests {
     }
 
     impl AdapterCallback for CapturingCallback {
-        fn register_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
-        fn unregister_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
+        fn register_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
+        fn unregister_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
         fn emit_event(&self, _: &Adapter, event: Event) {
             let mut ops = self.ops.lock().unwrap();
             match event {
@@ -650,7 +650,7 @@ mod tests {
         fn do_action(&mut self, _request: ActionRequest) {}
     }
 
-    fn with_children(role: Role, children: &[LocalNodeId]) -> Node {
+    fn with_children(role: Role, children: &[NodeId]) -> Node {
         let mut node = Node::new(role);
         node.set_children(children.to_vec());
         node
@@ -673,24 +673,21 @@ mod tests {
     fn initial_tree() -> TreeUpdate {
         TreeUpdate {
             nodes: vec![
-                (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1)]),
-                ),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(0), with_children(Role::Window, &[NodeId(1)])),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         }
     }
 
-    fn update(nodes: Vec<(LocalNodeId, Node)>) -> TreeUpdate {
+    fn update(nodes: Vec<(NodeId, Node)>) -> TreeUpdate {
         TreeUpdate {
             nodes,
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         }
     }
 
@@ -706,10 +703,10 @@ mod tests {
         ops.lock().unwrap().clear();
         adapter.update(update(vec![
             (
-                LocalNodeId(0),
-                with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                NodeId(0),
+                with_children(Role::Window, &[NodeId(1), NodeId(2)]),
             ),
-            (LocalNodeId(2), Node::new(Role::Button)),
+            (NodeId(2), Node::new(Role::Button)),
         ]));
         let ops = ops.lock().unwrap();
         assert_eq!(ops.len(), 1);
@@ -721,10 +718,10 @@ mod tests {
         let (mut adapter, ops) = build(initial_tree());
         adapter.update(update(vec![
             (
-                LocalNodeId(0),
-                with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                NodeId(0),
+                with_children(Role::Window, &[NodeId(1), NodeId(2)]),
             ),
-            (LocalNodeId(2), Node::new(Role::Button)),
+            (NodeId(2), Node::new(Role::Button)),
         ]));
         let added_id = match ops.lock().unwrap().as_slice() {
             [CacheOp::Added(id)] => *id,
@@ -732,8 +729,8 @@ mod tests {
         };
         ops.lock().unwrap().clear();
         adapter.update(update(vec![(
-            LocalNodeId(0),
-            with_children(Role::Window, &[LocalNodeId(1)]),
+            NodeId(0),
+            with_children(Role::Window, &[NodeId(1)]),
         )]));
         assert_eq!(*ops.lock().unwrap(), vec![CacheOp::Removed(added_id)]);
     }
@@ -744,15 +741,15 @@ mod tests {
         ops.lock().unwrap().clear();
         adapter.update(update(vec![
             (
-                LocalNodeId(0),
-                with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                NodeId(0),
+                with_children(Role::Window, &[NodeId(1), NodeId(2)]),
             ),
             (
-                LocalNodeId(2),
-                with_children(Role::Group, &[LocalNodeId(3), LocalNodeId(4)]),
+                NodeId(2),
+                with_children(Role::Group, &[NodeId(3), NodeId(4)]),
             ),
-            (LocalNodeId(3), Node::new(Role::Button)),
-            (LocalNodeId(4), Node::new(Role::Button)),
+            (NodeId(3), Node::new(Role::Button)),
+            (NodeId(4), Node::new(Role::Button)),
         ]));
         let ops = ops.lock().unwrap();
         assert_eq!(ops.len(), 3);
@@ -764,20 +761,20 @@ mod tests {
         let (mut adapter, ops) = build(initial_tree());
         adapter.update(update(vec![
             (
-                LocalNodeId(0),
-                with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                NodeId(0),
+                with_children(Role::Window, &[NodeId(1), NodeId(2)]),
             ),
             (
-                LocalNodeId(2),
-                with_children(Role::Group, &[LocalNodeId(3), LocalNodeId(4)]),
+                NodeId(2),
+                with_children(Role::Group, &[NodeId(3), NodeId(4)]),
             ),
-            (LocalNodeId(3), Node::new(Role::Button)),
-            (LocalNodeId(4), Node::new(Role::Button)),
+            (NodeId(3), Node::new(Role::Button)),
+            (NodeId(4), Node::new(Role::Button)),
         ]));
         ops.lock().unwrap().clear();
         adapter.update(update(vec![(
-            LocalNodeId(0),
-            with_children(Role::Window, &[LocalNodeId(1)]),
+            NodeId(0),
+            with_children(Role::Window, &[NodeId(1)]),
         )]));
         let ops = ops.lock().unwrap();
         assert_eq!(ops.len(), 3);
@@ -791,18 +788,18 @@ mod tests {
         let (mut adapter, ops) = build(TreeUpdate {
             nodes: vec![
                 (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                    NodeId(0),
+                    with_children(Role::Window, &[NodeId(1), NodeId(2)]),
                 ),
-                (LocalNodeId(1), Node::new(Role::Button)),
-                (LocalNodeId(2), hidden),
+                (NodeId(1), Node::new(Role::Button)),
+                (NodeId(2), hidden),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         });
         ops.lock().unwrap().clear();
-        adapter.update(update(vec![(LocalNodeId(2), Node::new(Role::Button))]));
+        adapter.update(update(vec![(NodeId(2), Node::new(Role::Button))]));
         let ops = ops.lock().unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(ops[0], CacheOp::Added(_)));
@@ -814,7 +811,7 @@ mod tests {
         ops.lock().unwrap().clear();
         let mut hidden = Node::new(Role::Button);
         hidden.set_hidden();
-        adapter.update(update(vec![(LocalNodeId(1), hidden)]));
+        adapter.update(update(vec![(NodeId(1), hidden)]));
         let ops = ops.lock().unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(ops[0], CacheOp::Removed(_)));

--- a/platforms/atspi-common/src/callback.rs
+++ b/platforms/atspi-common/src/callback.rs
@@ -3,13 +3,13 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit_consumer::NodeId;
+use accesskit_consumer::FullNodeId;
 use atspi_common::InterfaceSet;
 
 use crate::{Adapter, Event};
 
 pub trait AdapterCallback {
-    fn register_interfaces(&self, adapter: &Adapter, id: NodeId, interfaces: InterfaceSet);
-    fn unregister_interfaces(&self, adapter: &Adapter, id: NodeId, interfaces: InterfaceSet);
+    fn register_interfaces(&self, adapter: &Adapter, id: FullNodeId, interfaces: InterfaceSet);
+    fn unregister_interfaces(&self, adapter: &Adapter, id: FullNodeId, interfaces: InterfaceSet);
     fn emit_event(&self, adapter: &Adapter, event: Event);
 }

--- a/platforms/atspi-common/src/events.rs
+++ b/platforms/atspi-common/src/events.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit_consumer::NodeId;
+use accesskit_consumer::FullNodeId;
 use atspi_common::{Politeness, Role, State};
 
 use crate::{NodeIdOrRoot, Rect};
@@ -15,7 +15,7 @@ pub enum Event {
         event: ObjectEvent,
     },
     Window {
-        target: NodeId,
+        target: FullNodeId,
         name: String,
         event: WindowEvent,
     },
@@ -24,8 +24,8 @@ pub enum Event {
 
 #[derive(Debug)]
 pub enum CacheEvent {
-    Added(NodeId),
-    Removed(NodeId),
+    Added(FullNodeId),
+    Removed(FullNodeId),
 }
 
 #[derive(Debug)]
@@ -40,12 +40,12 @@ pub enum Property {
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 pub enum ObjectEvent {
-    ActiveDescendantChanged(NodeId),
+    ActiveDescendantChanged(FullNodeId),
     Announcement(String, Politeness),
     BoundsChanged(Rect),
     CaretMoved(i32),
-    ChildAdded(usize, NodeId),
-    ChildRemoved(NodeId),
+    ChildAdded(usize, FullNodeId),
+    ChildRemoved(FullNodeId),
     PropertyChanged(Property),
     SelectionChanged,
     StateChanged(State, bool),

--- a/platforms/atspi-common/src/lib.rs
+++ b/platforms/atspi-common/src/lib.rs
@@ -17,7 +17,7 @@ pub mod simplified;
 mod text_attributes;
 mod util;
 
-pub use accesskit_consumer::NodeId;
+pub use accesskit_consumer::FullNodeId;
 pub use atspi_common::{
     CoordType, Granularity, InterfaceSet, Layer, RelationType, Role, ScrollType, State, StateSet,
 };

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -9,10 +9,10 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    Action, ActionData, ActionRequest, Affine, Live, NodeId as LocalNodeId, Orientation, Point,
-    Rect, Role, Toggled, TreeId,
+    Action, ActionData, ActionRequest, Affine, Live, NodeId, Orientation, Point, Rect, Role,
+    Toggled, TreeId,
 };
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeState};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree, TreeState};
 use atspi_common::{
     CoordType, Granularity, Interface, InterfaceSet, Layer, Politeness, RelationType,
     Role as AtspiRole, ScrollType, State, StateSet,
@@ -32,7 +32,7 @@ use crate::{
     util::*,
 };
 
-pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a NodeRef<'a>);
 
 impl NodeWrapper<'_> {
     pub(crate) fn name(&self) -> Option<String> {
@@ -47,11 +47,11 @@ impl NodeWrapper<'_> {
         self.0.description()
     }
 
-    pub(crate) fn parent_id(&self) -> Option<NodeId> {
+    pub(crate) fn parent_id(&self) -> Option<FullNodeId> {
         self.0.parent_id()
     }
 
-    pub(crate) fn id(&self) -> NodeId {
+    pub(crate) fn id(&self) -> FullNodeId {
         self.0.id()
     }
 
@@ -80,7 +80,7 @@ impl NodeWrapper<'_> {
         }
     }
 
-    fn filtered_child_ids(&self) -> impl DoubleEndedIterator<Item = NodeId> {
+    fn filtered_child_ids(&self) -> impl DoubleEndedIterator<Item = FullNodeId> {
         self.0.filtered_children(&filter).map(|child| child.id())
     }
 
@@ -628,8 +628,8 @@ impl NodeWrapper<'_> {
     }
 
     fn notify_children_changes(&self, adapter: &Adapter, old: &NodeWrapper<'_>) {
-        let old_filtered_children = old.filtered_child_ids().collect::<Vec<NodeId>>();
-        let new_filtered_children = self.filtered_child_ids().collect::<Vec<NodeId>>();
+        let old_filtered_children = old.filtered_child_ids().collect::<Vec<FullNodeId>>();
+        let new_filtered_children = self.filtered_child_ids().collect::<Vec<FullNodeId>>();
         for (index, child) in new_filtered_children.iter().enumerate() {
             if !old_filtered_children.contains(child) {
                 adapter.emit_object_event(self.id(), ObjectEvent::ChildAdded(index, *child));
@@ -647,11 +647,11 @@ impl NodeWrapper<'_> {
 pub struct PlatformNode {
     context: Weak<Context>,
     adapter_id: usize,
-    id: NodeId,
+    id: FullNodeId,
 }
 
 impl PlatformNode {
-    pub(crate) fn new(context: &Arc<Context>, adapter_id: usize, id: NodeId) -> Self {
+    pub(crate) fn new(context: &Arc<Context>, adapter_id: usize, id: FullNodeId) -> Self {
         Self {
             context: Arc::downgrade(context),
             adapter_id,
@@ -692,7 +692,7 @@ impl PlatformNode {
 
     fn resolve_with_context<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &'a Tree, &Context) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &'a Tree, &Context) -> Result<T>,
     {
         self.with_tree_and_context(|tree, context| {
             if let Some(node) = tree.state().node_by_id(self.id) {
@@ -705,7 +705,7 @@ impl PlatformNode {
 
     fn resolve_for_selection_with_context<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &'a Tree, &Context) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &'a Tree, &Context) -> Result<T>,
     {
         self.resolve_with_context(|node, tree, context| {
             let wrapper = NodeWrapper(&node);
@@ -719,7 +719,7 @@ impl PlatformNode {
 
     fn resolve_for_text_with_context<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &'a Tree, &Context) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &'a Tree, &Context) -> Result<T>,
     {
         self.resolve_with_context(|node, tree, context| {
             let wrapper = NodeWrapper(&node);
@@ -733,14 +733,14 @@ impl PlatformNode {
 
     fn resolve<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>) -> Result<T>,
     {
         self.resolve_with_context(|node, _, _| f(node))
     }
 
     fn resolve_for_selection<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>) -> Result<T>,
     {
         self.resolve(|node| {
             let wrapper = NodeWrapper(&node);
@@ -754,14 +754,14 @@ impl PlatformNode {
 
     fn resolve_for_text<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>) -> Result<T>,
     {
         self.resolve_for_text_with_context(|node, _, _| f(node))
     }
 
-    fn do_action_internal<F>(&self, target: NodeId, f: F) -> Result<()>
+    fn do_action_internal<F>(&self, target: FullNodeId, f: F) -> Result<()>
     where
-        F: FnOnce(&TreeState, &Context, LocalNodeId, TreeId) -> ActionRequest,
+        F: FnOnce(&TreeState, &Context, NodeId, TreeId) -> ActionRequest,
     {
         let context = self.upgrade_context()?;
         let tree = context.read_tree();
@@ -789,7 +789,7 @@ impl PlatformNode {
         })
     }
 
-    pub fn relative(&self, id: NodeId) -> Self {
+    pub fn relative(&self, id: FullNodeId) -> Self {
         Self {
             context: self.context.clone(),
             adapter_id: self.adapter_id,
@@ -830,7 +830,7 @@ impl PlatformNode {
         self.adapter_id
     }
 
-    pub fn id(&self) -> NodeId {
+    pub fn id(&self) -> FullNodeId {
         self.id
     }
 
@@ -844,7 +844,7 @@ impl PlatformNode {
         })
     }
 
-    pub fn child_at_index(&self, index: usize) -> Result<Option<NodeId>> {
+    pub fn child_at_index(&self, index: usize) -> Result<Option<FullNodeId>> {
         self.resolve(|node| {
             let child = node
                 .filtered_children(&filter)
@@ -854,7 +854,7 @@ impl PlatformNode {
         })
     }
 
-    pub fn map_children<T, I>(&self, f: impl Fn(NodeId) -> I) -> Result<T>
+    pub fn map_children<T, I>(&self, f: impl Fn(FullNodeId) -> I) -> Result<T>
     where
         T: FromIterator<I>,
     {
@@ -909,7 +909,7 @@ impl PlatformNode {
 
     pub fn relation_set<T>(
         &self,
-        f: impl Fn(NodeId) -> T,
+        f: impl Fn(FullNodeId) -> T,
     ) -> Result<HashMap<RelationType, Vec<T>>> {
         self.resolve(|node| {
             let mut relations = HashMap::new();
@@ -1061,7 +1061,7 @@ impl PlatformNode {
         x: i32,
         y: i32,
         coord_type: CoordType,
-    ) -> Result<Option<NodeId>> {
+    ) -> Result<Option<FullNodeId>> {
         self.resolve_with_context(|node, _, context| {
             let window_bounds = context.read_root_window_bounds();
             let point = window_bounds.atspi_point_to_accesskit_point(
@@ -1154,7 +1154,7 @@ impl PlatformNode {
         })
     }
 
-    pub fn hyperlink_object(&self, index: i32) -> Result<Option<NodeId>> {
+    pub fn hyperlink_object(&self, index: i32) -> Result<Option<FullNodeId>> {
         self.resolve(|_| {
             if index == 0 {
                 Ok(Some(self.id))
@@ -1188,7 +1188,7 @@ impl PlatformNode {
         })
     }
 
-    pub fn selected_child(&self, selected_child_index: usize) -> Result<Option<NodeId>> {
+    pub fn selected_child(&self, selected_child_index: usize) -> Result<Option<FullNodeId>> {
         self.resolve_for_selection(|node| {
             Ok(node
                 .items(filter)
@@ -1744,7 +1744,7 @@ impl PlatformRoot {
         })
     }
 
-    pub fn child_id_at_index(&self, index: usize) -> Result<Option<(usize, NodeId)>> {
+    pub fn child_id_at_index(&self, index: usize) -> Result<Option<(usize, FullNodeId)>> {
         self.resolve_app_context(|context| {
             let child = context
                 .adapters
@@ -1769,7 +1769,7 @@ impl PlatformRoot {
         })
     }
 
-    pub fn map_child_ids<T, I>(&self, f: impl Fn((usize, NodeId)) -> I) -> Result<T>
+    pub fn map_child_ids<T, I>(&self, f: impl Fn((usize, FullNodeId)) -> I) -> Result<T>
     where
         T: FromIterator<I>,
     {
@@ -1811,7 +1811,7 @@ impl PlatformRoot {
         T: FromIterator<I>,
     {
         fn collect_descendants<I>(
-            node: Node<'_>,
+            node: NodeRef<'_>,
             index_in_parent: usize,
             adapter_id: usize,
             context: &Arc<Context>,
@@ -1854,7 +1854,7 @@ impl PlatformRoot {
         T: FromIterator<I>,
     {
         fn collect_descendants<I>(
-            node: Node<'_>,
+            node: NodeRef<'_>,
             index_in_parent: i32,
             adapter_id: usize,
             window_focused: bool,
@@ -1926,13 +1926,13 @@ impl Hash for PlatformRoot {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NodeIdOrRoot {
-    Node(NodeId),
+    Node(FullNodeId),
     Root,
 }
 
 pub struct CacheNode {
     pub adapter_id: usize,
-    pub id: NodeId,
+    pub id: FullNodeId,
     pub parent: NodeIdOrRoot,
     pub index_in_parent: i32,
     pub child_count: i32,

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -784,9 +784,7 @@ impl Event {
 mod tests {
     use super::{Accessible, Cache, Event as SimplifiedEvent};
     use crate::{Adapter, AdapterCallback, AppContext, Event, WindowBounds};
-    use accesskit::{
-        ActionHandler, ActionRequest, Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate,
-    };
+    use accesskit::{ActionHandler, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
     use accesskit_consumer::NodeId;
     use atspi_common::InterfaceSet;
     use std::sync::{Arc, Mutex};
@@ -818,7 +816,7 @@ mod tests {
         fn emit_event(&self, _: &Adapter, _: Event) {}
     }
 
-    fn with_children(role: Role, children: &[LocalNodeId]) -> Node {
+    fn with_children(role: Role, children: &[NodeId]) -> Node {
         let mut node = Node::new(role);
         node.set_children(children.to_vec());
         node
@@ -827,15 +825,12 @@ mod tests {
     fn initial_tree() -> TreeUpdate {
         TreeUpdate {
             nodes: vec![
-                (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1)]),
-                ),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(0), with_children(Role::Window, &[NodeId(1)])),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(Tree::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         }
     }
 
@@ -856,23 +851,20 @@ mod tests {
         adapter.update(TreeUpdate {
             nodes: vec![
                 (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                    NodeId(0),
+                    with_children(Role::Window, &[NodeId(1), NodeId(2)]),
                 ),
-                (LocalNodeId(2), Node::new(Role::Button)),
+                (NodeId(2), Node::new(Role::Button)),
             ],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         });
         adapter.update(TreeUpdate {
-            nodes: vec![(
-                LocalNodeId(0),
-                with_children(Role::Window, &[LocalNodeId(1)]),
-            )],
+            nodes: vec![(NodeId(0), with_children(Role::Window, &[NodeId(1)]))],
             tree: None,
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         });
         assert_eq!(*kinds.lock().unwrap(), vec!["cache:add", "cache:remove"]);
     }

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -784,8 +784,10 @@ impl Event {
 mod tests {
     use super::{Accessible, Cache, Event as SimplifiedEvent};
     use crate::{Adapter, AdapterCallback, AppContext, Event, WindowBounds};
-    use accesskit::{ActionHandler, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
-    use accesskit_consumer::NodeId;
+    use accesskit::{
+        ActionHandler, ActionRequest, Node, NodeId, Role, TreeInfo, TreeIo, TreeUpdate,
+    };
+    use accesskit_consumer::FullNodeId;
     use atspi_common::InterfaceSet;
     use std::sync::{Arc, Mutex};
 
@@ -799,8 +801,8 @@ mod tests {
     }
 
     impl AdapterCallback for CacheKindCallback {
-        fn register_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
-        fn unregister_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
+        fn register_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
+        fn unregister_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
         fn emit_event(&self, adapter: &Adapter, event: Event) {
             if matches!(event, Event::Cache(_)) {
                 let simplified = SimplifiedEvent::new(adapter, event);
@@ -811,8 +813,8 @@ mod tests {
 
     struct NoOpCallback;
     impl AdapterCallback for NoOpCallback {
-        fn register_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
-        fn unregister_interfaces(&self, _: &Adapter, _: NodeId, _: InterfaceSet) {}
+        fn register_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
+        fn unregister_interfaces(&self, _: &Adapter, _: FullNodeId, _: InterfaceSet) {}
         fn emit_event(&self, _: &Adapter, _: Event) {}
     }
 
@@ -828,7 +830,7 @@ mod tests {
                 (NodeId(0), with_children(Role::Window, &[NodeId(1)])),
                 (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(NodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
             focus: NodeId(0),
         }

--- a/platforms/atspi-common/src/simplified.rs
+++ b/platforms/atspi-common/src/simplified.rs
@@ -785,7 +785,7 @@ mod tests {
     use super::{Accessible, Cache, Event as SimplifiedEvent};
     use crate::{Adapter, AdapterCallback, AppContext, Event, WindowBounds};
     use accesskit::{
-        ActionHandler, ActionRequest, Node, NodeId, Role, TreeInfo, TreeIo, TreeUpdate,
+        ActionHandler, ActionRequest, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate,
     };
     use accesskit_consumer::FullNodeId;
     use atspi_common::InterfaceSet;

--- a/platforms/atspi-common/src/text_attributes.rs
+++ b/platforms/atspi-common/src/text_attributes.rs
@@ -4,34 +4,34 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Color, TextAlign, TextDecorationStyle};
-use accesskit_consumer::Node;
+use accesskit_consumer::NodeRef;
 use phf::phf_map;
 
 fn color_to_string(color: Color) -> String {
     format!("{},{},{}", color.red, color.green, color.blue)
 }
 
-fn family_name(node: &Node) -> Option<String> {
+fn family_name(node: &NodeRef) -> Option<String> {
     node.font_family().map(String::from)
 }
 
-fn size(node: &Node) -> Option<String> {
+fn size(node: &NodeRef) -> Option<String> {
     node.font_size().map(|value| value.to_string())
 }
 
-fn weight(node: &Node) -> Option<String> {
+fn weight(node: &NodeRef) -> Option<String> {
     node.font_weight().map(|value| value.to_string())
 }
 
-fn style(node: &Node) -> Option<String> {
+fn style(node: &NodeRef) -> Option<String> {
     node.is_italic().then(|| "italic".into())
 }
 
-fn strikethrough(node: &Node) -> Option<String> {
+fn strikethrough(node: &NodeRef) -> Option<String> {
     node.strikethrough().map(|_| "true".into())
 }
 
-fn underline(node: &Node) -> Option<String> {
+fn underline(node: &NodeRef) -> Option<String> {
     node.underline().map(|deco| {
         match deco.style {
             TextDecorationStyle::Double => "double",
@@ -41,19 +41,19 @@ fn underline(node: &Node) -> Option<String> {
     })
 }
 
-fn bg_color(node: &Node) -> Option<String> {
+fn bg_color(node: &NodeRef) -> Option<String> {
     node.background_color().map(color_to_string)
 }
 
-fn fg_color(node: &Node) -> Option<String> {
+fn fg_color(node: &NodeRef) -> Option<String> {
     node.foreground_color().map(color_to_string)
 }
 
-fn language(node: &Node) -> Option<String> {
+fn language(node: &NodeRef) -> Option<String> {
     node.language().map(String::from)
 }
 
-fn justification(node: &Node) -> Option<String> {
+fn justification(node: &NodeRef) -> Option<String> {
     node.text_align().map(|align| {
         match align {
             TextAlign::Left => "left",
@@ -65,7 +65,7 @@ fn justification(node: &Node) -> Option<String> {
     })
 }
 
-pub(crate) const ATTRIBUTE_GETTERS: phf::Map<&'static str, fn(&Node) -> Option<String>> = phf_map! {
+pub(crate) const ATTRIBUTE_GETTERS: phf::Map<&'static str, fn(&NodeRef) -> Option<String>> = phf_map! {
     "family-name" => family_name,
     "size" => size,
     "weight" => weight,

--- a/platforms/atspi-common/src/util.rs
+++ b/platforms/atspi-common/src/util.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Point, Rect, ScrollHint};
-use accesskit_consumer::{Node, TextPosition, TextRange};
+use accesskit_consumer::{NodeRef, TextPosition, TextRange};
 use atspi_common::{CoordType, Granularity, ScrollType};
 
 use crate::Error;
@@ -23,7 +23,7 @@ impl WindowBounds {
     pub(crate) fn accesskit_point_to_atspi_point(
         &self,
         point: Point,
-        parent: Option<Node>,
+        parent: Option<NodeRef>,
         coord_type: CoordType,
     ) -> Point {
         let origin = self.origin(parent, coord_type);
@@ -33,14 +33,14 @@ impl WindowBounds {
     pub(crate) fn atspi_point_to_accesskit_point(
         &self,
         point: Point,
-        parent: Option<Node>,
+        parent: Option<NodeRef>,
         coord_type: CoordType,
     ) -> Point {
         let origin = self.origin(parent, coord_type);
         Point::new(point.x - origin.x, point.y - origin.y)
     }
 
-    fn origin(&self, parent: Option<Node>, coord_type: CoordType) -> Point {
+    fn origin(&self, parent: Option<NodeRef>, coord_type: CoordType) -> Point {
         match coord_type {
             CoordType::Screen => self.inner.origin(),
             CoordType::Window => Point::ZERO,
@@ -57,7 +57,7 @@ impl WindowBounds {
 }
 
 pub(crate) fn text_position_from_offset<'a>(
-    node: &'a Node,
+    node: &'a NodeRef,
     offset: i32,
 ) -> Option<TextPosition<'a>> {
     let index = offset.try_into().ok()?;
@@ -65,7 +65,7 @@ pub(crate) fn text_position_from_offset<'a>(
 }
 
 pub(crate) fn text_range_from_offset<'a>(
-    node: &'a Node,
+    node: &'a NodeRef,
     offset: i32,
     granularity: Granularity,
 ) -> Result<TextRange<'a>, Error> {
@@ -94,7 +94,7 @@ pub(crate) fn text_range_from_offset<'a>(
 }
 
 pub(crate) fn text_range_from_offsets<'a>(
-    node: &'a Node,
+    node: &'a NodeRef,
     start_offset: i32,
     end_offset: i32,
 ) -> Option<TextRange<'a>> {
@@ -111,7 +111,7 @@ pub(crate) fn text_range_from_offsets<'a>(
 }
 
 pub(crate) fn text_range_bounds_from_offsets(
-    node: &Node,
+    node: &NodeRef,
     start_offset: i32,
     end_offset: i32,
 ) -> Option<Rect> {

--- a/platforms/ios/src/adapter.rs
+++ b/platforms/ios/src/adapter.rs
@@ -9,8 +9,8 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{
-    ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node as NodeProvider,
-    NodeId, Role, Tree as TreeData, TreeId, TreeUpdate,
+    ActionHandler, ActionRequest, ActivationHandler, DeactivationHandler, Node, NodeId, Role,
+    TreeId, TreeInfo, TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Tree};
 use objc2::{
@@ -164,8 +164,8 @@ fn get_or_init_context(
             }
             None => {
                 let placeholder_update = TreeUpdate {
-                    nodes: vec![(PLACEHOLDER_ROOT_ID, NodeProvider::new(Role::Window))],
-                    tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
+                    nodes: vec![(PLACEHOLDER_ROOT_ID, Node::new(Role::Window))],
+                    tree: Some(TreeInfo::new(PLACEHOLDER_ROOT_ID)),
                     tree_id: TreeId::ROOT,
                     focus: PLACEHOLDER_ROOT_ID,
                 };

--- a/platforms/ios/src/context.rs
+++ b/platforms/ios/src/context.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, ActionRequest};
-use accesskit_consumer::{NodeId, Tree};
+use accesskit_consumer::{FullNodeId, Tree};
 use hashbrown::HashMap;
 use objc2::rc::{Retained, WeakId};
 use objc2_foundation::MainThreadMarker;
@@ -36,8 +36,8 @@ pub(crate) struct Context {
     pub(crate) view: WeakId<UIView>,
     pub(crate) tree: RefCell<Tree>,
     pub(crate) action_handler: Rc<dyn ActionHandlerNoMut>,
-    platform_nodes: RefCell<HashMap<NodeId, Retained<PlatformNode>>>,
-    pub(crate) platform_focus: RefCell<Option<NodeId>>,
+    platform_nodes: RefCell<HashMap<FullNodeId, Retained<PlatformNode>>>,
+    pub(crate) platform_focus: RefCell<Option<FullNodeId>>,
     pub(crate) mtm: MainThreadMarker,
 }
 
@@ -73,7 +73,7 @@ impl Context {
 
     pub(crate) fn get_or_create_platform_node(
         self: &Rc<Self>,
-        id: NodeId,
+        id: FullNodeId,
     ) -> Option<Retained<PlatformNode>> {
         if let Some(result) = self.platform_nodes.borrow().get(&id) {
             return Some(result.clone());
@@ -84,7 +84,7 @@ impl Context {
         Some(result)
     }
 
-    pub(crate) fn remove_platform_node(&self, id: NodeId) -> Option<Retained<PlatformNode>> {
+    pub(crate) fn remove_platform_node(&self, id: FullNodeId) -> Option<Retained<PlatformNode>> {
         let mut platform_nodes = self.platform_nodes.borrow_mut();
         platform_nodes.remove(&id)
     }

--- a/platforms/ios/src/event.rs
+++ b/platforms/ios/src/event.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::Live;
-use accesskit_consumer::{FilterResult, Node, NodeId, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, TreeChangeHandler};
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_foundation::{
     NSAttributedString, NSAttributedStringKey, NSMutableDictionary, NSNumber, NSString,
@@ -26,10 +26,10 @@ use crate::{
 
 pub(crate) enum QueuedEvent {
     Generic {
-        node_id: Option<NodeId>,
+        node_id: Option<FullNodeId>,
         notification: UIAccessibilityNotifications,
     },
-    NodeDestroyed(NodeId),
+    NodeDestroyed(FullNodeId),
     Announcement {
         text: String,
         assertive: bool,
@@ -129,14 +129,14 @@ impl QueuedEvents {
     }
 }
 
-pub(crate) fn layout_event(node_id: Option<NodeId>) -> QueuedEvent {
+pub(crate) fn layout_event(node_id: Option<FullNodeId>) -> QueuedEvent {
     QueuedEvent::Generic {
         node_id,
         notification: unsafe { UIAccessibilityLayoutChangedNotification },
     }
 }
 
-pub(crate) fn screen_changed_event(node_id: Option<NodeId>) -> QueuedEvent {
+pub(crate) fn screen_changed_event(node_id: Option<FullNodeId>) -> QueuedEvent {
     QueuedEvent::Generic {
         node_id,
         notification: unsafe { UIAccessibilityScreenChangedNotification },
@@ -145,8 +145,8 @@ pub(crate) fn screen_changed_event(node_id: Option<NodeId>) -> QueuedEvent {
 
 pub(crate) struct EventGenerator {
     context: Rc<Context>,
-    platform_focus: Option<NodeId>,
-    layout_event_focus: Option<Option<NodeId>>,
+    platform_focus: Option<FullNodeId>,
+    layout_event_focus: Option<Option<FullNodeId>>,
     events: Vec<QueuedEvent>,
 }
 
@@ -161,7 +161,7 @@ impl EventGenerator {
         }
     }
 
-    fn insert_focus_moved_event_if_needed(&mut self, focus: NodeId) {
+    fn insert_focus_moved_event_if_needed(&mut self, focus: FullNodeId) {
         if self.platform_focus != Some(focus) {
             self.layout_event_focus = Some(Some(focus));
         }
@@ -173,7 +173,7 @@ impl EventGenerator {
         }
     }
 
-    fn remove_node(&mut self, id: NodeId) {
+    fn remove_node(&mut self, id: FullNodeId) {
         self.insert_layout_changed_event_if_needed();
         if self.platform_focus == Some(id) {
             *self.context.platform_focus.borrow_mut() = None;
@@ -182,7 +182,7 @@ impl EventGenerator {
         self.events.push(QueuedEvent::NodeDestroyed(id));
     }
 
-    fn remove_subtree(&mut self, node: &Node) {
+    fn remove_subtree(&mut self, node: &NodeRef) {
         let mut to_remove = VecDeque::new();
         to_remove.push_back(*node);
 
@@ -205,7 +205,7 @@ impl EventGenerator {
 }
 
 impl TreeChangeHandler for EventGenerator {
-    fn node_added(&mut self, node: &Node) {
+    fn node_added(&mut self, node: &NodeRef) {
         if filter(node) != FilterResult::Include {
             return;
         }
@@ -218,7 +218,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         let old_filter_result = filter(old_node);
         let old_included = old_filter_result == FilterResult::Include;
         let new_filter_result = filter(new_node);
@@ -252,7 +252,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
+    fn focus_moved(&mut self, _old_node: Option<&NodeRef>, new_node: Option<&NodeRef>) {
         if let Some(new_node) = new_node {
             if filter(new_node) != FilterResult::Include {
                 return;
@@ -261,7 +261,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_removed(&mut self, node: &Node) {
+    fn node_removed(&mut self, node: &NodeRef) {
         if filter(node) != FilterResult::Include {
             return;
         }

--- a/platforms/ios/src/event.rs
+++ b/platforms/ios/src/event.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::Live;
-use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, TreeChangeHandler};
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_foundation::{
     NSAttributedString, NSAttributedStringKey, NSMutableDictionary, NSNumber, NSString,

--- a/platforms/ios/src/filters.rs
+++ b/platforms/ios/src/filters.rs
@@ -3,7 +3,7 @@
 // the LICENSE-APACHE file) or the MIT license (found in
 // the LICENSE-MIT file), at your option.
 
-use accesskit_consumer::{FilterResult, Node};
+use accesskit_consumer::{FilterResult, NodeRef};
 
 pub(crate) use accesskit_consumer::common_filter as filter;
 
@@ -24,7 +24,7 @@ use crate::node::NodeWrapper;
 /// Otherwise, non-focusable children (e.g. Labels, Images) just provide
 /// labeling info to the parent, so the parent should remain the
 /// accessibility element.
-pub(crate) fn filter_for_is_accessibility_element(node: &Node) -> FilterResult {
+pub(crate) fn filter_for_is_accessibility_element(node: &NodeRef) -> FilterResult {
     let result = filter(node);
     if result != FilterResult::Include {
         return result;
@@ -54,22 +54,22 @@ pub(crate) fn filter_for_is_accessibility_element(node: &Node) -> FilterResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use accesskit::{Action, Node as NodeBuilder, NodeId, Role, Tree, TreeId, TreeUpdate};
+    use accesskit::{Action, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate};
 
     const ROOT_ID: NodeId = NodeId(0);
     const CHILD_1_ID: NodeId = NodeId(1);
 
-    fn build_tree(nodes: Vec<(NodeId, NodeBuilder)>) -> accesskit_consumer::Tree {
+    fn build_tree(nodes: Vec<(NodeId, Node)>) -> accesskit_consumer::Tree {
         let update = TreeUpdate {
             nodes,
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
         accesskit_consumer::Tree::new(update, false)
     }
 
-    fn filter_node(nodes: Vec<(NodeId, NodeBuilder)>, target: NodeId) -> FilterResult {
+    fn filter_node(nodes: Vec<(NodeId, Node)>, target: NodeId) -> FilterResult {
         let tree = build_tree(nodes);
         let node = tree
             .state()
@@ -78,8 +78,8 @@ mod tests {
         filter_for_is_accessibility_element(&node)
     }
 
-    fn make_button(label: &str) -> NodeBuilder {
-        let mut node = NodeBuilder::new(Role::Button);
+    fn make_button(label: &str) -> Node {
+        let mut node = Node::new(Role::Button);
         node.set_label(label);
         node.add_action(Action::Click);
         node
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn leaf_button_is_element() {
-        let mut root = NodeBuilder::new(Role::Window);
+        let mut root = Node::new(Role::Window);
         root.set_children(vec![CHILD_1_ID]);
         let child = make_button("OK");
         assert_eq!(
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn hidden_node_excluded() {
-        let mut root = NodeBuilder::new(Role::Window);
+        let mut root = Node::new(Role::Window);
         root.set_children(vec![CHILD_1_ID]);
         let mut hidden = make_button("Hidden");
         hidden.set_hidden();
@@ -112,12 +112,12 @@ mod tests {
     fn checkbox_with_label_child_is_leaf() {
         const CHECKBOX_ID: NodeId = NodeId(1);
         const LABEL_ID: NodeId = NodeId(2);
-        let mut root = NodeBuilder::new(Role::Window);
+        let mut root = Node::new(Role::Window);
         root.set_children(vec![CHECKBOX_ID]);
-        let mut checkbox = NodeBuilder::new(Role::CheckBox);
+        let mut checkbox = Node::new(Role::CheckBox);
         checkbox.add_action(Action::Click);
         checkbox.set_children(vec![LABEL_ID]);
-        let mut label = NodeBuilder::new(Role::Label);
+        let mut label = Node::new(Role::Label);
         label.set_value("Accept terms");
         assert_eq!(
             filter_node(

--- a/platforms/ios/src/node.rs
+++ b/platforms/ios/src/node.rs
@@ -9,7 +9,7 @@
 // found in the LICENSE.chromium file.
 
 use accesskit::{Action, ActionRequest, Live, Rect, Role, Toggled};
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree};
 use objc2::{
     ClassType, DeclaredClass, declare_class, msg_send_id,
     mutability::MainThreadOnly,
@@ -58,7 +58,7 @@ enum FrameSource {
     Zero,
 }
 
-pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a NodeRef<'a>);
 
 impl NodeWrapper<'_> {
     fn label(&self) -> Option<String> {
@@ -183,7 +183,7 @@ impl NodeWrapper<'_> {
 
 pub(crate) struct PlatformNodeIvars {
     context: Weak<Context>,
-    node_id: NodeId,
+    node_id: FullNodeId,
 }
 
 declare_class!(
@@ -443,7 +443,7 @@ impl PlatformNode {
         Retained::into_super(Self::into_ns_object(this))
     }
 
-    pub(crate) fn new(context: &Rc<Context>, node_id: NodeId) -> Option<Retained<Self>> {
+    pub(crate) fn new(context: &Rc<Context>, node_id: FullNodeId) -> Option<Retained<Self>> {
         // UIAccessibilityElement's designated initializer is
         // `initWithAccessibilityContainer:`; plain `init` raises
         // NSInvalidArgumentException at runtime. Following Flutter's iOS
@@ -461,7 +461,7 @@ impl PlatformNode {
 
     fn resolve<F, T>(&self, f: F) -> Option<T>
     where
-        F: FnOnce(&Node) -> T,
+        F: FnOnce(&NodeRef) -> T,
     {
         let context = self.ivars().context.upgrade()?;
         let tree = context.tree.borrow();
@@ -472,7 +472,7 @@ impl PlatformNode {
 
     fn resolve_with_context<F, T>(&self, f: F) -> Option<T>
     where
-        F: FnOnce(&Node, &Tree, &Rc<Context>) -> T,
+        F: FnOnce(&NodeRef, &Tree, &Rc<Context>) -> T,
     {
         let context = self.ivars().context.upgrade()?;
         let tree = context.tree.borrow();
@@ -505,23 +505,23 @@ impl PlatformNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use accesskit::{Action, Node as NodeBuilder, NodeId, Rect, Toggled, Tree, TreeId, TreeUpdate};
+    use accesskit::{Action, Node, NodeId, Rect, Toggled, TreeId, TreeInfo, TreeUpdate};
 
     const ROOT_ID: NodeId = NodeId(0);
 
-    fn build_tree(nodes: Vec<(NodeId, NodeBuilder)>) -> accesskit_consumer::Tree {
+    fn build_tree(nodes: Vec<(NodeId, Node)>) -> accesskit_consumer::Tree {
         let update = TreeUpdate {
             nodes,
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: ROOT_ID,
         };
         accesskit_consumer::Tree::new(update, false)
     }
 
-    fn with_single<F, R>(node: &NodeBuilder, f: F) -> R
+    fn with_single<F, R>(node: &Node, f: F) -> R
     where
-        F: FnOnce(&Node) -> R,
+        F: FnOnce(&NodeRef) -> R,
     {
         let tree = build_tree(vec![(ROOT_ID, node.clone())]);
         let state = tree.state();
@@ -529,27 +529,27 @@ mod tests {
         f(&tree_node)
     }
 
-    fn wrapper_value(node: &NodeBuilder) -> Option<Value> {
+    fn wrapper_value(node: &Node) -> Option<Value> {
         with_single(node, |n| NodeWrapper(n).value())
     }
 
-    fn wrapper_label(node: &NodeBuilder) -> Option<String> {
+    fn wrapper_label(node: &Node) -> Option<String> {
         with_single(node, |n| NodeWrapper(n).label())
     }
 
-    fn wrapper_hint(node: &NodeBuilder) -> Option<String> {
+    fn wrapper_hint(node: &Node) -> Option<String> {
         with_single(node, |n| NodeWrapper(n).hint())
     }
 
-    fn node_traits(node: &NodeBuilder) -> UIAccessibilityTraits {
+    fn node_traits(node: &Node) -> UIAccessibilityTraits {
         with_single(node, |n| NodeWrapper(n).traits())
     }
 
-    fn node_container_type(node: &NodeBuilder) -> UIAccessibilityContainerType {
+    fn node_container_type(node: &Node) -> UIAccessibilityContainerType {
         with_single(node, |n| NodeWrapper(n).container_type())
     }
 
-    fn node_can_be_focused(nodes: Vec<(NodeId, NodeBuilder)>, target: NodeId) -> bool {
+    fn node_can_be_focused(nodes: Vec<(NodeId, Node)>, target: NodeId) -> bool {
         let tree = build_tree(nodes);
         let state = tree.state();
         let node = state.node_by_tree_local_id(target, TreeId::ROOT).unwrap();
@@ -560,14 +560,14 @@ mod tests {
 
     #[test]
     fn label_present() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_label("OK");
         assert_eq!(wrapper_label(&node), Some("OK".into()));
     }
 
     #[test]
     fn label_absent() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         assert_eq!(wrapper_label(&node), None);
     }
 
@@ -575,14 +575,14 @@ mod tests {
 
     #[test]
     fn hint_present() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_description("Confirms the action");
         assert_eq!(wrapper_hint(&node), Some("Confirms the action".into()));
     }
 
     #[test]
     fn hint_absent() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         assert_eq!(wrapper_hint(&node), None);
     }
 
@@ -590,42 +590,42 @@ mod tests {
 
     #[test]
     fn value_toggled_true() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::True);
         assert_eq!(wrapper_value(&node), Some(Value::Bool(true)));
     }
 
     #[test]
     fn value_toggled_false() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::False);
         assert_eq!(wrapper_value(&node), Some(Value::Bool(false)));
     }
 
     #[test]
     fn value_toggled_mixed() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::Mixed);
         assert_eq!(wrapper_value(&node), Some(Value::Bool(true)));
     }
 
     #[test]
     fn value_text_string() {
-        let mut node = NodeBuilder::new(Role::Label);
+        let mut node = Node::new(Role::Label);
         node.set_value("hello");
         assert_eq!(wrapper_value(&node), Some(Value::String("hello".into())));
     }
 
     #[test]
     fn value_numeric() {
-        let mut node = NodeBuilder::new(Role::Slider);
+        let mut node = Node::new(Role::Slider);
         node.set_numeric_value(42.5);
         assert_eq!(wrapper_value(&node), Some(Value::Number(42.5)));
     }
 
     #[test]
     fn value_toggled_takes_priority() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::True);
         node.set_value("ignored");
         node.set_numeric_value(99.0);
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn value_string_over_numeric() {
-        let mut node = NodeBuilder::new(Role::Label);
+        let mut node = Node::new(Role::Label);
         node.set_value("text");
         node.set_numeric_value(1.0);
         assert_eq!(wrapper_value(&node), Some(Value::String("text".into())));
@@ -642,7 +642,7 @@ mod tests {
 
     #[test]
     fn value_none() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         assert_eq!(wrapper_value(&node), None);
     }
 
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn focusable_button() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_label("OK");
         node.add_action(Action::Click);
         assert!(node_can_be_focused(vec![(ROOT_ID, node)], ROOT_ID));
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn window_not_focusable() {
-        let node = NodeBuilder::new(Role::Window);
+        let node = Node::new(Role::Window);
         assert!(!node_can_be_focused(vec![(ROOT_ID, node)], ROOT_ID));
     }
 
@@ -688,25 +688,25 @@ mod tests {
 
     #[test]
     fn traits_button() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitButton } != 0);
     }
 
     #[test]
     fn traits_default_button() {
-        let node = NodeBuilder::new(Role::DefaultButton);
+        let node = Node::new(Role::DefaultButton);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitButton } != 0);
     }
 
     #[test]
     fn traits_disclosure_triangle() {
-        let node = NodeBuilder::new(Role::DisclosureTriangle);
+        let node = Node::new(Role::DisclosureTriangle);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitButton } != 0);
     }
 
     #[test]
     fn traits_checkbox_is_button_and_toggle() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::False);
         let t = node_traits(&node);
         assert!(t & unsafe { UIAccessibilityTraitButton } != 0);
@@ -715,7 +715,7 @@ mod tests {
 
     #[test]
     fn traits_switch_is_button_and_toggle() {
-        let mut node = NodeBuilder::new(Role::Switch);
+        let mut node = Node::new(Role::Switch);
         node.set_toggled(Toggled::True);
         let t = node_traits(&node);
         assert!(t & unsafe { UIAccessibilityTraitButton } != 0);
@@ -731,7 +731,7 @@ mod tests {
             Role::MenuItemRadio,
             Role::Tab,
         ] {
-            let node = NodeBuilder::new(role);
+            let node = Node::new(role);
             assert!(
                 node_traits(&node) & unsafe { UIAccessibilityTraitButton } != 0,
                 "role {role:?}",
@@ -742,7 +742,7 @@ mod tests {
     #[test]
     fn traits_toggled_true_and_mixed_set_toggle_button() {
         for toggled in [Toggled::True, Toggled::Mixed] {
-            let mut node = NodeBuilder::new(Role::CheckBox);
+            let mut node = Node::new(Role::CheckBox);
             node.set_toggled(toggled);
             assert!(
                 node_traits(&node) & toggle_button_trait() != 0,
@@ -753,70 +753,70 @@ mod tests {
 
     #[test]
     fn traits_link() {
-        let node = NodeBuilder::new(Role::Link);
+        let node = Node::new(Role::Link);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitLink } != 0);
     }
 
     #[test]
     fn traits_image() {
-        let node = NodeBuilder::new(Role::Image);
+        let node = Node::new(Role::Image);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitImage } != 0);
     }
 
     #[test]
     fn traits_label() {
-        let node = NodeBuilder::new(Role::Label);
+        let node = Node::new(Role::Label);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitStaticText } != 0);
     }
 
     #[test]
     fn traits_heading() {
-        let node = NodeBuilder::new(Role::Heading);
+        let node = Node::new(Role::Heading);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitHeader } != 0);
     }
 
     #[test]
     fn traits_slider() {
-        let node = NodeBuilder::new(Role::Slider);
+        let node = Node::new(Role::Slider);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitAdjustable } != 0);
     }
 
     #[test]
     fn traits_spin_button() {
-        let node = NodeBuilder::new(Role::SpinButton);
+        let node = Node::new(Role::SpinButton);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitAdjustable } != 0);
     }
 
     #[test]
     fn traits_search_input() {
-        let node = NodeBuilder::new(Role::SearchInput);
+        let node = Node::new(Role::SearchInput);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitSearchField } != 0);
     }
 
     #[test]
     fn traits_disabled() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_disabled();
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitNotEnabled } != 0);
     }
 
     #[test]
     fn traits_selected() {
-        let mut node = NodeBuilder::new(Role::Tab);
+        let mut node = Node::new(Role::Tab);
         node.set_selected(true);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitSelected } != 0);
     }
 
     #[test]
     fn traits_selected_false_does_not_set_selected() {
-        let mut node = NodeBuilder::new(Role::Tab);
+        let mut node = Node::new(Role::Tab);
         node.set_selected(false);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitSelected } == 0);
     }
 
     #[test]
     fn traits_plain_button_has_no_modifiers() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         let t = node_traits(&node);
         assert!(t & unsafe { UIAccessibilityTraitButton } != 0);
         assert!(t & unsafe { UIAccessibilityTraitNotEnabled } == 0);
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn traits_disabled_and_selected_accumulate() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_disabled();
         node.set_selected(true);
         let t = node_traits(&node);
@@ -839,27 +839,27 @@ mod tests {
 
     #[test]
     fn traits_live_region() {
-        let mut node = NodeBuilder::new(Role::Label);
+        let mut node = Node::new(Role::Label);
         node.set_live(Live::Polite);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitUpdatesFrequently } != 0);
     }
 
     #[test]
     fn traits_live_off_not_updating() {
-        let mut node = NodeBuilder::new(Role::Label);
+        let mut node = Node::new(Role::Label);
         node.set_live(Live::Off);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitUpdatesFrequently } == 0);
     }
 
     #[test]
     fn traits_progress_indicator_updates_frequently() {
-        let node = NodeBuilder::new(Role::ProgressIndicator);
+        let node = Node::new(Role::ProgressIndicator);
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitUpdatesFrequently } != 0);
     }
 
     #[test]
     fn traits_combined() {
-        let mut node = NodeBuilder::new(Role::CheckBox);
+        let mut node = Node::new(Role::CheckBox);
         node.set_toggled(Toggled::False);
         node.set_disabled();
         let t = node_traits(&node);
@@ -870,14 +870,14 @@ mod tests {
 
     #[test]
     fn traits_touch_transparent() {
-        let mut node = NodeBuilder::new(Role::Image);
+        let mut node = Node::new(Role::Image);
         node.set_touch_transparent();
         assert!(node_traits(&node) & unsafe { UIAccessibilityTraitAllowsDirectInteraction } != 0);
     }
 
     #[test]
     fn traits_none_for_group() {
-        let node = NodeBuilder::new(Role::Group);
+        let node = Node::new(Role::Group);
         assert_eq!(node_traits(&node), unsafe { UIAccessibilityTraitNone });
     }
 
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn container_type_data_table_roles() {
         for role in [Role::Table, Role::Grid, Role::TreeGrid, Role::ListGrid] {
-            let node = NodeBuilder::new(role);
+            let node = Node::new(role);
             assert_eq!(
                 node_container_type(&node),
                 UIAccessibilityContainerType::DataTable,
@@ -898,7 +898,7 @@ mod tests {
     #[test]
     fn container_type_list_roles() {
         for role in [Role::List, Role::ListBox, Role::DescriptionList, Role::Tree] {
-            let node = NodeBuilder::new(role);
+            let node = Node::new(role);
             assert_eq!(
                 node_container_type(&node),
                 UIAccessibilityContainerType::List,
@@ -921,7 +921,7 @@ mod tests {
             Role::Region,
             Role::Search,
         ] {
-            let node = NodeBuilder::new(role);
+            let node = Node::new(role);
             assert_eq!(
                 node_container_type(&node),
                 UIAccessibilityContainerType::Landmark,
@@ -932,7 +932,7 @@ mod tests {
 
     #[test]
     fn container_type_semantic_group_for_group() {
-        let node = NodeBuilder::new(Role::Group);
+        let node = Node::new(Role::Group);
         assert_eq!(
             node_container_type(&node),
             UIAccessibilityContainerType::SemanticGroup,
@@ -941,7 +941,7 @@ mod tests {
 
     #[test]
     fn container_type_none_for_button() {
-        let node = NodeBuilder::new(Role::Button);
+        let node = Node::new(Role::Button);
         assert_eq!(
             node_container_type(&node),
             UIAccessibilityContainerType::None,
@@ -950,7 +950,7 @@ mod tests {
 
     // ---- frame_source ----
 
-    fn node_frame_source(nodes: Vec<(NodeId, NodeBuilder)>, target: NodeId) -> FrameSource {
+    fn node_frame_source(nodes: Vec<(NodeId, Node)>, target: NodeId) -> FrameSource {
         let tree = build_tree(nodes);
         let state = tree.state();
         let node = state.node_by_tree_local_id(target, TreeId::ROOT).unwrap();
@@ -959,7 +959,7 @@ mod tests {
 
     #[test]
     fn frame_source_uses_bounding_box_when_present() {
-        let mut node = NodeBuilder::new(Role::Button);
+        let mut node = Node::new(Role::Button);
         node.set_bounds(Rect {
             x0: 1.0,
             y0: 2.0,
@@ -979,7 +979,7 @@ mod tests {
 
     #[test]
     fn frame_source_root_without_bounds_uses_view_bounds() {
-        let node = NodeBuilder::new(Role::Window);
+        let node = Node::new(Role::Window);
         assert_eq!(
             node_frame_source(vec![(ROOT_ID, node)], ROOT_ID),
             FrameSource::ViewBounds,
@@ -989,9 +989,9 @@ mod tests {
     #[test]
     fn frame_source_non_root_without_bounds_is_zero() {
         const CHILD_ID: NodeId = NodeId(1);
-        let mut root = NodeBuilder::new(Role::Window);
+        let mut root = Node::new(Role::Window);
         root.set_children(vec![CHILD_ID]);
-        let child = NodeBuilder::new(Role::Button);
+        let child = Node::new(Role::Button);
         assert_eq!(
             node_frame_source(vec![(ROOT_ID, root), (CHILD_ID, child)], CHILD_ID),
             FrameSource::Zero,
@@ -1000,7 +1000,7 @@ mod tests {
 
     #[test]
     fn frame_source_bounding_box_takes_priority_on_root() {
-        let mut node = NodeBuilder::new(Role::Window);
+        let mut node = Node::new(Role::Window);
         node.set_bounds(Rect {
             x0: 0.0,
             y0: 0.0,

--- a/platforms/ios/src/util.rs
+++ b/platforms/ios/src/util.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::Point;
-use accesskit_consumer::Node;
+use accesskit_consumer::NodeRef;
 use objc2::encode::{Encode, Encoding, RefEncode};
 use objc2_foundation::{CGPoint, CGRect, CGSize, NSAttributedStringKey, NSInteger, NSString};
 use objc2_ui_kit::{
@@ -34,7 +34,7 @@ unsafe impl RefEncode for UIAccessibilityExpandedStatus {
     const ENCODING_REF: Encoding = Encoding::Pointer(&Self::ENCODING);
 }
 
-pub(crate) fn from_cg_point(view: &UIView, node: &Node, point: CGPoint) -> Option<Point> {
+pub(crate) fn from_cg_point(view: &UIView, node: &NodeRef, point: CGPoint) -> Option<Point> {
     let window = view.window()?;
     let screen_space = window.screen().coordinateSpace();
     let local_point = view.convertPoint_fromCoordinateSpace(point, &screen_space);

--- a/platforms/macos/src/adapter.rs
+++ b/platforms/macos/src/adapter.rs
@@ -11,8 +11,8 @@ use crate::{
     util::*,
 };
 use accesskit::{
-    ActionHandler, ActionRequest, ActivationHandler, Node as NodeProvider, NodeId as LocalNodeId,
-    Role, Tree as TreeData, TreeId, TreeUpdate,
+    ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, TreeId, TreeInfo,
+    TreeUpdate,
 };
 use accesskit_consumer::{FilterResult, Tree};
 use objc2::rc::{Id, WeakId};
@@ -21,7 +21,7 @@ use objc2_foundation::{MainThreadMarker, NSArray, NSObject, NSPoint};
 use std::fmt::{Debug, Formatter};
 use std::{ffi::c_void, ptr::null_mut, rc::Rc};
 
-const PLACEHOLDER_ROOT_ID: LocalNodeId = LocalNodeId(0);
+const PLACEHOLDER_ROOT_ID: NodeId = NodeId(0);
 
 enum State {
     Inactive {
@@ -191,8 +191,8 @@ impl Adapter {
                 }
                 None => {
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeProvider::new(Role::Window))],
-                        tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, Node::new(Role::Window))],
+                        tree: Some(TreeInfo::new(PLACEHOLDER_ROOT_ID)),
                         tree_id: TreeId::ROOT,
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/macos/src/context.rs
+++ b/platforms/macos/src/context.rs
@@ -5,7 +5,7 @@
 
 use crate::node::PlatformNode;
 use accesskit::{ActionHandler, ActionRequest};
-use accesskit_consumer::{NodeId, Tree};
+use accesskit_consumer::{FullNodeId, Tree};
 use hashbrown::HashMap;
 use objc2::rc::{Id, WeakId};
 use objc2_app_kit::*;
@@ -35,7 +35,7 @@ pub(crate) struct Context {
     pub(crate) view: WeakId<NSView>,
     pub(crate) tree: RefCell<Tree>,
     pub(crate) action_handler: Rc<dyn ActionHandlerNoMut>,
-    platform_nodes: RefCell<HashMap<NodeId, Id<PlatformNode>>>,
+    platform_nodes: RefCell<HashMap<FullNodeId, Id<PlatformNode>>>,
     pub(crate) mtm: MainThreadMarker,
 }
 
@@ -67,7 +67,7 @@ impl Context {
         })
     }
 
-    pub(crate) fn get_or_create_platform_node(self: &Rc<Self>, id: NodeId) -> Id<PlatformNode> {
+    pub(crate) fn get_or_create_platform_node(self: &Rc<Self>, id: FullNodeId) -> Id<PlatformNode> {
         let mut platform_nodes = self.platform_nodes.borrow_mut();
         if let Some(result) = platform_nodes.get(&id) {
             return result.clone();
@@ -78,7 +78,7 @@ impl Context {
         result
     }
 
-    pub(crate) fn remove_platform_node(&self, id: NodeId) -> Option<Id<PlatformNode>> {
+    pub(crate) fn remove_platform_node(&self, id: FullNodeId) -> Option<Id<PlatformNode>> {
         let mut platform_nodes = self.platform_nodes.borrow_mut();
         platform_nodes.remove(&id)
     }

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Live, Role};
-use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, TreeChangeHandler};
 use hashbrown::HashSet;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_app_kit::*;

--- a/platforms/macos/src/event.rs
+++ b/platforms/macos/src/event.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Live, Role};
-use accesskit_consumer::{FilterResult, Node, NodeId, TreeChangeHandler};
+use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, TreeChangeHandler};
 use hashbrown::HashSet;
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2_app_kit::*;
@@ -21,10 +21,10 @@ use crate::{
 // and send to the main thread. This ability isn't yet used though.
 pub(crate) enum QueuedEvent {
     Generic {
-        node_id: NodeId,
+        node_id: FullNodeId,
         notification: &'static NSAccessibilityNotificationName,
     },
-    NodeDestroyed(NodeId),
+    NodeDestroyed(FullNodeId),
     Announcement {
         text: String,
         priority: NSAccessibilityPriorityLevel,
@@ -32,7 +32,7 @@ pub(crate) enum QueuedEvent {
 }
 
 impl QueuedEvent {
-    fn live_region_announcement(node: &Node) -> Self {
+    fn live_region_announcement(node: &NodeRef) -> Self {
         Self::Announcement {
             text: node.value().unwrap(),
             priority: if node.live() == Live::Assertive {
@@ -130,7 +130,7 @@ impl QueuedEvents {
     }
 }
 
-pub(crate) fn focus_event(node_id: NodeId) -> QueuedEvent {
+pub(crate) fn focus_event(node_id: FullNodeId) -> QueuedEvent {
     QueuedEvent::Generic {
         node_id,
         notification: unsafe { NSAccessibilityFocusedUIElementChangedNotification },
@@ -140,8 +140,8 @@ pub(crate) fn focus_event(node_id: NodeId) -> QueuedEvent {
 pub(crate) struct EventGenerator {
     context: Rc<Context>,
     events: Vec<QueuedEvent>,
-    text_changed: HashSet<NodeId>,
-    selected_rows_changed: HashSet<NodeId>,
+    text_changed: HashSet<FullNodeId>,
+    selected_rows_changed: HashSet<FullNodeId>,
 }
 
 impl EventGenerator {
@@ -158,7 +158,7 @@ impl EventGenerator {
         QueuedEvents::new(self.context, self.events)
     }
 
-    fn remove_subtree(&mut self, node: &Node) {
+    fn remove_subtree(&mut self, node: &NodeRef) {
         let mut to_remove = VecDeque::new();
         to_remove.push_back(*node);
 
@@ -171,7 +171,7 @@ impl EventGenerator {
         }
     }
 
-    fn insert_text_change_if_needed_parent(&mut self, node: Node) {
+    fn insert_text_change_if_needed_parent(&mut self, node: NodeRef) {
         if !node.supports_text_ranges() {
             return;
         }
@@ -192,7 +192,7 @@ impl EventGenerator {
         self.text_changed.insert(id);
     }
 
-    fn insert_text_change_if_needed(&mut self, node: &Node) {
+    fn insert_text_change_if_needed(&mut self, node: &NodeRef) {
         if node.role() != Role::TextRun {
             return;
         }
@@ -201,7 +201,7 @@ impl EventGenerator {
         }
     }
 
-    fn enqueue_selected_rows_change_if_needed_parent(&mut self, node: Node) {
+    fn enqueue_selected_rows_change_if_needed_parent(&mut self, node: NodeRef) {
         let id = node.id();
         if self.selected_rows_changed.contains(&id) {
             return;
@@ -213,7 +213,7 @@ impl EventGenerator {
         self.selected_rows_changed.insert(id);
     }
 
-    fn enqueue_selected_rows_change_if_needed(&mut self, node: &Node) {
+    fn enqueue_selected_rows_change_if_needed(&mut self, node: &NodeRef) {
         let wrapper = NodeWrapper(node);
         if !wrapper.is_item_like() {
             return;
@@ -225,7 +225,7 @@ impl EventGenerator {
 }
 
 impl TreeChangeHandler for EventGenerator {
-    fn node_added(&mut self, node: &Node) {
+    fn node_added(&mut self, node: &NodeRef) {
         self.insert_text_change_if_needed(node);
         if filter(node) != FilterResult::Include {
             return;
@@ -239,7 +239,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -311,7 +311,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
+    fn focus_moved(&mut self, _old_node: Option<&NodeRef>, new_node: Option<&NodeRef>) {
         if let Some(new_node) = new_node {
             if filter(new_node) != FilterResult::Include {
                 return;
@@ -320,7 +320,7 @@ impl TreeChangeHandler for EventGenerator {
         }
     }
 
-    fn node_removed(&mut self, node: &Node) {
+    fn node_removed(&mut self, node: &NodeRef) {
         self.insert_text_change_if_needed(node);
         if let Some(true) = node.is_selected() {
             self.enqueue_selected_rows_change_if_needed(node);

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -13,7 +13,7 @@
 use accesskit::{
     Action, ActionData, ActionRequest, Orientation, Role, TextAlign, TextSelection, Toggled,
 };
-use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, Tree};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree};
 use objc2::{
     ClassType, DeclaredClass, declare_class, msg_send_id,
     mutability::InteriorMutable,

--- a/platforms/macos/src/node.rs
+++ b/platforms/macos/src/node.rs
@@ -13,7 +13,7 @@
 use accesskit::{
     Action, ActionData, ActionRequest, Orientation, Role, TextAlign, TextSelection, Toggled,
 };
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree};
+use accesskit_consumer::{FilterResult, FullRefdeId, NodeId, Tree};
 use objc2::{
     ClassType, DeclaredClass, declare_class, msg_send_id,
     mutability::InteriorMutable,
@@ -33,7 +33,7 @@ use crate::{context::Context, filters::filter, util::*};
 
 const SCROLL_TO_VISIBLE_ACTION: &str = "AXScrollToVisible";
 
-fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
+fn ns_role(node: &NodeRef) -> &'static NSAccessibilityRole {
     let role = node.role();
     // TODO: Handle special cases.
     unsafe {
@@ -230,7 +230,7 @@ fn ns_role(node: &Node) -> &'static NSAccessibilityRole {
     }
 }
 
-fn ns_sub_role(node: &Node) -> &'static NSAccessibilitySubrole {
+fn ns_sub_role(node: &NodeRef) -> &'static NSAccessibilitySubrole {
     let role = node.role();
 
     unsafe {
@@ -285,7 +285,7 @@ fn ns_sub_role(node: &Node) -> &'static NSAccessibilitySubrole {
     }
 }
 
-pub(crate) fn can_be_focused(node: &Node) -> bool {
+pub(crate) fn can_be_focused(node: &NodeRef) -> bool {
     filter(node) == FilterResult::Include && node.role() != Role::Window
 }
 
@@ -296,7 +296,7 @@ pub(crate) enum Value {
     String(String),
 }
 
-pub(crate) struct NodeWrapper<'a>(pub(crate) &'a Node<'a>);
+pub(crate) struct NodeWrapper<'a>(pub(crate) &'a NodeRef<'a>);
 
 impl NodeWrapper<'_> {
     fn is_root(&self) -> bool {
@@ -364,7 +364,7 @@ fn downcast_ref<T: ClassType>(obj: &NSObject) -> Option<&T> {
 
 pub(crate) struct PlatformNodeIvars {
     context: Weak<Context>,
-    node_id: NodeId,
+    node_id: FullNodeId,
 }
 
 declare_class!(
@@ -1302,7 +1302,7 @@ declare_class!(
 );
 
 impl PlatformNode {
-    pub(crate) fn new(context: Weak<Context>, node_id: NodeId) -> Id<Self> {
+    pub(crate) fn new(context: Weak<Context>, node_id: FullNodeId) -> Id<Self> {
         let this = Self::alloc().set_ivars(PlatformNodeIvars { context, node_id });
 
         unsafe { msg_send_id![super(this), init] }
@@ -1310,7 +1310,7 @@ impl PlatformNode {
 
     fn resolve_with_context<F, T>(&self, f: F) -> Option<T>
     where
-        F: FnOnce(&Node, &Tree, &Rc<Context>) -> T,
+        F: FnOnce(&NodeRef, &Tree, &Rc<Context>) -> T,
     {
         let context = self.ivars().context.upgrade()?;
         let tree = context.tree.borrow();
@@ -1321,7 +1321,7 @@ impl PlatformNode {
 
     fn resolve<F, T>(&self, f: F) -> Option<T>
     where
-        F: FnOnce(&Node) -> T,
+        F: FnOnce(&NodeRef) -> T,
     {
         self.resolve_with_context(|node, _, _| f(node))
     }

--- a/platforms/macos/src/util.rs
+++ b/platforms/macos/src/util.rs
@@ -4,13 +4,13 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{Color, Point, Rect};
-use accesskit_consumer::{Node, TextPosition, TextRange};
+use accesskit_consumer::{NodeRef, TextPosition, TextRange};
 use objc2::encode::{Encoding, RefEncode};
 use objc2::{msg_send, rc::Id, runtime::AnyObject};
 use objc2_app_kit::*;
 use objc2_foundation::{NSPoint, NSRange, NSRect, NSSize};
 
-pub(crate) fn from_ns_range<'a>(node: &'a Node<'a>, ns_range: NSRange) -> Option<TextRange<'a>> {
+pub(crate) fn from_ns_range<'a>(node: &'a NodeRef<'a>, ns_range: NSRange) -> Option<TextRange<'a>> {
     let pos = node.text_position_from_global_utf16_index(ns_range.location)?;
     let mut range = pos.to_degenerate_range();
     if ns_range.length > 0 {
@@ -35,7 +35,7 @@ pub(crate) fn to_ns_range_for_character(pos: &TextPosition) -> NSRange {
     to_ns_range(&range)
 }
 
-pub(crate) fn from_ns_point(view: &NSView, node: &Node, point: NSPoint) -> Point {
+pub(crate) fn from_ns_point(view: &NSView, node: &NodeRef, point: NSPoint) -> Point {
     let window = view.window().unwrap();
     let point = window.convertPointFromScreen(point);
     let point = view.convertPoint_fromView(point, None);

--- a/platforms/unix/src/adapter.rs
+++ b/platforms/unix/src/adapter.rs
@@ -6,7 +6,7 @@
 use accesskit::{ActionHandler, ActivationHandler, DeactivationHandler, Rect, TreeUpdate};
 use accesskit_atspi_common::{
     ActionHandlerNoMut, ActionHandlerWrapper, Adapter as AdapterImpl, AdapterCallback, CacheEvent,
-    Event, NodeId, PlatformNode, WindowBounds, next_adapter_id,
+    Event, FullNodeId, PlatformNode, WindowBounds, next_adapter_id,
 };
 #[cfg(not(feature = "tokio"))]
 use async_channel::Sender;
@@ -37,12 +37,17 @@ impl Callback {
 }
 
 impl AdapterCallback for Callback {
-    fn register_interfaces(&self, adapter: &AdapterImpl, id: NodeId, interfaces: InterfaceSet) {
+    fn register_interfaces(&self, adapter: &AdapterImpl, id: FullNodeId, interfaces: InterfaceSet) {
         let node = adapter.platform_node(id);
         self.send_message(Message::RegisterInterfaces { node, interfaces });
     }
 
-    fn unregister_interfaces(&self, adapter: &AdapterImpl, id: NodeId, interfaces: InterfaceSet) {
+    fn unregister_interfaces(
+        &self,
+        adapter: &AdapterImpl,
+        id: FullNodeId,
+        interfaces: InterfaceSet,
+    ) {
         self.send_message(Message::UnregisterInterfaces {
             adapter_id: adapter.id(),
             node_id: id,
@@ -254,7 +259,7 @@ pub(crate) enum Message {
     },
     UnregisterInterfaces {
         adapter_id: usize,
-        node_id: NodeId,
+        node_id: FullNodeId,
         interfaces: InterfaceSet,
     },
     EmitEvent {
@@ -266,6 +271,6 @@ pub(crate) enum Message {
     },
     EmitCacheRemove {
         adapter_id: usize,
-        node_id: NodeId,
+        node_id: FullNodeId,
     },
 }

--- a/platforms/unix/src/atspi/bus.rs
+++ b/platforms/unix/src/atspi/bus.rs
@@ -9,7 +9,7 @@ use crate::{
     executor::{Executor, Task},
 };
 use accesskit_atspi_common::{
-    NodeId, NodeIdOrRoot, ObjectEvent, PlatformNode, PlatformRoot, Property, WindowEvent,
+    FullNodeId, NodeIdOrRoot, ObjectEvent, PlatformNode, PlatformRoot, Property, WindowEvent,
 };
 use atspi::{
     Interface, InterfaceSet, ObjectRefOwned,
@@ -181,7 +181,7 @@ impl Bus {
     pub(crate) async fn unregister_interfaces(
         &self,
         adapter_id: usize,
-        node_id: NodeId,
+        node_id: FullNodeId,
         old_interfaces: InterfaceSet,
     ) -> zbus::Result<()> {
         let path = ObjectId::Node {
@@ -374,7 +374,7 @@ impl Bus {
     pub(crate) async fn emit_window_event(
         &self,
         adapter_id: usize,
-        target: NodeId,
+        target: FullNodeId,
         window_name: String,
         event: WindowEvent,
     ) -> Result<()> {
@@ -399,7 +399,11 @@ impl Bus {
         self.emit_cache_signal("AddAccessible", &item).await
     }
 
-    pub(crate) async fn emit_cache_remove(&self, adapter_id: usize, node_id: NodeId) -> Result<()> {
+    pub(crate) async fn emit_cache_remove(
+        &self,
+        adapter_id: usize,
+        node_id: FullNodeId,
+    ) -> Result<()> {
         let reference = object_ref(
             self.unique_name().inner(),
             ObjectId::Node {

--- a/platforms/unix/src/atspi/interfaces/cache.rs
+++ b/platforms/unix/src/atspi/interfaces/cache.rs
@@ -117,10 +117,10 @@ mod tests {
     use super::{CacheInterface, object_ref};
     use crate::atspi::ObjectId;
     use accesskit::{
-        ActionHandler, ActionRequest, Node, NodeId as LocalNodeId, Role, Tree, TreeId, TreeUpdate,
+        ActionHandler, ActionRequest, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate,
     };
     use accesskit_atspi_common::{
-        Adapter, AdapterCallback, AppContext, Event, NodeId, PlatformRoot, WindowBounds,
+        Adapter, AdapterCallback, AppContext, Event, FullNodeId, PlatformRoot, WindowBounds,
     };
     use atspi::{Interface, ObjectRefOwned, Role as AtspiRole};
     use std::sync::{Arc, OnceLock};
@@ -133,12 +133,12 @@ mod tests {
 
     struct NoOpCallback;
     impl AdapterCallback for NoOpCallback {
-        fn register_interfaces(&self, _: &Adapter, _: NodeId, _: atspi::InterfaceSet) {}
-        fn unregister_interfaces(&self, _: &Adapter, _: NodeId, _: atspi::InterfaceSet) {}
+        fn register_interfaces(&self, _: &Adapter, _: FullNodeId, _: atspi::InterfaceSet) {}
+        fn unregister_interfaces(&self, _: &Adapter, _: FullNodeId, _: atspi::InterfaceSet) {}
         fn emit_event(&self, _: &Adapter, _: Event) {}
     }
 
-    fn with_children(role: Role, children: &[LocalNodeId]) -> Node {
+    fn with_children(role: Role, children: &[NodeId]) -> Node {
         let mut node = Node::new(role);
         node.set_children(children.to_vec());
         node
@@ -174,15 +174,12 @@ mod tests {
     fn window_with_button() -> TreeUpdate {
         TreeUpdate {
             nodes: vec![
-                (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1)]),
-                ),
-                (LocalNodeId(1), Node::new(Role::Button)),
+                (NodeId(0), with_children(Role::Window, &[NodeId(1)])),
+                (NodeId(1), Node::new(Role::Button)),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         }
     }
 
@@ -238,15 +235,15 @@ mod tests {
         let update = TreeUpdate {
             nodes: vec![
                 (
-                    LocalNodeId(0),
-                    with_children(Role::Window, &[LocalNodeId(1), LocalNodeId(2)]),
+                    NodeId(0),
+                    with_children(Role::Window, &[NodeId(1), NodeId(2)]),
                 ),
-                (LocalNodeId(1), Node::new(Role::Button)),
-                (LocalNodeId(2), hidden),
+                (NodeId(1), Node::new(Role::Button)),
+                (NodeId(2), hidden),
             ],
-            tree: Some(Tree::new(LocalNodeId(0))),
+            tree: Some(TreeInfo::new(NodeId(0))),
             tree_id: TreeId::ROOT,
-            focus: LocalNodeId(0),
+            focus: NodeId(0),
         };
         let (_adapter, iface) = cache(update);
         let items = iface.items().unwrap();

--- a/platforms/unix/src/atspi/object_id.rs
+++ b/platforms/unix/src/atspi/object_id.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use crate::atspi::OwnedObjectAddress;
-use accesskit_atspi_common::{NodeId, PlatformNode};
+use accesskit_atspi_common::{FullNodeId, PlatformNode};
 use serde::{Serialize, Serializer};
 use zbus::{
     names::UniqueName,
@@ -22,7 +22,7 @@ pub(crate) fn cache_path() -> OwnedObjectPath {
 #[derive(Debug, PartialEq)]
 pub(crate) enum ObjectId {
     Root,
-    Node { adapter: usize, node: NodeId },
+    Node { adapter: usize, node: FullNodeId },
 }
 
 impl ObjectId {

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -1,8 +1,8 @@
 // Based on the create_window sample in windows-samples-rs.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Live, Node, NodeId, Rect, Role, Tree,
-    TreeId, TreeUpdate,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Live, Node, NodeId, Rect, Role,
+    TreeId, TreeInfo, TreeUpdate,
 };
 use accesskit_windows::Adapter;
 use once_cell::sync::Lazy;
@@ -106,7 +106,7 @@ impl ActivationHandler for InnerWindowState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let tree = Tree::new(WINDOW_ID);
+        let tree = TreeInfo::new(WINDOW_ID);
 
         let mut result = TreeUpdate {
             nodes: vec![

--- a/platforms/windows/src/adapter.rs
+++ b/platforms/windows/src/adapter.rs
@@ -4,10 +4,9 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    ActionHandler, ActivationHandler, Live, Node as NodeProvider, NodeId as LocalNodeId, Role,
-    Tree as TreeData, TreeId, TreeUpdate,
+    ActionHandler, ActivationHandler, Live, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate,
 };
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeChangeHandler, TreeState};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree, TreeChangeHandler, TreeState};
 use hashbrown::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, atomic::Ordering};
@@ -24,7 +23,7 @@ use crate::{
     window_handle::WindowHandle,
 };
 
-fn focus_event(context: &Arc<Context>, node_id: NodeId) -> QueuedEvent {
+fn focus_event(context: &Arc<Context>, node_id: FullNodeId) -> QueuedEvent {
     let platform_node = context.get_or_create_platform_node(node_id);
     let element: IRawElementProviderSimple = platform_node.into_interface();
     QueuedEvent::Simple {
@@ -36,8 +35,8 @@ fn focus_event(context: &Arc<Context>, node_id: NodeId) -> QueuedEvent {
 struct AdapterChangeHandler<'a> {
     context: &'a Arc<Context>,
     queue: Vec<QueuedEvent>,
-    text_changed: HashSet<NodeId>,
-    selection_changed: HashMap<NodeId, SelectionChanges>,
+    text_changed: HashSet<FullNodeId>,
+    selection_changed: HashMap<FullNodeId, SelectionChanges>,
 }
 
 impl<'a> AdapterChangeHandler<'a> {
@@ -52,7 +51,7 @@ impl<'a> AdapterChangeHandler<'a> {
 }
 
 impl AdapterChangeHandler<'_> {
-    fn insert_text_change_if_needed_parent(&mut self, node: Node) {
+    fn insert_text_change_if_needed_parent(&mut self, node: NodeRef) {
         if !node.supports_text_ranges() {
             return;
         }
@@ -75,7 +74,7 @@ impl AdapterChangeHandler<'_> {
         self.text_changed.insert(id);
     }
 
-    fn insert_text_change_if_needed(&mut self, node: &Node) {
+    fn insert_text_change_if_needed(&mut self, node: &NodeRef) {
         if node.role() != Role::TextRun {
             return;
         }
@@ -87,7 +86,7 @@ impl AdapterChangeHandler<'_> {
     fn element_for_possibly_removed_node(
         &self,
         tree_state: &TreeState,
-        id: NodeId,
+        id: FullNodeId,
     ) -> IRawElementProviderSimple {
         if tree_state.node_by_id(id).is_some() {
             self.context
@@ -98,7 +97,7 @@ impl AdapterChangeHandler<'_> {
         }
     }
 
-    fn handle_selection_state_change(&mut self, node: &Node, is_selected: bool) {
+    fn handle_selection_state_change(&mut self, node: &NodeRef, is_selected: bool) {
         // If `node` belongs to a selection container, then map the events with the
         // selection container as the key because |FinalizeSelectionEvents| needs to
         // determine whether or not there is only one element selected in order to
@@ -231,12 +230,12 @@ impl AdapterChangeHandler<'_> {
 }
 
 struct SelectionChanges {
-    added_items: HashSet<NodeId>,
-    removed_items: HashSet<NodeId>,
+    added_items: HashSet<FullNodeId>,
+    removed_items: HashSet<FullNodeId>,
 }
 
 impl TreeChangeHandler for AdapterChangeHandler<'_> {
-    fn node_added(&mut self, node: &Node) {
+    fn node_added(&mut self, node: &NodeRef) {
         self.insert_text_change_if_needed(node);
         if filter(node) != FilterResult::Include {
             return;
@@ -267,7 +266,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn node_updated(&mut self, old_node: &Node, new_node: &Node) {
+    fn node_updated(&mut self, old_node: &NodeRef, new_node: &NodeRef) {
         if old_node.raw_value() != new_node.raw_value() {
             self.insert_text_change_if_needed(new_node);
         }
@@ -339,13 +338,13 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
         }
     }
 
-    fn focus_moved(&mut self, _old_node: Option<&Node>, new_node: Option<&Node>) {
+    fn focus_moved(&mut self, _old_node: Option<&NodeRef>, new_node: Option<&NodeRef>) {
         if let Some(new_node) = new_node {
             self.queue.push(focus_event(self.context, new_node.id()));
         }
     }
 
-    fn node_removed(&mut self, node: &Node) {
+    fn node_removed(&mut self, node: &NodeRef) {
         self.insert_text_change_if_needed(node);
         self.context.remove_platform_node(node.id());
         if filter(node) != FilterResult::Include {
@@ -372,7 +371,7 @@ impl TreeChangeHandler for AdapterChangeHandler<'_> {
     // TODO: handle other events (#20)
 }
 
-const PLACEHOLDER_ROOT_ID: LocalNodeId = LocalNodeId(0);
+const PLACEHOLDER_ROOT_ID: NodeId = NodeId(0);
 
 enum State {
     Inactive {
@@ -565,8 +564,8 @@ impl Adapter {
                 None => {
                     let hwnd = *hwnd;
                     let placeholder_update = TreeUpdate {
-                        nodes: vec![(PLACEHOLDER_ROOT_ID, NodeProvider::new(Role::Window))],
-                        tree: Some(TreeData::new(PLACEHOLDER_ROOT_ID)),
+                        nodes: vec![(PLACEHOLDER_ROOT_ID, Node::new(Role::Window))],
+                        tree: Some(TreeInfo::new(PLACEHOLDER_ROOT_ID)),
                         tree_id: TreeId::ROOT,
                         focus: PLACEHOLDER_ROOT_ID,
                     };

--- a/platforms/windows/src/context.rs
+++ b/platforms/windows/src/context.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, ActionRequest, Point};
-use accesskit_consumer::{NodeId, Tree};
+use accesskit_consumer::{FullNodeId, Tree};
 use hashbrown::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, atomic::AtomicBool};
@@ -35,7 +35,7 @@ pub(crate) struct Context {
     pub(crate) tree: RwLock<Tree>,
     pub(crate) action_handler: Arc<dyn ActionHandlerNoMut + Send + Sync>,
     pub(crate) is_placeholder: AtomicBool,
-    platform_nodes: Mutex<HashMap<NodeId, ComObject<PlatformNode>>>,
+    platform_nodes: Mutex<HashMap<FullNodeId, ComObject<PlatformNode>>>,
 }
 
 impl Debug for Context {
@@ -79,7 +79,7 @@ impl Context {
 
     pub(crate) fn get_or_create_platform_node(
         self: &Arc<Self>,
-        id: NodeId,
+        id: FullNodeId,
     ) -> ComObject<PlatformNode> {
         let mut platform_nodes = self.platform_nodes.lock().unwrap();
         if let Some(result) = platform_nodes.get(&id) {
@@ -91,7 +91,7 @@ impl Context {
         result
     }
 
-    pub(crate) fn remove_platform_node(&self, id: NodeId) {
+    pub(crate) fn remove_platform_node(&self, id: FullNodeId) {
         let mut platform_nodes = self.platform_nodes.lock().unwrap();
         platform_nodes.remove(&id);
     }

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -11,10 +11,10 @@
 #![allow(non_upper_case_globals)]
 
 use accesskit::{
-    Action, ActionData, ActionRequest, AriaCurrent, HasPopup, Live, NodeId as LocalNodeId,
-    Orientation, Point, Role, SortDirection, Toggled, TreeId,
+    Action, ActionData, ActionRequest, AriaCurrent, HasPopup, Live, NodeId, Orientation, Point,
+    Role, SortDirection, Toggled, TreeId,
 };
-use accesskit_consumer::{FilterResult, Node, NodeId, Tree, TreeState};
+use accesskit_consumer::{FilterResult, FullNodeId, NodeRef, Tree, TreeState};
 use std::{
     fmt::Write,
     sync::{Arc, Weak, atomic::Ordering},
@@ -37,8 +37,8 @@ use crate::{
 
 const RUNTIME_ID_SIZE: usize = 5;
 
-fn runtime_id_from_node_id(id: NodeId) -> [i32; RUNTIME_ID_SIZE] {
-    static_assertions::assert_eq_size!(NodeId, u128);
+fn runtime_id_from_node_id(id: FullNodeId) -> [i32; RUNTIME_ID_SIZE] {
+    static_assertions::assert_eq_size!(FullNodeId, u128);
     let id: u128 = id.into();
     [
         UiaAppendRuntimeId as _,
@@ -50,7 +50,7 @@ fn runtime_id_from_node_id(id: NodeId) -> [i32; RUNTIME_ID_SIZE] {
 }
 
 pub(crate) struct NodeWrapper<'a> {
-    pub(crate) node: &'a Node<'a>,
+    pub(crate) node: &'a NodeRef<'a>,
     pub(crate) string_buffer: &'a mut Vec<u16>,
 }
 
@@ -803,11 +803,11 @@ fn enqueue_property_change(
 )]
 pub(crate) struct PlatformNode {
     pub(crate) context: Weak<Context>,
-    pub(crate) node_id: Option<NodeId>,
+    pub(crate) node_id: Option<FullNodeId>,
 }
 
 impl PlatformNode {
-    pub(crate) fn new(context: &Arc<Context>, node_id: NodeId) -> ComObject<Self> {
+    pub(crate) fn new(context: &Arc<Context>, node_id: FullNodeId) -> ComObject<Self> {
         Self {
             context: Arc::downgrade(context),
             node_id: Some(node_id),
@@ -843,7 +843,7 @@ impl PlatformNode {
         f(&tree, &context)
     }
 
-    fn node<'a>(&self, tree: &'a Tree) -> Result<Node<'a>> {
+    fn node<'a>(&self, tree: &'a Tree) -> Result<NodeRef<'a>> {
         let state = tree.state();
         if let Some(id) = self.node_id {
             if let Some(node) = state.node_by_id(id) {
@@ -856,7 +856,7 @@ impl PlatformNode {
         }
     }
 
-    fn node_with_location<'a>(&self, tree: &'a Tree) -> Result<(Node<'a>, LocalNodeId, TreeId)> {
+    fn node_with_location<'a>(&self, tree: &'a Tree) -> Result<(NodeRef<'a>, NodeId, TreeId)> {
         let node = self.node(tree)?;
         let (local_id, tree_id) = tree
             .state()
@@ -867,7 +867,7 @@ impl PlatformNode {
 
     fn resolve_with_context<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &Arc<Context>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &Arc<Context>) -> Result<T>,
     {
         self.with_tree_and_context(|tree, context| {
             let node = self.node(tree)?;
@@ -877,7 +877,7 @@ impl PlatformNode {
 
     fn resolve_with_tree_state_and_context<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &TreeState, &Arc<Context>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &TreeState, &Arc<Context>) -> Result<T>,
     {
         self.with_tree_and_context(|tree, context| {
             let node = self.node(tree)?;
@@ -887,14 +887,14 @@ impl PlatformNode {
 
     fn resolve<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>) -> Result<T>,
     {
         self.resolve_with_context(|node, _| f(node))
     }
 
     fn resolve_with_context_for_text_pattern<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>, &Arc<Context>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>, &Arc<Context>) -> Result<T>,
     {
         self.with_tree_and_context(|tree, context| {
             let node = self.node(tree)?;
@@ -908,14 +908,14 @@ impl PlatformNode {
 
     fn resolve_for_text_pattern<F, T>(&self, f: F) -> Result<T>
     where
-        for<'a> F: FnOnce(Node<'a>) -> Result<T>,
+        for<'a> F: FnOnce(NodeRef<'a>) -> Result<T>,
     {
         self.resolve_with_context_for_text_pattern(|node, _| f(node))
     }
 
     fn do_complex_action<F>(&self, f: F) -> Result<()>
     where
-        for<'a> F: FnOnce(Node<'a>, LocalNodeId, TreeId) -> Result<Option<ActionRequest>>,
+        for<'a> F: FnOnce(NodeRef<'a>, NodeId, TreeId) -> Result<Option<ActionRequest>>,
     {
         let context = self.upgrade_context()?;
         if context.is_placeholder.load(Ordering::SeqCst) {

--- a/platforms/windows/src/tests/simple.rs
+++ b/platforms/windows/src/tests/simple.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, Tree, TreeId,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, TreeId, TreeInfo,
     TreeUpdate,
 };
 use windows::{Win32::UI::Accessibility::*, core::*};
@@ -35,7 +35,7 @@ fn get_initial_state() -> TreeUpdate {
             (BUTTON_1_ID, button_1),
             (BUTTON_2_ID, button_2),
         ],
-        tree: Some(Tree::new(WINDOW_ID)),
+        tree: Some(TreeInfo::new(WINDOW_ID)),
         tree_id: TreeId::ROOT,
         focus: BUTTON_1_ID,
     }

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -4,7 +4,7 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{
-    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, Tree, TreeId,
+    Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, TreeId, TreeInfo,
     TreeUpdate,
 };
 use once_cell::sync::Lazy;
@@ -52,7 +52,7 @@ fn get_initial_state() -> TreeUpdate {
             (BUTTON_1_ID, button_1),
             (BUTTON_2_ID, button_2),
         ],
-        tree: Some(Tree::new(WINDOW_ID)),
+        tree: Some(TreeInfo::new(WINDOW_ID)),
         tree_id: TreeId::ROOT,
         focus: BUTTON_1_ID,
     }

--- a/platforms/windows/src/text.rs
+++ b/platforms/windows/src/text.rs
@@ -7,7 +7,8 @@
 
 use accesskit::{Action, ActionData, ActionRequest, ScrollHint, VerticalOffset};
 use accesskit_consumer::{
-    Node, TextPosition as Position, TextRange as Range, Tree, TreeState, WeakTextRange as WeakRange,
+    NodeRef, TextPosition as Position, TextRange as Range, Tree, TreeState,
+    WeakTextRange as WeakRange,
 };
 use std::sync::{Arc, RwLock, Weak};
 use windows::{
@@ -28,7 +29,7 @@ fn upgrade_range<'a>(weak: &WeakRange, tree_state: &'a TreeState) -> Result<Rang
     }
 }
 
-fn upgrade_range_node<'a>(weak: &WeakRange, tree_state: &'a TreeState) -> Result<Node<'a>> {
+fn upgrade_range_node<'a>(weak: &WeakRange, tree_state: &'a TreeState) -> Result<NodeRef<'a>> {
     if let Some(node) = weak.upgrade_node(tree_state) {
         Ok(node)
     } else {
@@ -239,7 +240,7 @@ impl PlatformRange {
         self.with_tree_state_and_context(|state, _| f(state))
     }
 
-    fn upgrade_node<'a>(&self, tree_state: &'a TreeState) -> Result<Node<'a>> {
+    fn upgrade_node<'a>(&self, tree_state: &'a TreeState) -> Result<NodeRef<'a>> {
         let state = self.state.read().unwrap();
         upgrade_range_node(&state, tree_state)
     }

--- a/platforms/winit/examples/mixed_handlers.rs
+++ b/platforms/winit/examples/mixed_handlers.rs
@@ -2,8 +2,8 @@
 mod fill;
 
 use accesskit::{
-    Action, ActionRequest, ActivationHandler, Affine, Live, Node, NodeId, Rect, Role, Tree, TreeId,
-    TreeUpdate, Vec2,
+    Action, ActionRequest, ActivationHandler, Affine, Live, Node, NodeId, Rect, Role, TreeId,
+    TreeInfo, TreeUpdate, Vec2,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use std::{
@@ -125,7 +125,7 @@ impl UiState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let tree = Tree::new(WINDOW_ID);
+        let tree = TreeInfo::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),

--- a/platforms/winit/examples/simple.rs
+++ b/platforms/winit/examples/simple.rs
@@ -2,7 +2,8 @@
 mod fill;
 
 use accesskit::{
-    Action, ActionRequest, Affine, Live, Node, NodeId, Rect, Role, Tree, TreeId, TreeUpdate, Vec2,
+    Action, ActionRequest, Affine, Live, Node, NodeId, Rect, Role, TreeId, TreeInfo, TreeUpdate,
+    Vec2,
 };
 use accesskit_winit::{Adapter, Event as AccessKitEvent, WindowEvent as AccessKitWindowEvent};
 use std::error::Error;
@@ -119,7 +120,7 @@ impl UiState {
         let root = self.build_root();
         let button_1 = build_button(BUTTON_1_ID, "Button 1");
         let button_2 = build_button(BUTTON_2_ID, "Button 2");
-        let tree = Tree::new(WINDOW_ID);
+        let tree = TreeInfo::new(WINDOW_ID);
         let mut result = TreeUpdate {
             nodes: vec![
                 (WINDOW_ID, root),


### PR DESCRIPTION
Closes #720

Rename accesskit::Tree to TreeInfo
Rename accesskit_consumer::Node to accesskit_consumer::NodeRef Rename accesskit_consumer::NodeId to FullNodeId
Rename accesskit_consumer::State to TreeState

Because the previous names were ambiguous or had collisions, a lot of files imported them with aliases.
This PR removes most of these alias imports.

This is a rename-only PR with no behavior changes; most changes were done with rust-analyzer's "rename symbol" assist and similar (non-AI) tools.