### PR TITLE
fix: Drop once_cell Windows dev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,6 @@ dependencies = [
  "accesskit",
  "accesskit_consumer",
  "hashbrown",
- "once_cell",
  "parking_lot",
  "scopeguard",
  "static_assertions",

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -38,7 +38,6 @@ features = [
 ]
 
 [dev-dependencies]
-once_cell = "1.13.0"
 parking_lot = "0.12.4"
 scopeguard = "1.1.0"
 winit = "0.30"

--- a/platforms/windows/examples/hello_world.rs
+++ b/platforms/windows/examples/hello_world.rs
@@ -5,8 +5,7 @@ use accesskit::{
     TreeId, TreeInfo, TreeUpdate,
 };
 use accesskit_windows::Adapter;
-use once_cell::sync::Lazy;
-use std::cell::RefCell;
+use std::{cell::RefCell, sync::LazyLock};
 use windows::{
     Win32::{
         Foundation::*,
@@ -17,7 +16,7 @@ use windows::{
     core::*,
 };
 
-static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
+static WINDOW_CLASS_ATOM: LazyLock<u16> = LazyLock::new(|| {
     let class_name = w!("AccessKitTest");
 
     let wc = WNDCLASSW {

--- a/platforms/windows/src/tests/mod.rs
+++ b/platforms/windows/src/tests/mod.rs
@@ -4,10 +4,9 @@
 // the LICENSE-MIT file), at your option.
 
 use accesskit::{ActionHandler, ActivationHandler};
-use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
-    sync::{Arc, Condvar, Mutex},
+    sync::{Arc, Condvar, LazyLock, Mutex},
     thread,
     time::Duration,
 };
@@ -31,7 +30,7 @@ use super::{
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
-static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
+static WINDOW_CLASS_ATOM: LazyLock<u16> = LazyLock::new(|| {
     let class_name = w!("AccessKitTest");
 
     let wc = WNDCLASSW {

--- a/platforms/windows/src/tests/subclassed.rs
+++ b/platforms/windows/src/tests/subclassed.rs
@@ -7,7 +7,7 @@ use accesskit::{
     Action, ActionHandler, ActionRequest, ActivationHandler, Node, NodeId, Role, TreeId, TreeInfo,
     TreeUpdate,
 };
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use windows::{
     Win32::{
         Foundation::*,
@@ -119,7 +119,7 @@ extern "system" fn wndproc(window: HWND, message: u32, wparam: WPARAM, lparam: L
     unsafe { DefWindowProcW(window, message, wparam, lparam) }
 }
 
-static WINDOW_CLASS_ATOM: Lazy<u16> = Lazy::new(|| {
+static WINDOW_CLASS_ATOM: LazyLock<u16> = LazyLock::new(|| {
     let class_name = w!("AccessKitSubclassTest");
 
     let wc = WNDCLASSW {


### PR DESCRIPTION
Now that our MSRV is higher than 1.80, we can replace `once_cell::sync::Lazy` by `std::sync::LazyLock`.