### PR TITLE
fix: Update smallvec to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"


### PR DESCRIPTION
`smallvec` 0.10 documentation fails to build on Linux with recent version of rustc. Updating it to its latest version fixes documenting `accesskit_winit`.