### PR TITLE
fix: Three process-abort paths in the Android injecting adapter

### DIFF
--- a/adapters/android/src/event.rs
+++ b/adapters/android/src/event.rs
@@ -55,6 +55,13 @@ fn send_completed_event(env: &mut JNIEnv, host: &JObject, event: JObject) {
         .unwrap()
         .l()
         .unwrap();
+    // Events are raised from a closure posted with `View.post`, which can run
+    // after the host view has been detached; `getParent()` is then null, and
+    // calling a method on it would fail. There is nothing to send the event to,
+    // so drop it.
+    if parent.is_null() {
+        return;
+    }
     env.call_method(
         &parent,
         "requestSendAccessibilityEvent",

--- a/adapters/android/src/inject.rs
+++ b/adapters/android/src/inject.rs
@@ -164,6 +164,9 @@ fn post_to_ui_thread(
         .unwrap()
         .l()
         .unwrap();
+    // Free the `Runnable` local reference: this can be reached from a caller
+    // thread that never pops a local frame.
+    let runnable = env.auto_local(runnable);
     env.call_method(
         host,
         "post",
@@ -446,6 +449,12 @@ impl InjectingAdapter {
         let Some(host) = self.host.upgrade_local(&env).unwrap() else {
             return;
         };
+        // `upgrade_local` creates a new local reference, and on a caller thread
+        // that is not executing a JNI native method (which this type documents
+        // as supported) nothing pops a local frame — so without an explicit
+        // free, every call leaks one local until ART hits its local reference
+        // table limit.
+        let host = env.auto_local(host);
         // A contained panic in a delegate callback poisons this mutex; skip
         // rather than propagate the poison panic into the caller's thread —
         // accessibility is already degraded at that point.
@@ -473,6 +482,8 @@ impl Drop for InjectingAdapter {
             let Some(host) = host.upgrade_local(env)? else {
                 return Ok(());
             };
+            // Same local-reference discipline as `update_if_active`.
+            let host = env.auto_local(host);
             post_to_ui_thread(env, delegate_class, &host, |env, delegate_class, host| {
                 let prev_delegate = env
                     .call_method(

--- a/adapters/android/src/inject.rs
+++ b/adapters/android/src/inject.rs
@@ -18,9 +18,11 @@ use jni::{
 };
 use log::debug;
 use std::{
+    any::Any,
     collections::BTreeMap,
     ffi::c_void,
     fmt::{Debug, Formatter},
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{
         Arc, Mutex, OnceLock, Weak,
         atomic::{AtomicI64, Ordering},
@@ -28,6 +30,47 @@ use std::{
 };
 
 use crate::{action::PlatformAction, adapter::Adapter, event::QueuedEvents};
+
+/// Log a panic caught at a JNI boundary and clear any Java exception it left
+/// pending (returning to the JVM with one pending rethrows it in the Java
+/// caller — for `runCallback` that is inside the UI `Looper`).
+fn report_contained_panic(env: &mut JNIEnv, what: &str, payload: Box<dyn Any + Send>) {
+    let msg: &str = if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s
+    } else {
+        "non-string panic payload"
+    };
+    log::error!("accesskit_android: panic contained at the JNI boundary in {what}: {msg}");
+    if env.exception_check().unwrap_or(false) {
+        let _ = env.exception_describe();
+        let _ = env.exception_clear();
+    }
+}
+
+/// Run a native-method body with the unwind boundary an `extern "system"` fn
+/// requires, returning `T::default()` (null / `JNI_FALSE`) if it panicked.
+///
+/// Rust aborts the process when a panic reaches an `extern "system"` frame,
+/// and the code under these entry points surfaces every JNI error (a detached
+/// host view, a missing method, an OOM) as a panic — so without this
+/// boundary, any of those errors aborted the process. A contained panic
+/// poisons the adapter's mutex, so later delegate calls fail too (also
+/// contained): the process survives and accessibility degrades.
+fn guard_ffi<'local, T: Default>(
+    env: &mut JNIEnv<'local>,
+    what: &str,
+    f: impl FnOnce(&mut JNIEnv<'local>) -> T,
+) -> T {
+    match catch_unwind(AssertUnwindSafe(|| f(&mut *env))) {
+        Ok(value) => value,
+        Err(payload) => {
+            report_contained_panic(env, what, payload);
+            T::default()
+        }
+    }
+}
 
 struct InnerInjectingAdapter {
     adapter: Adapter,
@@ -139,7 +182,7 @@ extern "system" fn run_callback<'local>(
     let Some(callback) = CALLBACK_MAP.lock().unwrap().remove(&handle) else {
         return;
     };
-    callback(&mut env, &class, &host);
+    guard_ffi(&mut env, "runCallback", |env| callback(env, &class, &host));
 }
 
 extern "system" fn create_accessibility_node_info<'local>(
@@ -149,11 +192,13 @@ extern "system" fn create_accessibility_node_info<'local>(
     host: JObject<'local>,
     virtual_view_id: jint,
 ) -> JObject<'local> {
-    let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
-        return JObject::null();
-    };
-    let mut inner_adapter = inner_adapter.lock().unwrap();
-    inner_adapter.create_accessibility_node_info(&mut env, &host, virtual_view_id)
+    guard_ffi(&mut env, "createAccessibilityNodeInfo", |env| {
+        let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
+            return JObject::null();
+        };
+        let mut inner_adapter = inner_adapter.lock().unwrap();
+        inner_adapter.create_accessibility_node_info(env, &host, virtual_view_id)
+    })
 }
 
 extern "system" fn find_focus<'local>(
@@ -163,11 +208,13 @@ extern "system" fn find_focus<'local>(
     host: JObject<'local>,
     focus_type: jint,
 ) -> JObject<'local> {
-    let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
-        return JObject::null();
-    };
-    let mut inner_adapter = inner_adapter.lock().unwrap();
-    inner_adapter.find_focus(&mut env, &host, focus_type)
+    guard_ffi(&mut env, "findFocus", |env| {
+        let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
+            return JObject::null();
+        };
+        let mut inner_adapter = inner_adapter.lock().unwrap();
+        inner_adapter.find_focus(env, &host, focus_type)
+    })
 }
 
 extern "system" fn perform_action<'local>(
@@ -179,19 +226,21 @@ extern "system" fn perform_action<'local>(
     action: jint,
     arguments: JObject<'local>,
 ) -> jboolean {
-    let Some(action) = PlatformAction::from_java(&mut env, action, &arguments) else {
-        return JNI_FALSE;
-    };
-    let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
-        return JNI_FALSE;
-    };
-    let mut inner_adapter = inner_adapter.lock().unwrap();
-    let Some(events) = inner_adapter.perform_action(virtual_view_id, &action) else {
-        return JNI_FALSE;
-    };
-    drop(inner_adapter);
-    events.raise(&mut env, &host);
-    JNI_TRUE
+    guard_ffi(&mut env, "performAction", |env| {
+        let Some(action) = PlatformAction::from_java(env, action, &arguments) else {
+            return JNI_FALSE;
+        };
+        let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
+            return JNI_FALSE;
+        };
+        let mut inner_adapter = inner_adapter.lock().unwrap();
+        let Some(events) = inner_adapter.perform_action(virtual_view_id, &action) else {
+            return JNI_FALSE;
+        };
+        drop(inner_adapter);
+        events.raise(env, &host);
+        JNI_TRUE
+    })
 }
 
 extern "system" fn on_hover_event<'local>(
@@ -203,16 +252,18 @@ extern "system" fn on_hover_event<'local>(
     x: jfloat,
     y: jfloat,
 ) -> jboolean {
-    let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
-        return JNI_FALSE;
-    };
-    let mut inner_adapter = inner_adapter.lock().unwrap();
-    let Some(events) = inner_adapter.on_hover_event(action, x, y) else {
-        return JNI_FALSE;
-    };
-    drop(inner_adapter);
-    events.raise(&mut env, &host);
-    JNI_TRUE
+    guard_ffi(&mut env, "onHoverEvent", |env| {
+        let Some(inner_adapter) = inner_adapter_from_handle(adapter_handle) else {
+            return JNI_FALSE;
+        };
+        let mut inner_adapter = inner_adapter.lock().unwrap();
+        let Some(events) = inner_adapter.on_hover_event(action, x, y) else {
+            return JNI_FALSE;
+        };
+        drop(inner_adapter);
+        events.raise(env, &host);
+        JNI_TRUE
+    })
 }
 
 fn delegate_class(env: &mut JNIEnv) -> &'static JClass<'static> {
@@ -395,7 +446,12 @@ impl InjectingAdapter {
         let Some(host) = self.host.upgrade_local(&env).unwrap() else {
             return;
         };
-        let mut inner = self.inner.lock().unwrap();
+        // A contained panic in a delegate callback poisons this mutex; skip
+        // rather than propagate the poison panic into the caller's thread —
+        // accessibility is already degraded at that point.
+        let Ok(mut inner) = self.inner.lock() else {
+            return;
+        };
         let Some(events) = inner.adapter.update_if_active(update_factory) else {
             return;
         };


### PR DESCRIPTION
Using `accesskit_android` (`embedded-dex`) with an `InjectingAdapter` over a host `View` whose lifetime tracks `AccessibilityManager.isEnabled()`, there are three distinct ways to abort the process. All three live in `inject.rs` / `event.rs`, and each fix is small — one commit per fix.

**1. `update_if_active` leaks two JNI local references per call (and `Drop` leaks a third).** `self.host.upgrade_local(&env)` is a bare `NewLocalRef`, and the `Runnable` created in `post_to_ui_thread` is another; jni 0.21's `JObject` has no `Drop` glue, so neither is freed — and the adapter's `Drop` impl upgrades the host the same way. The type documents that its functions make no assumptions about being called from the Android UI thread — but on a thread that is not executing a JNI native method, nothing pops a local frame, so the references accumulate until ART aborts (API ≤ 25, fixed 512-entry table) or grows the table without bound (API 26+). For a toolkit pushing a tree update per accessibility-relevant frame, the fixed table fills in seconds. Fix: register all three references with `auto_local`.

**2. No unwind boundary at the five `extern "system"` entry points.** `runCallback`, `createAccessibilityNodeInfo`, `findFocus`, `performAction` and `onHoverEvent` run `.unwrap()`-based code directly in an `extern "system"` frame, where Rust aborts on unwind — so any JNI error underneath (a detached view, a genuinely missing method, an OOM) is a SIGABRT rather than a recoverable failure. Nothing in the crate documents an API floor either — `getAccessibilityDelegate()` in the install closure, for instance, is only public API since 29 (hidden before that), and any lookup that does fail becomes an abort. Fix: a small `guard_ffi` helper that catches, logs, clears any pending Java exception (returning to Java with one pending rethrows it in the Java caller — inside the UI `Looper` for `runCallback`), and returns null / `JNI_FALSE`. A contained panic poisons the adapter mutex, so later delegate calls fail contained too, and `update_if_active` skips its work on a poisoned mutex instead of propagating the poison panic into the caller's thread: accessibility degrades instead of the process dying or resuming on half-applied state.

**3. `send_completed_event` calls a method on a null `ViewParent`.** Event raises run from a `View.post` closure, and Android runs an enqueued `Runnable` even after the view has been detached — at which point `getParent()` returns null, jni's `call_method` rejects the null receiver, and the `.unwrap()` panics (and, per 2, aborts). Reachable on every "remove the accessibility host view when the screen reader is disabled" edge. Fix: return early — there is nothing to send the event to.

Note that fix 2's `catch_unwind` is inert in a release profile built with `panic = "abort"` — which is exactly why fixes 1 and 3, which remove the panic and the leak rather than catching them, are load-bearing on their own.

<sup>This PR was generated by Claude</sup>
