### PR TITLE
fix: Base AT-SPI ENABLED/SENSITIVE states on the disabled flag

### DIFF
--- a/adapters/atspi-common/src/node.rs
+++ b/adapters/atspi-common/src/node.rs
@@ -375,7 +375,12 @@ impl NodeWrapper<'_> {
 
         if state.is_read_only_supported() && state.is_read_only_or_disabled() {
             atspi_state.insert(State::ReadOnly);
-        } else {
+        }
+
+        // `Enabled` and `Sensitive` track the disabled flag, not the read-only
+        // branch above. A read-only control is still enabled, and a disabled
+        // control is not, whether or not its role supports read-only.
+        if !state.is_disabled() {
             atspi_state.insert(State::Enabled | State::Sensitive);
         }
 
@@ -2028,4 +2033,71 @@ pub struct CacheNode {
     pub description: String,
     pub role: AtspiRole,
     pub states: StateSet,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NodeWrapper;
+    use accesskit::{Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate};
+    use accesskit_consumer::Tree;
+    use atspi_common::{State, StateSet};
+
+    fn state_of(node: Node) -> StateSet {
+        let mut root = Node::new(Role::Window);
+        root.set_children(vec![NodeId(1)]);
+        let tree = Tree::new(
+            TreeUpdate {
+                nodes: vec![(NodeId(0), root), (NodeId(1), node)],
+                tree: Some(TreeInfo::new(NodeId(0))),
+                tree_id: TreeId::ROOT,
+                focus: NodeId(0),
+            },
+            true,
+        );
+        let state = tree.state();
+        let node = state.root().children().next().unwrap();
+        NodeWrapper(&node).state(true)
+    }
+
+    #[test]
+    fn disabled_node_is_neither_enabled_nor_sensitive() {
+        // A role that doesn't support read-only, so the read-only branch
+        // can't stand in for the disabled flag.
+        for role in [Role::Button, Role::Link, Role::MenuItem, Role::Tab] {
+            let mut node = Node::new(role);
+            node.set_disabled();
+            let state = state_of(node);
+            assert!(!state.contains(State::Enabled), "{role:?}");
+            assert!(!state.contains(State::Sensitive), "{role:?}");
+        }
+    }
+
+    #[test]
+    fn enabled_node_is_enabled_and_sensitive() {
+        for role in [Role::Button, Role::Link, Role::MenuItem, Role::Tab] {
+            let state = state_of(Node::new(role));
+            assert!(state.contains(State::Enabled), "{role:?}");
+            assert!(state.contains(State::Sensitive), "{role:?}");
+        }
+    }
+
+    #[test]
+    fn read_only_text_input_is_still_enabled_and_sensitive() {
+        let mut node = Node::new(Role::TextInput);
+        node.set_read_only();
+        let state = state_of(node);
+        assert!(state.contains(State::ReadOnly));
+        assert!(state.contains(State::Enabled));
+        assert!(state.contains(State::Sensitive));
+    }
+
+    #[test]
+    fn disabled_text_input_is_read_only_and_not_enabled() {
+        let mut node = Node::new(Role::TextInput);
+        node.set_disabled();
+        let state = state_of(node);
+        assert!(state.contains(State::ReadOnly));
+        assert!(!state.contains(State::Enabled));
+        assert!(!state.contains(State::Sensitive));
+    }
 }


### PR DESCRIPTION
`NodeWrapper::state` computed `STATE_ENABLED` and `STATE_SENSITIVE` in the `else` arm of the read-only branch (`adapters/atspi-common/src/node.rs:376-380`), so neither ever consulted `is_disabled`. Measured on clean `main` by calling `state()` directly:

```
role=Button    disabled=true   => ENABLED=true  SENSITIVE=true  READ_ONLY=false
role=Button    disabled=false  => ENABLED=true  SENSITIVE=true  READ_ONLY=false
role=Link      disabled=true   => ENABLED=true  SENSITIVE=true  READ_ONLY=false
role=MenuItem  disabled=true   => ENABLED=true  SENSITIVE=true  READ_ONLY=false
role=TextInput read_only=true  => ENABLED=false SENSITIVE=false READ_ONLY=true
```

So a disabled node whose role doesn't support `aria-readonly` (`Button`, `Link`, `MenuItem`, `Tab`, ...) is indistinguishable from the enabled one, and a read-only-but-enabled control loses both states.

Core-AAM 1.2 §3.5.2.27 maps `aria-disabled="true"` to ATK/AT-SPI "State: `STATE_ENABLED` not exposed" and §3.5.2.28 maps `aria-disabled="false"` to `STATE_ENABLED`; the `aria-readonly="true"` row (§3.5.2.77) withdraws only `STATE_EDITABLE`. The other four adapters already derive the platform enabled state from `is_disabled` — `macos/src/node.rs:660`, `windows/src/node.rs:535`, `android/src/node.rs:35`, `ios/src/node.rs:144` — and #474 was that same change for macOS.

The fix leaves the read-only branch exactly as it was and gates `Enabled | Sensitive` on `!is_disabled()`. Behaviour changes in the two cells above and nowhere else.

`cargo +1.85 test -p accesskit_atspi_common` (the MSRV toolchain CI uses): 7 passed on clean `main`, 11 passed here, 13 with `--all-features`. `cargo fmt --all -- --check`, `cargo clippy -p accesskit_atspi_common --all-features --all-targets -- -D warnings` and `cargo doc` with `RUSTDOCFLAGS=-D warnings` all clean locally.

The new tests discriminate: reverting the source alone fails 2 of the 4; the narrower `} else if !state.is_disabled() {` still fails the read-only one; dropping the read-only branch instead fails both `READ_ONLY` assertions. `enabled_node_is_enabled_and_sensitive` passes in every one of those trees.

Not tested: I have no Linux machine or Orca here, so this is verified at the `accesskit_atspi_common` translation layer only, not end to end through `accesskit_unix` against a live AT.

This change was prepared with AI assistance (Claude Opus 5).
