### PR TITLE
Make `Tree::toolkit_name` return 'AccessKit' by default

### DIFF
--- a/consumer/src/tree.rs
+++ b/consumer/src/tree.rs
@@ -559,12 +559,15 @@ impl State {
         None
     }
 
-    pub fn toolkit_name(&self) -> Option<&str> {
-        self.data.toolkit_name.as_deref()
+    pub fn toolkit_name(&self) -> &str {
+        self.data.toolkit_name.as_deref().unwrap_or("AccessKit")
     }
 
     pub fn toolkit_version(&self) -> Option<&str> {
-        self.data.toolkit_version.as_deref()
+        self.data
+            .toolkit_version
+            .as_deref()
+            .filter(|_| self.data.toolkit_name.is_some())
     }
 
     pub fn locate_node(&self, node_id: NodeId) -> Option<(LocalNodeId, TreeId)> {
@@ -3134,5 +3137,51 @@ mod tests {
         assert!(handler.focus_moved_called);
         assert_eq!(handler.old_focus, Some(node_id(2)));
         assert_eq!(handler.new_focus, Some(node_id(3)));
+    }
+
+    fn tree_with_toolkit_info(name: Option<&str>, version: Option<&str>) -> super::Tree {
+        let mut tree_data = Tree::new(LocalNodeId(0));
+        tree_data.toolkit_name = name.map(Into::into);
+        tree_data.toolkit_version = version.map(Into::into);
+        let update = TreeUpdate {
+            nodes: vec![(LocalNodeId(0), Node::new(Role::Window))],
+            tree: Some(tree_data),
+            tree_id: TreeId::ROOT,
+            focus: LocalNodeId(0),
+        };
+        super::Tree::new(update, false)
+    }
+
+    #[test]
+    fn toolkit_info_is_reported_when_both_name_and_version_are_set() {
+        let tree = tree_with_toolkit_info(Some("egui"), Some("0.30.0"));
+        let state = tree.state();
+        assert_eq!("egui", state.toolkit_name());
+        assert_eq!(Some("0.30.0"), state.toolkit_version());
+    }
+
+    #[test]
+    fn toolkit_version_is_none_when_only_name_is_set() {
+        let tree = tree_with_toolkit_info(Some("egui"), None);
+        let state = tree.state();
+        assert_eq!("egui", state.toolkit_name());
+        assert_eq!(None, state.toolkit_version());
+    }
+
+    #[test]
+    fn toolkit_name_falls_back_to_accesskit_when_unset() {
+        let tree = tree_with_toolkit_info(None, None);
+        let state = tree.state();
+        assert_eq!("AccessKit", state.toolkit_name());
+        assert_eq!(None, state.toolkit_version());
+    }
+
+    #[test]
+    fn toolkit_version_is_suppressed_when_name_is_unset() {
+        // A version without a name would be misreported as the version of AccessKit.
+        let tree = tree_with_toolkit_info(None, Some("0.30.0"));
+        let state = tree.state();
+        assert_eq!("AccessKit", state.toolkit_name());
+        assert_eq!(None, state.toolkit_version());
     }
 }

--- a/platforms/atspi-common/src/adapter.rs
+++ b/platforms/atspi-common/src/adapter.rs
@@ -458,7 +458,7 @@ impl Adapter {
             let tree = self.context.read_tree();
             let tree_state = tree.state();
             let mut app_context = self.context.write_app_context();
-            app_context.toolkit_name = tree_state.toolkit_name().map(|s| s.to_string());
+            app_context.toolkit_name = Some(tree_state.toolkit_name().to_string());
             app_context.toolkit_version = tree_state.toolkit_version().map(|s| s.to_string());
             let adapter_index = app_context.adapter_index(self.id).unwrap();
             let root = tree_state.root();

--- a/platforms/atspi-common/src/node.rs
+++ b/platforms/atspi-common/src/node.rs
@@ -803,7 +803,7 @@ impl PlatformNode {
     }
 
     pub fn toolkit_name(&self) -> Result<String> {
-        self.with_tree_state(|state| Ok(state.toolkit_name().unwrap_or_default().to_string()))
+        self.with_tree_state(|state| Ok(state.toolkit_name().to_string()))
     }
 
     pub fn toolkit_version(&self) -> Result<String> {

--- a/platforms/windows/src/node.rs
+++ b/platforms/windows/src/node.rs
@@ -1035,10 +1035,7 @@ impl IRawElementProviderSimple_Impl for PlatformNode_Impl {
                 }
                 match property_id {
                     UIA_FrameworkIdPropertyId => {
-                        result = state
-                            .toolkit_name()
-                            .map(|s| StrWrapper::new(s, &mut buffer))
-                            .into()
+                        result = StrWrapper::new(state.toolkit_name(), &mut buffer).into()
                     }
                     UIA_ProviderDescriptionPropertyId => {
                         result = toolkit_description(state, &mut buffer).into()

--- a/platforms/windows/src/util.rs
+++ b/platforms/windows/src/util.rs
@@ -413,16 +413,14 @@ pub(crate) fn window_title(hwnd: WindowHandle, buffer: &mut Vec<u16>) -> Option<
 pub(crate) fn toolkit_description<'a>(
     state: &TreeState,
     buffer: &'a mut Vec<u16>,
-) -> Option<WideString<'a>> {
-    state.toolkit_name().map(|name| {
-        let mut result = WideString::new(buffer);
-        result.write_str(name).unwrap();
-        if let Some(version) = state.toolkit_version() {
-            result.write_char(' ').unwrap();
-            result.write_str(version).unwrap();
-        }
-        result
-    })
+) -> WideString<'a> {
+    let mut result = WideString::new(buffer);
+    result.write_str(state.toolkit_name()).unwrap();
+    if let Some(version) = state.toolkit_version() {
+        result.write_char(' ').unwrap();
+        result.write_str(version).unwrap();
+    }
+    result
 }
 
 pub(crate) fn upgrade<T>(weak: &Weak<T>) -> Result<Arc<T>> {


### PR DESCRIPTION
Requested in #742.

When investigating an issue with an assistive technology, there is value in knowing that AccessKit is involved on the provider side if the toolkit doesn't report its name and version. Cargo gives us access to a crate version at build time but I figured it might be confusing as multiple AccessKit crates are involved and they all have different versions.

Commits in this pull request will need to be rebased on main when merging.